### PR TITLE
Fix ACL missing ProgrammingError

### DIFF
--- a/timesketch/settings.py.example
+++ b/timesketch/settings.py.example
@@ -144,6 +144,7 @@ INSTALLED_APPS = (
     'timesketch.apps.ui',
     'timesketch.apps.userprofile',
     'timesketch.apps.api',
+    'timesketch.apps.acl',
 )
 
 # A sample logging configuration. The only tangible logging


### PR DESCRIPTION
Added timesketch.apps.acl to the INSTALLED_APPS section
