### PR TITLE
Support virtualenv in the wsgi application

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -15,9 +15,23 @@
 """This module is for creating the app for a WSGI server.
 
 Example with Gunicorn:
-$ gunicorn -b 127.0.0.1:4000 --debug --log-file - wsgi:app
+$ gunicorn -b 127.0.0.1:4000 --log-file - wsgi:application
+
+Example configuration for Apache with mod_wsgi (a2enmod mod_wsgi):
+<VirtualHost *:443>
+        ServerAdmin root@localhost
+        SSLEngine On
+        SSLCertificateFile    /etc/apache2/cert.crt
+        SSLCertificateKeyFile /etc/apache2/cert.key
+        WSGIScriptAlias / /path/to/this/file/wsgi.py
+</VirtualHost>
 """
+
+# If you installed Timesketch in a virtualenv you need to activate it.
+# This needs to be before any imports in order to import from the virtualenv.
+#activate_virtualenv = '/path/to/your/virtualenv/bin/activate_this.py'
+#execfile(activate_virtualenv, dict(__file__=activate_virtualenv))
 
 from timesketch import create_app
 
-app = create_app()
+application = create_app()


### PR DESCRIPTION
Add sane defaults.

* Commented out support for virtualenv.
* Add Apache configuration example.
* Apache mod_wsgi expects the wsgi application be named "application", not "app".

Reviewer: @onager