### PR TITLE
Fix Safari bug with xsrf token

### DIFF
--- a/timesketch/ui/static/app.js
+++ b/timesketch/ui/static/app.js
@@ -46,7 +46,7 @@ limitations under the License.
                 }
             };
         });
-        var csrftoken = document.getElementsByTagName('meta')['csrf-token'].getAttribute('content');
+        var csrftoken = document.getElementsByTagName('meta')[0]['content'];
         $httpProvider.defaults.headers.common['X-CSRFToken'] = csrftoken;
     });
 })();


### PR DESCRIPTION
Fixes a bug where Safari couldnt get the XSRF token from the meta tag.
Ref issue: #97 

Reviewer: @onager