### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/timesketch/__init__.py
+++ b/timesketch/__init__.py
@@ -84,7 +84,7 @@ def create_app(config=None):
     db = init_db()
 
     # Alembic migration support:
-    # https://alembic.readthedocs.org/en/latest/
+    # http://alembic.zzzcomputing.com/en/latest/
     migrate = Migrate()
     migrate.init_app(app, db)
 

--- a/timesketch/migrations/env.py
+++ b/timesketch/migrations/env.py
@@ -61,7 +61,7 @@ def run_migrations_online():
 
     # this callback is used to prevent an auto-migration from being generated
     # when there are no changes to the schema
-    # reference: http://alembic.readthedocs.org/en/latest/cookbook.html
+    # reference: http://alembic.zzzcomputing.com/en/latest/cookbook.html
     def process_revision_directives(context, revision, directives):
         if getattr(config.cmd_opts, 'autogenerate', False):
             script = directives[0]


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.