### PR TITLE
Set a default MEDIA_URL value.

### DIFF
--- a/timesketch/apps/ui/templates/registration/login.html
+++ b/timesketch/apps/ui/templates/registration/login.html
@@ -1,0 +1,60 @@
+<!--
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+{% load staticfiles %}
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="screen" href="{% static "third_party/bootstrap/css/bootstrap.min.css" %}">
+    <link rel='stylesheet' media="screen" href="{% static "third_party/font-awesome/css/font-awesome.min.css" %}">
+    <link rel='stylesheet' media="screen" href="{% static "css/app.css" %}">
+  </head>
+  <style>
+      body {
+          background: #333;
+      }
+  </style>
+  <body>
+  <div id="login-box">
+      <img width="150px" height="25px" style="margin-left:3px;margin-top:5px;" src="/static/img/logo.png">
+      <br>
+      <br>
+      <form class="form-horizontal" role="form" method="post" action="{% url 'django.contrib.auth.views.login' %}">
+        {% csrf_token %}
+
+  <div class="form-group">
+    <div class="col-lg-12">
+      <input type="text" class="form-control" id="id_username" name="username" maxlength="254" placeholder="Username">
+    </div>
+  </div>
+  <div class="form-group">
+    <div class="col-lg-12">
+      <input type="password" class="form-control" id="id_password" name="password" placeholder="Password">
+    </div>
+  </div>
+  <div class="form-group">
+    <div class="col-lg-12">
+      <input type="submit" class="btn btn-default" value="Login" />
+      <input type="hidden" name="next" value="{{ next }}" />
+    </div>
+  </div>
+</form>
+
+
+      </div>
+
+  </body>
+</html>

--- a/timesketch/settings.py.example
+++ b/timesketch/settings.py.example
@@ -67,7 +67,7 @@ MEDIA_ROOT = ''
 # URL that handles the media served from MEDIA_ROOT. Make sure to use a
 # trailing slash.
 # Examples: "http://example.com/media/", "http://media.example.com/"
-MEDIA_URL = ''
+MEDIA_URL = '/media/'
 
 # Absolute path to the directory static files should be collected to.
 # Don't put anything in this directory yourself; store your static files


### PR DESCRIPTION
An empty MEDIA_URL causes an exception at server start.

ImproperlyConfigured at /
Empty static prefix not permitted
Request Method:	GET
Request URL:	http://localhost:8000/
Django Version:	1.7.1
Exception Type:	ImproperlyConfigured
Exception Value:	Empty static prefix not permitted