### PR TITLE
Fix for #243 (update current_app imports) / update one FlaskWTF import in forms

### DIFF
--- a/timesketch/api/v1/resources.py
+++ b/timesketch/api/v1/resources.py
@@ -33,10 +33,10 @@ import os
 import uuid
 
 from flask import abort
+from flask import current_app
 from flask import jsonify
 from flask import request
 from flask_login import current_user
-from flask_login import current_app
 from flask_login import login_required
 from flask_restful import fields
 from flask_restful import marshal

--- a/timesketch/lib/forms.py
+++ b/timesketch/lib/forms.py
@@ -14,7 +14,7 @@
 """Form definitions and validators for the forms used in the application."""
 
 
-from flask_wtf import Form
+from flask_wtf import FlaskForm
 from flask_wtf.file import FileField
 from flask_wtf.file import FileRequired
 from flask_wtf.file import FileAllowed
@@ -63,7 +63,7 @@ class MultiDict(dict):
         return [self[key]]
 
 
-class BaseForm(Form):
+class BaseForm(FlaskForm):
     """Base class for forms."""
     @classmethod
     def build(cls, request):

--- a/timesketch/ui/views/home.py
+++ b/timesketch/ui/views/home.py
@@ -14,11 +14,11 @@
 """This module implements HTTP request handler."""
 
 from flask import Blueprint
+from flask import current_app
 from flask import render_template
 from flask import redirect
 from flask import request
 from flask import url_for
-from flask_login import current_app
 from flask_login import current_user
 from flask_login import login_required
 from sqlalchemy import not_

--- a/timesketch/ui/views/user.py
+++ b/timesketch/ui/views/user.py
@@ -14,11 +14,11 @@
 """This module implements HTTP request handlers for the user views."""
 
 from flask import Blueprint
+from flask import current_app
 from flask import redirect
 from flask import render_template
 from flask import request
 from flask import url_for
-from flask_login import current_app
 from flask_login import current_user
 from flask_login import login_user
 from flask_login import logout_user

--- a/timesketch/ui/views/user_test.py
+++ b/timesketch/ui/views/user_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Tests for the user views."""
 
-from flask_login import current_app
+from flask import current_app
 from flask_login import current_user
 
 from timesketch.lib.definitions import HTTP_STATUS_CODE_REDIRECT


### PR DESCRIPTION
Change all imports of current_app to import from flask instead of
flask_login. Refactoring in Flask-Login between v.0.3.2 and v0.4.0
moved their import of current_app into another module and broke
Timesketch stuff that relied on it (#243). Also updating forms to use
flask_wtf.FlaskForm instead of flask_wtf.Form, since flask_wtf.Form has
been re-named and is apparently going away soonish.