### PR TITLE
Remove apostrophe from random chars

### DIFF
--- a/utils/gen_secret_key.py
+++ b/utils/gen_secret_key.py
@@ -18,7 +18,8 @@ import string
 
 
 def generate_secret_key():
-    allowed_chars = string.letters + string.digits + string.punctuation
+    allowed_chars = string.letters + string.digits + \
+        string.punctuation.replace("'", "")
     return get_random_string(length=50, allowed_chars=allowed_chars)
 
 if __name__ == "__main__":


### PR DESCRIPTION
A naive copy/paste of the random string can generate a syntax error because of the apostrophe. 

```
Traceback (most recent call last):
  File "manage.py", line 24, in <module>
...
  File "/opt/apps/timesketch/timesketch/settings.py", line 102
    SECRET_KEY = 'Kqg'1Z%v`_(J(cMw7?^B+6.IUGY=G>:D9kG;DZwL2-7BH5qwo'

SyntaxError: invalid syntax
```
