### PR TITLE
Timeline picker bug

### DIFF
--- a/timesketch/ui/static/components/explore/explore-search-directive.js
+++ b/timesketch/ui/static/components/explore/explore-search-directive.js
@@ -32,20 +32,24 @@ limitations under the License.
             },
             controllerAs: 'ctrl',
             link: function(scope, elem, attrs, ctrl) {
-                if (attrs.autoload == 'true') {
-                    timesketchApi.getView(attrs.sketchId, attrs.viewId).success(function(data) {
-                        var query = data.objects[0].query_string;
-                        var filter = angular.fromJson(data.objects[0].query_filter);
-                        ctrl.search(query, filter);
-                    });
-                }
-                if (attrs.redirect == 'true') {
-                    scope.redirectView = true;
-                }
+                scope.$watch("sketch.views", function(value) {
+                    if (!scope.filter.indices.length) {
+                        return
+                    }
+                    if (attrs.autoload == 'true') {
+                        timesketchApi.getView(attrs.sketchId, attrs.viewId).success(function(data) {
+                            var query = data.objects[0].query_string;
+                            var filter = angular.fromJson(data.objects[0].query_filter);
+                            ctrl.search(query, filter);
+                        });
+                    }
+                    if (attrs.redirect == 'true') {
+                        scope.redirectView = true;
+                    }
+                }, true);
             },
             controller: function($scope) {
                 $scope.filter = {"indices": []};
-
                 timesketchApi.getSketch($scope.sketchId).success(function(data) {
                     $scope.sketch = data.objects[0];
                     $scope.sketch.views = data.meta.views;


### PR DESCRIPTION
There is a race condition on how the timeline picker gets rendered in the UI. In some cases the View XHR request returns to the client before the Sketch XHR request, making the list of selected timelines to reset to all selected.

This change will not fetch the view before the sketch XHR is done, as intended.

Ref issue: #150 
Reviewer: @onager
