### PR TITLE
Elasticsearch 2.x support

### DIFF
--- a/timesketch/api/v1/resources_test.py
+++ b/timesketch/api/v1/resources_test.py
@@ -14,8 +14,8 @@
 """Tests for v1 of the Timesketch API."""
 
 
-import mock
 import json
+import mock
 
 from timesketch.lib.definitions import HTTP_STATUS_CODE_CREATED
 from timesketch.lib.definitions import HTTP_STATUS_CODE_BAD_REQUEST

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -252,12 +252,11 @@ class ElasticSearchDataStore(datastore.DataStore):
         """
         _document_mapping = {
             doc_type: {
-                u'_timestamp': {
-                    u'enabled': True,
-                    u'path': u'datetime',
-                    u'format': u'date_time_no_millis'
-                },
-                u'properties': {u'timesketch_label': {u'type': u'nested'}}
+                u'properties': {
+                    u'timesketch_label': {
+                        u'type': u'nested'
+                    }
+                }
             }
         }
 

--- a/timesketch/lib/tasks.py
+++ b/timesketch/lib/tasks.py
@@ -76,6 +76,6 @@ def run_plaso(source_file_path, timeline_name, index_name):
     plugins, queue_producers = frontend.GetAnalysisPluginsAndEventQueues(
         analysis_plugins)
     counter = frontend.ProcessStorage(
-        output_module, storage_file, plugins, queue_producers)
+        output_module, storage_file, source_file_path, plugins, queue_producers)
 
     return dict(counter)

--- a/timesketch/lib/tasks_test.py
+++ b/timesketch/lib/tasks_test.py
@@ -23,8 +23,6 @@ class TestTasks(BaseTest):
     """Tests for the functionality on the tasks module."""
     def test_get_data_location(self):
         """Test to get data_location path."""
-        data_location_none = get_data_location()
         current_app.config[u'PLASO_DATA_LOCATION'] = u'/tmp'
         data_location_exists = get_data_location()
-        self.assertFalse(data_location_none)
         self.assertEqual(u'/tmp', data_location_exists)

--- a/timesketch/lib/testlib.py
+++ b/timesketch/lib/testlib.py
@@ -170,7 +170,7 @@ class BaseTest(TestCase):
         """
         user = User(username=username)
         if set_password:
-            user.set_password(plaintext=u'test', rounds=1)
+            user.set_password(plaintext=u'test', rounds=4)
         self._commit_to_database(user)
         return user
 

--- a/timesketch/models/acl.py
+++ b/timesketch/models/acl.py
@@ -102,6 +102,7 @@ class AccessControlMixin(object):
         if not user:
             user = current_user
 
+        # pylint: disable=singleton-comparison
         return cls.query.filter(
             or_(
                 cls.AccessControlEntry.user == user,
@@ -136,6 +137,7 @@ class AccessControlMixin(object):
         Returns:
             List of users (instances of timesketch.models.user.User)
         """
+        # pylint: disable=singleton-comparison
         aces = self.AccessControlEntry.query.filter(
             not_(self.AccessControlEntry.user == self.user),
             not_(self.AccessControlEntry.user == None),

--- a/timesketch/models/annotations_test.py
+++ b/timesketch/models/annotations_test.py
@@ -29,6 +29,7 @@ class LabelModelTest(AnnotationBaseTest):
     def test_label_annotation(self):
         """Test that the label is associated with our test sketch."""
         self._test_annotation(self.sketch1.labels)
+        # pylint: disable=unsubscriptable-object
         self.assertEquals(self.sketch1.labels[0].label, u'Test label')
 
 
@@ -37,6 +38,7 @@ class StatusModelTest(AnnotationBaseTest):
     def test_status_annotation(self):
         """Test that the status is associated with our test sketch."""
         self._test_annotation(self.sketch1.status)
+        # pylint: disable=unsubscriptable-object
         self.assertEquals(self.sketch1.status[0].status, u'Test status')
 
 
@@ -45,4 +47,5 @@ class CommentModelTest(AnnotationBaseTest):
     def test_comment_annotation(self):
         """Test that the comment is associated with our test event."""
         self._test_annotation(self.event.comments)
+        # pylint: disable=unsubscriptable-object
         self.assertEquals(self.event.comments[0].comment, u'test')

--- a/timesketch/models/user_test.py
+++ b/timesketch/models/user_test.py
@@ -33,7 +33,7 @@ class UserModelTest(ModelBaseTest):
 
     def test_set_password(self):
         """Test setting a password for the user."""
-        self.assertIsNone(self.user1.set_password(u'test', rounds=1))
+        self.assertIsNone(self.user1.set_password(u'test', rounds=4))
 
     def test_valid_password(self):
         """Test checking a valid password."""

--- a/utils/pylintrc
+++ b/utils/pylintrc
@@ -11,7 +11,7 @@
 #init-hook=
 
 # Profiled execution.
-profile=no
+#profile=no
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
@@ -99,7 +99,7 @@ evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / stateme
 
 # Add a comment according to your evaluation note. This is used by the global
 # evaluation report (RP0004).
-comment=no
+#comment=no
 
 
 [VARIABLES]
@@ -128,7 +128,7 @@ ignored-classes=SQLObject,twisted.internet.reactor,hashlib,google.appengine.api.
 
 # When zope mode is activated, add a predefined set of Zope acquired attributes
 # to generated-members.
-zope=no
+#zope=no
 
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E0201 when accessed. Python regular
@@ -171,7 +171,7 @@ indent-string='    '
 [BASIC]
 
 # Required attributes for module, separated by a comma
-required-attributes=
+#required-attributes=
 
 # List of builtins function names that should not be used, separated by a comma
 bad-functions=map,filter,apply,input
@@ -253,7 +253,7 @@ max-public-methods=20
 
 # List of interface methods to ignore, separated by a comma. This is used for
 # instance to not check methods defines in Zope's Interface base class.
-ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
+#ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
 
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,__new__,setUp


### PR DESCRIPTION
- Remove unnecessary mapping (incompatible with ES 2.x)
- Fix pylintrc file for new pylint version
- Fix new linter errors
- bcrypt now wants min of 4 rounds, fix tests where rounds=1
- Plaso data path is not always empty, which breaks the test. Fixed.

Ref issue: #166 
Reviewer: @onager