### PR TITLE
API endpoint for tsctl's add_index

### DIFF
--- a/timesketch.conf
+++ b/timesketch.conf
@@ -73,7 +73,9 @@ UPLOAD_ENABLED = False
 
 # Folder for temporarily storage of Plaso dump files before being processed and
 # inserted into the datastore.
-UPLOAD_FOLDER = u'/tmp'o enable the tsctl API endpointss
+UPLOAD_FOLDER = u'/tmp'
+
+# Celery broker configuration. You need to change ip/port to where your Redis
 # server is running.
 CELERY_BROKER_URL='redis://127.0.0.1:6379',
 CELERY_RESULT_BACKEND='redis://127.0.0.1:6379'

--- a/timesketch.conf
+++ b/timesketch.conf
@@ -73,9 +73,7 @@ UPLOAD_ENABLED = False
 
 # Folder for temporarily storage of Plaso dump files before being processed and
 # inserted into the datastore.
-UPLOAD_FOLDER = u'/tmp'
-
-# Celery broker configuration. You need to change ip/port to where your Redis
+UPLOAD_FOLDER = u'/tmp'o enable the tsctl API endpointss
 # server is running.
 CELERY_BROKER_URL='redis://127.0.0.1:6379',
 CELERY_RESULT_BACKEND='redis://127.0.0.1:6379'
@@ -83,3 +81,11 @@ CELERY_RESULT_BACKEND='redis://127.0.0.1:6379'
 # Path to plaso data directory.
 # If not set, defaults to system prefix + share/plaso
 #PLASO_DATA_LOCATION = u'/path/to/dir/with/plaso/data/files'
+
+#-------------------------------------------------------------------------------
+
+# tsctl API
+#
+# The tsctl API adds API endpoints for a limited set of tsctl's functionality.
+# It is disabled by default. To enable it, set an API key below:
+TSCTL_API_KEY = u''

--- a/timesketch/__init__.py
+++ b/timesketch/__init__.py
@@ -175,7 +175,8 @@ def create_app(config=None):
 
     # Load the tsctl API endpoints only if the TSCTL API key is set
     if u'TSCTL_API_KEY' in app.config and app.config[u'TSCTL_API_KEY']:
-        tsctlapi_v1 = Api(app, prefix=u'/api/v1/tsctl', decorators=[csrf.exempt])
+        tsctlapi_v1 = Api(app, prefix=u'/api/v1/tsctl',
+                          decorators=[csrf.exempt])
         tsctlapi_v1.add_resource(SearchIndexResource, u'/searchindices/')
 
     return app

--- a/timesketch/__init__.py
+++ b/timesketch/__init__.py
@@ -41,6 +41,7 @@ from timesketch.api.v1.resources import QueryResource
 from timesketch.api.v1.resources import CountEventsResource
 from timesketch.api.v1.resources import TimelineResource
 from timesketch.api.v1.resources import TimelineListResource
+from timesketch.api.v1.resources import SearchIndexResource
 from timesketch.lib.errors import ApiHTTPError
 from timesketch.models import configure_engine
 from timesketch.models import init_db
@@ -170,7 +171,12 @@ def create_app(config=None):
         return User.query.get(user_id)
 
     # Setup CSRF protection for the whole application
-    CSRFProtect(app)
+    csrf = CSRFProtect(app)
+
+    # Load the tsctl API endpoints only if the TSCTL API key is set
+    if u'TSCTL_API_KEY' in app.config and app.config[u'TSCTL_API_KEY']:
+        tsctlapi_v1 = Api(app, prefix=u'/api/v1/tsctl', decorators=[csrf.exempt])
+        tsctlapi_v1.add_resource(SearchIndexResource, u'/searchindices/')
 
     return app
 

--- a/timesketch/lib/forms.py
+++ b/timesketch/lib/forms.py
@@ -205,6 +205,7 @@ class StoryForm(BaseForm):
         u'Content', validators=[], widget=widgets.TextArea())
 
 class SearchIndexForm(BaseForm):
+    """Form to handle API requests to add search indices."""
     name = StringField(u'Name', validators=[DataRequired()])
     index = StringField(u'Index', validators=[DataRequired()])
     api_key = StringField(u'Index', validators=[DataRequired()])

--- a/timesketch/lib/forms.py
+++ b/timesketch/lib/forms.py
@@ -208,4 +208,5 @@ class SearchIndexForm(BaseForm):
     """Form to handle API requests to add search indices."""
     name = StringField(u'Name', validators=[DataRequired()])
     index = StringField(u'Index', validators=[DataRequired()])
+    username = StringField(u'Username', validators=[DataRequired()])
     api_key = StringField(u'Index', validators=[DataRequired()])

--- a/timesketch/lib/forms.py
+++ b/timesketch/lib/forms.py
@@ -203,3 +203,8 @@ class StoryForm(BaseForm):
     title = StringField(u'Title', validators=[])
     content = StringField(
         u'Content', validators=[], widget=widgets.TextArea())
+
+class SearchIndexForm(BaseForm):
+    name = StringField(u'Name', validators=[DataRequired()])
+    index = StringField(u'Index', validators=[DataRequired()])
+    api_key = StringField(u'Index', validators=[DataRequired()])


### PR DESCRIPTION
I think this has general utility for folks doing automation and integration work with Timesketch, so I figured I'd offer it up.

We wrote this to make some integrations possible between Timesketch and other parts of our stack. It's useful when you have things pushing data to ES (Timesketch) not using psort or tsctl and would like them to advise Timesketch of the existence of the data, without needing to have Timesketch installed, command line access to the Timesketch server, or access to Timesketch's database. 

To do this, we added a tsctl API under /api/v1/tsctl/ and added a searchindices endpoint that mirrors exactly what tsctl's add_index command does, with a couple minor changes for context. Requests to the tsctl API are authenticated with a token set in timesketch.conf; the tsctl API endpoints only get loaded if the token is set.

Related thoughts that came up while doing this:
- Would it make sense to enforce a uniqueness constraint on the ES index name on the SearchIndex. I can't think of a use case for multiple, differently named timelines using the same ES index. It just seems to add opportunities for things to go wrong or get confusing.
- Should all the things that create a SearchIndex check for the timesketch_label mapping's presence and add it if it's not present?
- The error handler for ApiHTTPError doesn't seem to be called when DEBUG is false, which precludes things using it from providing intelligent errors to users. I'll open a separate issue on that.