### PR TITLE
Preserve newlines etc in event info and comments

### DIFF
--- a/timesketch/ui/static/components/explore/explore-event.html
+++ b/timesketch/ui/static/components/explore/explore-event.html
@@ -30,7 +30,7 @@
             </span>
             <i ng-if="::event._source.tag" ng-repeat="tag in ::event._source.tag" class="label label-primary">{{::tag}}</i>
 
-            <span ng-class="{true: 'message-hidden'}[event.hidden]">[{{ event._source.timestamp_desc }}] {{ event._source.message|limitTo:500 }}</span>
+            <span ng-class="{true: 'message-hidden'}[event.hidden]">[{{ event._source.timestamp_desc }}] <span style=white-space:pre-wrap;">{{ event._source.message|limitTo:500 }}</span></span>
 
             <div style="width:20px;height:20px;cursor: pointer;" class="pull-right tooltips"><span>Details</span><i ng-class="{true: 'fa fa-minus-square-o', false: 'fa fa-plus-square-o'}[showDetails]" style="color:#999;"></i></div>
 
@@ -54,7 +54,7 @@
                     <table class="table table-bordered table-hover">
                         <tr ng-repeat="(key, value) in eventdetail">
                             <td width="150px">{{ key }}</td>
-                            <td>{{::value}}</td>
+                            <td><span style=white-space:pre-wrap;">{{::value}}</span></td>
                         </tr>
                     </table>
                 </div>
@@ -62,7 +62,7 @@
                     <div ng-repeat="comment in comments">
                         <div class="comment-bubble">
                             <div class="comment-name">{{::comment.user.username}}</div>
-                            <div class="comment-body">{{::comment.comment}}</div>
+                            <div class="comment-body"><span style=white-space:pre-wrap;">{{::comment.comment}}</span></div>
                             <div class="comment-timestamp"><i class="fa fa-clock-o"></i> {{::comment.created_at}}</div>
                         </div>
                     </div>


### PR DESCRIPTION
Fix formatting in events info and comments. This fixes newlines etc.

Ref issue: #120 
Reviewer: @onager

