### PR TITLE
Handle URL parameters for search and filter

### DIFF
--- a/timesketch/ui/views/sketch.py
+++ b/timesketch/ui/views/sketch.py
@@ -122,10 +122,24 @@ def explore(sketch_id, view_id=None):
     """
     sketch = Sketch.query.get_with_acl(sketch_id)
     sketch_timelines = [t.searchindex.index_name for t in sketch.timelines]
+    view_form = SaveViewForm()
+
+    # Get parameters from the GET query
+    url_query = request.args.get(u'q', u'')
+    url_time_start = request.args.get(u'time_start', None)
+    url_time_end = request.args.get(u'time_end', None)
+
     if view_id:
         view = View.query.get(view_id)
     else:
         view = sketch.get_user_view(current_user)
+        if url_query:
+            view.query_string = url_query
+            query_filter = json.loads(view.query_filter)
+            query_filter[u'time_start'] = url_time_start
+            query_filter[u'time_end'] = url_time_end
+            view.query_filter = json.dumps(query_filter, ensure_ascii=False)
+
     if not view:
         query_filter = dict(indices=sketch_timelines)
         view = View(
@@ -133,7 +147,6 @@ def explore(sketch_id, view_id=None):
             query_filter=json.dumps(query_filter, ensure_ascii=False))
         db_session.add(view)
         db_session.commit()
-    view_form = SaveViewForm()
 
     return render_template(
         u'sketch/explore.html', sketch=sketch, view=view,


### PR DESCRIPTION
Initial support for setting query string and some limited filtering from GET request parameters. This gives you this e.g:

http://127.0.0.1:5000/sketch/1/explore/?q=foobar&time_start=2015-01-01&time_end=2015-12-13

Ref issue: #94 
Reviewer: @onager