### PR TITLE
Bring back context queries

### DIFF
--- a/timesketch/ui/static/components/explore/explore-event-directive.js
+++ b/timesketch/ui/static/components/explore/explore-event-directive.js
@@ -178,9 +178,10 @@ limitations under the License.
                 nextTimestamp: '=',
                 index: '=',
                 isContextEvent: '=',
+                enableContextQuery: '=',
                 order: '='
             },
-            //require: '^tsSearch',
+            require: '?^tsSearch',
             controller: function ($scope, timesketchApi) {
 
                 // Calculate the time delta in days between two events.
@@ -243,6 +244,7 @@ limitations under the License.
                             $scope.comments = data.meta.comments;
                         })
                 };
+
                 $scope.postComment = function() {
                     timesketchApi.saveEventAnnotation(
                         $scope.sketchId,
@@ -255,6 +257,7 @@ limitations under the License.
                             $scope.comment = true;
                         })
                 };
+
                 $scope.$watch('event', function(value) {
                     $scope.star = false;
                     $scope.comment = false;
@@ -279,11 +282,11 @@ limitations under the License.
                 });
 
             },
-            //link: function(scope, elem, attrs, ctrl) {
-            //    scope.getContext = function(event) {
-            //        ctrl.getContext(event);
-            //    }
-            //}
+            link: function(scope, elem, attrs, ctrl) {
+                scope.getContext = function(event) {
+                    ctrl.getContext(event);
+                }
+            }
         }
     });
 

--- a/timesketch/ui/static/components/explore/explore-event-list.html
+++ b/timesketch/ui/static/components/explore/explore-event-list.html
@@ -69,6 +69,6 @@
     <br><br><br>
 
     <div ng-repeat="event in events">
-        <ts-event ng-hide="event.hidden && !meta.showHiddenEvents" event="::event" meta="::meta" sketch-id="::sketchId" prev-timestamp="::events[$index-1]['_source'].timestamp" next-timestamp="::events[$index+1]['_source'].timestamp" index="::$index" order="::filter.order"></ts-event>
+        <ts-event ng-hide="event.hidden && !meta.showHiddenEvents" enable-context-query="true" event="::event" meta="::meta" sketch-id="::sketchId" prev-timestamp="::events[$index-1]['_source'].timestamp" next-timestamp="::events[$index+1]['_source'].timestamp" index="::$index" order="::filter.order"></ts-event>
     </div>
 </div>

--- a/timesketch/ui/static/components/explore/explore-event.html
+++ b/timesketch/ui/static/components/explore/explore-event.html
@@ -38,11 +38,11 @@
 
         <td width="150px" style="text-align: right;background: #f1f1f1;">
             <span class="label ts-name-label">{{::timeline_name}}</span>
-            <!--
-            <div style="width:20px;height:20px;cursor: pointer;" class="tooltips" ng-click="getContext(event)">
+
+            <div ng-if="enableContextQuery" style="width:20px;height:20px;cursor: pointer;" class="tooltips" ng-click="getContext(event)">
                 <span>Context query</span><i class="fa fa-search-plus" style="color:#777;"></i>
             </div>
-            -->
+
         </td>
 
     </tr>

--- a/timesketch/ui/static/components/explore/explore-search-directive.js
+++ b/timesketch/ui/static/components/explore/explore-search-directive.js
@@ -127,6 +127,7 @@ limitations under the License.
                     var new_filter = {};
                     var current_filter = $scope.filter;
                     var current_query = $scope.query;
+                    var current_queryDsl = $scope.queryDsl;
                     angular.copy(current_filter, new_filter);
 
                     var context_query = "*";
@@ -134,6 +135,7 @@ limitations under the License.
                     if (!angular.isDefined(new_filter.context)) {
                         new_filter.context = {};
                         new_filter.context.query = current_query;
+                        new_filter.context.queryDsl = current_queryDsl;
                         new_filter.context.sketchId = $scope.sketchId;
                         new_filter.context.filter = current_filter;
                         new_filter.context.seconds = 300;
@@ -154,7 +156,7 @@ limitations under the License.
                 this.closeContext = function(context) {
                     delete context.filter.context;
                     $scope.showFilters = false;
-                    this.search(context.query, context.filter)
+                    this.search(context.query, context.filter, context.queryDsl)
                 };
             }
         }

--- a/timesketch/ui/static/components/story/story-event-list.html
+++ b/timesketch/ui/static/components/story/story-event-list.html
@@ -1,6 +1,13 @@
-<b>{{ viewName }}</b>
-<div class="pull-right" style="margin-bottom:6px;"><a href="/sketch/{{ sketchId }}/explore/view/{{ viewId }}">Go to view <i class="fa fa-arrow-right"></i></a></div>
-<div ng-repeat="event in events">
-    <ts-event ng-hide="event.hidden && !meta.showHiddenEvents" event="::event" meta="::meta" sketch-id="::sketchId" prev-timestamp="::events[$index-1]['_source'].timestamp" next-timestamp="::events[$index+1]['_source'].timestamp" index="::$index" order="::filter.order"></ts-event>
+<div ng-if="deleted">
+    <b>Deleted view: {{ viewName }}</b>
+</div>
+
+<div ng-if="!deleted">
+    <b>{{ viewName }}</b>
+    <div class="pull-right" style="margin-bottom:6px;"><a href="/sketch/{{ sketchId }}/explore/view/{{ viewId }}">Go to view <i class="fa fa-arrow-right"></i></a></div>
+    <div ng-repeat="event in events">
+        <ts-event ng-hide="event.hidden && !meta.showHiddenEvents" enable-context-query="false" event="::event" meta="::meta" sketch-id="::sketchId" prev-timestamp="::events[$index-1]['_source'].timestamp" next-timestamp="::events[$index+1]['_source'].timestamp" index="::$index" order="::filter.order"></ts-event>
+    </div>
+    <br><br>
 </div>
 <br><br>


### PR DESCRIPTION
Make require tsSearch optional to make context queries NOT brake event list in stories.
Ref issue: #241 