### PR TITLE
Add JSON import suppport

### DIFF
--- a/timesketch/api/v1/resources.py
+++ b/timesketch/api/v1/resources.py
@@ -227,7 +227,7 @@ class ViewListResource(ResourceMixin, Resource):
             view = View(
                 name=form.name.data, sketch=sketch, user=current_user,
                 query_string=form.query.data,
-                query_filter=json.dumps(form.filter.data))
+                query_filter=json.dumps(form.filter.data, ensure_ascii=False))
             db_session.add(view)
             db_session.commit()
             return self.to_json(view, status_code=HTTP_STATUS_CODE_CREATED)
@@ -430,6 +430,7 @@ class EventAnnotationResource(ResourceMixin, Resource):
             searchindex_id = form.searchindex_id.data
             searchindex = SearchIndex.query.get(searchindex_id)
             event_id = form.event_id.data
+            event_type = form.event_type.data
 
             if searchindex_id not in indices:
                 abort(HTTP_STATUS_CODE_BAD_REQUEST)
@@ -437,8 +438,8 @@ class EventAnnotationResource(ResourceMixin, Resource):
             def _set_label(label, toggle=False):
                 """Set label on the event in the datastore."""
                 self.datastore.set_label(
-                    searchindex_id, event_id, sketch.id, current_user.id, label,
-                    toggle=toggle)
+                    searchindex_id, event_id, event_type, sketch.id,
+                    current_user.id, label, toggle=toggle)
 
             # Get or create an event in the SQL database to have something to
             # attach the annotation to.

--- a/timesketch/api/v1/resources_test.py
+++ b/timesketch/api/v1/resources_test.py
@@ -69,7 +69,7 @@ class ViewListResourceTest(BaseTest):
         self.login()
         data = dict(name=u'test', query=u'test', filter=u'{}')
         response = self.client.post(
-            self.resource_url, data=json.dumps(data),
+            self.resource_url, data=json.dumps(data, ensure_ascii=False),
             content_type=u'application/json')
         self.assertEquals(response.status_code, HTTP_STATUS_CODE_CREATED)
 
@@ -200,7 +200,8 @@ class EventAnnotationResourceTest(BaseTest):
         for annotation_type in [u'comment', u'label']:
             data = dict(
                 annotation=u'test', annotation_type=annotation_type,
-                event_id=u'test', searchindex_id=u'test')
+                event_id=u'test', searchindex_id=u'test',
+                event_type=u'test_event')
             response = self.client.post(
                 self.resource_url, data=json.dumps(data),
                 content_type=u'application/json')

--- a/timesketch/lib/datastore.py
+++ b/timesketch/lib/datastore.py
@@ -42,8 +42,9 @@ class DataStore(object):
         """
 
     @abc.abstractmethod
-    def set_label(self, searchindex_id, event_id, sketch_id, user_id, label,
-                  toggle=False):
+    def set_label(
+            self, searchindex_id, event_id, event_type, sketch_id, user_id,
+            label, toggle=False):
         """Add label to an event.
 
         Args:

--- a/timesketch/lib/forms.py
+++ b/timesketch/lib/forms.py
@@ -153,3 +153,4 @@ class EventAnnotationForm(BaseForm):
     annotation_type = StringField(u'Type', validators=[DataRequired()])
     searchindex_id = StringField(u'Searchindex', validators=[DataRequired()])
     event_id = StringField(u'Event', validators=[DataRequired()])
+    event_type = StringField(u'Event type', validators=[DataRequired()])

--- a/timesketch/lib/testlib.py
+++ b/timesketch/lib/testlib.py
@@ -129,8 +129,8 @@ class MockDataStore(datastore.DataStore):
         return self.event_dict
 
     def set_label(
-            self, searchindex_id, event_id, sketch_id, user_id, label,
-            toggle=False):
+            self, searchindex_id, event_id, event_type, sketch_id, user_id,
+            label, toggle=False):
         """Mock adding a label to an event."""
         return
 

--- a/timesketch/ui/static/js/controllers.js
+++ b/timesketch/ui/static/js/controllers.js
@@ -131,7 +131,8 @@ timesketch.controller('TsEventCtrl', function($scope, timesketchApi) {
             'label',
             '__ts_star',
             $scope.event._index,
-            $scope.event._id).success(function(data) {})
+            $scope.event._id,
+            $scope.event._type).success(function(data) {})
     }
 });
 
@@ -153,7 +154,8 @@ timesketch.controller('TsEventDetailCtrl', function($scope, timesketchApi) {
             'comment',
             $scope.formData.comment,
             $scope.event._index,
-            $scope.event._id).success(function(data) {
+            $scope.event._id,
+            $scope.event._type).success(function(data) {
                 $scope.formData.comment = '';
                 $scope.commentForm.$setPristine();
                 $scope.comments.push(data['objects'][0]);

--- a/timesketch/ui/static/js/services.js
+++ b/timesketch/ui/static/js/services.js
@@ -68,22 +68,24 @@ var timesketchApiImplementation = function($http) {
         return $http.get(resource_url, params)
     };
 
-    this.saveEventAnnotation = function(sketch_id, type, annotation, searchindex_id, event_id) {
+    this.saveEventAnnotation = function(sketch_id, annotation_type, annotation, searchindex_id, event_id, event_type) {
         /**
          * Save a Timesketch event annotation.
          * @param sketch_id - The id for the sketch.
-         * @param type - The type of the annotation, e.g. comment or tag.
+         * @param annotation_type - The type of the annotation, e.g. comment or tag.
          * @param annotation - The content for the annotation.
          * @param searchindex_id - The id for the search index.
          * @param event_id - The id for the event.
+         * @param event_type - The document type for the event.
          * @returns A $http promise with two methods, success and error.
          */
         var resource_url = BASE_URL + sketch_id + '/event/annotate/';
         var params = {
             annotation: annotation,
-            annotation_type: type,
+            annotation_type: annotation_type,
             searchindex_id: searchindex_id,
-            event_id: event_id
+            event_id: event_id,
+            event_type: event_type
         };
         return $http.post(resource_url, params);
     };

--- a/timesketch/ui/views/sketch.py
+++ b/timesketch/ui/views/sketch.py
@@ -152,9 +152,10 @@ def timelines(sketch_id):
     sketch = Sketch.query.get_with_acl(sketch_id)
     searchindices_in_sketch = [t.searchindex.id for t in sketch.timelines]
     query = request.args.get(u'q', None)
-    indices = SearchIndex.all_with_acl(current_user).order_by(
-        desc(SearchIndex.created_at)).filter(
-        not_(SearchIndex.id.in_(searchindices_in_sketch)))
+    indices = SearchIndex.all_with_acl(
+        current_user).order_by(
+            desc(SearchIndex.created_at)).filter(
+                not_(SearchIndex.id.in_(searchindices_in_sketch)))
     filtered = False
 
     if query:

--- a/tsctl
+++ b/tsctl
@@ -14,6 +14,8 @@
 # limitations under the License.
 """This module is for management of the timesketch application."""
 
+from collections import Counter
+import json
 import sys
 
 from flask import current_app
@@ -122,13 +124,122 @@ class AddSearchIndex(Command):
         sys.stdout.write(u'Search index {0:s} created\n'.format(name))
 
 
+class CreateTimelineFromJson(Command):
+    """Create a new Timesketch timeline from a JSON file.
+
+        NOTE: The way the built in json module works is by loading the whole
+        document into memory. This is of course not optimal and expensive.
+        Don't try to ingest too big of a document. We will implement a CSV
+        importer in the future to address this.
+
+        Elasticsearch is very forgiving about how your JSON is structured, but
+        Timesketch has a minimum set of attributes that needs to be present to
+        render correctly in the UI. These are:
+
+        * message
+        * timestamp
+        * datetime
+        * timestamp_desc
+
+        You can of course have more attributes, and these will be indexed
+        automatically and shown in the detailed view of the event.
+
+        Example (minimal) JSON structure:
+        [
+            {
+              "message": "foo",
+              "timestamp": "1432293395",
+              "datetime": "2015-05-22T13:16:35+00:00",
+              "timestamp_desc": "Some timestamp",
+            },
+            {
+              "message": "bar",
+              "timestamp": "1432293443",
+              "datetime": "2015-05-22T13:17:23+00:00",
+              "timestamp_desc": "Some timestamp",
+            }
+        ]
+    """
+    DEFAULT_FLUSH_INTERVAL = 1000
+    option_list = (
+        Option(u'--name', u'-n', dest=u'timeline_name', required=True),
+        Option(u'--file', u'-f', dest=u'filename', required=True),
+        Option(
+            u'--flush_interval', dest=u'flush_interval', required=False,
+            default=DEFAULT_FLUSH_INTERVAL,
+            help=u'Default: {0:d}'.format(DEFAULT_FLUSH_INTERVAL))
+    )
+
+    def __init__(self):
+        super(CreateTimelineFromJson, self).__init__()
+
+    def run(self, timeline_name, filename, flush_interval):
+        """Create the timeline.
+
+        Args:
+            timeline_name: Name for the new timeline.
+            filename: Path to JSON file.
+            flush_interval: Number of events to queue up before bulk insert.
+        """
+        counter = Counter()
+        events = []
+        es = ElasticSearchDataStore(
+            host=current_app.config[u'ELASTIC_HOST'],
+            port=current_app.config[u'ELASTIC_PORT'])
+        timeline_name = unicode(timeline_name.decode(encoding=u'utf-8'))
+        flush_interval = int(flush_interval)
+
+        def _insert_events_to_elasticsearch(_events):
+            """Bulk insert events into Elasticsearch.
+
+            Args:
+                _events: List of events to insert.
+            """
+            es.client.bulk(
+                index=index_name, doc_type=doc_type, body=_events)
+
+        try:
+            with open(filename, u'rb') as fh:
+                # This is expensive, i.e. whole file is read into memory.
+                # TODO: Implement CSV importer that can be made more efficient.
+                # TODO: Check file size and bail out if big.
+                index_name, doc_type = es.create_index()
+                for event in json.load(fh):
+                    # Header needed by Elasticsearch when bulk inserting.
+                    events.append(
+                        {u'index': {u'_index': index_name, u'_type': doc_type}})
+                    events.append(event)
+                    counter[u'events'] += 1
+                    if counter[u'events'] % flush_interval == 0:
+                        _insert_events_to_elasticsearch(events)
+                        events = []
+                # Insert any remaining events.
+                if events:
+                    _insert_events_to_elasticsearch(events)
+
+            # Created the searchindex in the Timesketch database.
+            searchindex = SearchIndex(
+                name=timeline_name, description=timeline_name,
+                user=None, index_name=index_name)
+            searchindex.grant_permission(None, u'read')
+            db_session.add(searchindex)
+            db_session.commit()
+            sys.stdout.write(
+                u'Search index {0:s} created\n{1:d} events inserted\n'.format(
+                    timeline_name, counter[u'events']))
+        except IOError as exception:
+            sys.stderr.write(u'Error: {0:s}\n'.format(exception))
+
+
 if __name__ == '__main__':
     # Setup Flask-script command manager and register commands.
     shell_manager = Manager(create_app)
     shell_manager.add_command(u'add_user', AddUser())
     shell_manager.add_command(u'add_index', AddSearchIndex())
     shell_manager.add_command(u'drop_db', DropDataBaseTables())
-    shell_manager.add_command(u'runserver', Server(host='127.0.0.1', port=5000))
+    shell_manager.add_command(u'json2ts', CreateTimelineFromJson())
+    shell_manager.add_command(u'runserver', Server(
+        host=u'127.0.0.1', port=5000))
     shell_manager.add_option(
         u'-c', u'--config', dest=u'config', default=u'/etc/timesketch.conf',
         required=False)

--- a/tsctl
+++ b/tsctl
@@ -17,6 +17,7 @@
 from collections import Counter
 import json
 import sys
+from uuid import uuid4
 
 from flask import current_app
 from flask_script import Command
@@ -125,7 +126,42 @@ class AddSearchIndex(Command):
 
 
 class CreateTimelineFromJson(Command):
-    """Create a new Timesketch timeline from a JSON file.
+    """Create a new Timesketch timeline from a JSON file."""
+    DEFAULT_FLUSH_INTERVAL = 1000
+    DEFAULT_EVENT_TYPE = u'generic_event'
+    DEFAULT_INDEX_NAME = uuid4().hex
+    option_list = (
+        Option(u'--name', u'-n', dest=u'timeline_name', required=True,
+               help=u'Name of the timeline as it will appear in the '
+                    u'Timesketch UI.'),
+        Option(u'--file', u'-f', dest=u'filename', required=True,
+               help=u'Path to the JSON file to process'),
+        Option(
+            u'--index_name', dest=u'index_name', required=False,
+            default=DEFAULT_INDEX_NAME,
+            help=u'OPTIONAL: Name of the Elasticsearch index. Specify an '
+                 u'existing one to append to it. Default: unique UUID'),
+        Option(
+            u'--event_type', dest=u'event_type', required=False,
+            default=DEFAULT_EVENT_TYPE,
+            help=u'OPTIONAL: Type of event. This is what becomes the '
+                 u'document type in Elasticsearch. '
+                 u'Default: {0:s}.'.format(DEFAULT_EVENT_TYPE)),
+
+        Option(
+            u'--flush_interval', dest=u'flush_interval', required=False,
+            default=DEFAULT_FLUSH_INTERVAL,
+            help=u'OPTIONAL: How often to bulk insert events to Elasticsearch. '
+                 u'Default: Every {0:d} event.'.format(DEFAULT_FLUSH_INTERVAL))
+    )
+
+    def __init__(self):
+        super(CreateTimelineFromJson, self).__init__()
+
+    def run(
+            self, timeline_name, index_name, filename, event_type,
+            flush_interval):
+        """Create the timeline.
 
         NOTE: The way the built in json module works is by loading the whole
         document into memory. This is of course not optimal and expensive.
@@ -159,26 +195,12 @@ class CreateTimelineFromJson(Command):
               "timestamp_desc": "Some timestamp",
             }
         ]
-    """
-    DEFAULT_FLUSH_INTERVAL = 1000
-    option_list = (
-        Option(u'--name', u'-n', dest=u'timeline_name', required=True),
-        Option(u'--file', u'-f', dest=u'filename', required=True),
-        Option(
-            u'--flush_interval', dest=u'flush_interval', required=False,
-            default=DEFAULT_FLUSH_INTERVAL,
-            help=u'Default: {0:d}'.format(DEFAULT_FLUSH_INTERVAL))
-    )
-
-    def __init__(self):
-        super(CreateTimelineFromJson, self).__init__()
-
-    def run(self, timeline_name, filename, flush_interval):
-        """Create the timeline.
 
         Args:
             timeline_name: Name for the new timeline.
+            index_name: Name for the index in Elasticsearch.
             filename: Path to JSON file.
+            event_type: Type of event, i.e. doc_type in Elasticsearch.
             flush_interval: Number of events to queue up before bulk insert.
         """
         counter = Counter()
@@ -189,35 +211,43 @@ class CreateTimelineFromJson(Command):
         timeline_name = unicode(timeline_name.decode(encoding=u'utf-8'))
         flush_interval = int(flush_interval)
 
-        def _insert_events_to_elasticsearch(_events):
+        def _insert_events_to_elasticsearch(_events, _index, _event_type):
             """Bulk insert events into Elasticsearch.
 
             Args:
                 _events: List of events to insert.
+                _index: Elasticsearch index to add the events to.
+                _event_type: Document type for the events.
             """
             es.client.bulk(
-                index=index_name, doc_type=doc_type, body=_events)
+                index=_index, doc_type=_event_type, body=_events)
 
         try:
             with open(filename, u'rb') as fh:
                 # This is expensive, i.e. whole file is read into memory.
                 # TODO: Implement CSV importer that can be made more efficient.
                 # TODO: Check file size and bail out if big.
-                index_name, doc_type = es.create_index()
+                index_name, event_type = es.create_index(
+                    index_name=index_name, doc_type=event_type)
                 for event in json.load(fh):
                     # Header needed by Elasticsearch when bulk inserting.
-                    events.append(
-                        {u'index': {u'_index': index_name, u'_type': doc_type}})
+                    events.append({
+                        u'index': {
+                            u'_index': index_name, u'_type': event_type
+                        }
+                    })
                     events.append(event)
                     counter[u'events'] += 1
                     if counter[u'events'] % flush_interval == 0:
-                        _insert_events_to_elasticsearch(events)
+                        _insert_events_to_elasticsearch(
+                            events, index_name, event_type)
                         events = []
                 # Insert any remaining events.
                 if events:
-                    _insert_events_to_elasticsearch(events)
+                    _insert_events_to_elasticsearch(
+                        events, index_name, event_type)
 
-            # Created the searchindex in the Timesketch database.
+            # Create the searchindex in the Timesketch database.
             searchindex = SearchIndex(
                 name=timeline_name, description=timeline_name,
                 user=None, index_name=index_name)


### PR DESCRIPTION
### Import timeline from JSON document
This PR adds support for ingesting timeline events from JSON. It is not the most optimal solution due to the way the built in JSON module works (reading the whole document into memory) but for reasonable sized files it should be ok. To address this I plan to implement a CSV importer later.

When this is submitted we will be able to do:
$ tsctl json2ts --name foo --file /path/to/file.json

Ref issue: #79 
Reviewer: @liamjm
