### PR TITLE
Elasticsearch 5 support (closes #262)

### DIFF
--- a/contrib/add_label.groovy
+++ b/contrib/add_label.groovy
@@ -1,3 +1,0 @@
-if( ! ctx._source.timesketch_label.contains (timesketch_label)) {
-    ctx._source.timesketch_label += timesketch_label
-}

--- a/contrib/add_label.painless
+++ b/contrib/add_label.painless
@@ -1,0 +1,3 @@
+if( ! ctx._source.timesketch_label.contains (params.timesketch_label)) {
+    ctx._source.timesketch_label.add(params.timesketch_label)
+}

--- a/contrib/toggle_label.groovy
+++ b/contrib/toggle_label.groovy
@@ -1,5 +1,0 @@
-if(ctx._source.timesketch_label.contains (timesketch_label)) {
-    ctx._source.timesketch_label.remove(timesketch_label)
-} else {
-    ctx._source.timesketch_label += timesketch_label
-}

--- a/contrib/toggle_label.painless
+++ b/contrib/toggle_label.painless
@@ -1,0 +1,10 @@
+if(ctx._source.timesketch_label.contains(params.timesketch_label)) {
+    for (int i = 0; i < ctx._source.timesketch_label.size(); i++) {
+      if (ctx._source.timesketch_label[i] == params.timesketch_label) {
+        ctx._source.timesketch_label.remove(i)
+      }
+      i++;
+    }
+} else {
+    ctx._source.timesketch_label.add(params.timesketch_label)
+}

--- a/timesketch/api/v1/resources.py
+++ b/timesketch/api/v1/resources.py
@@ -939,9 +939,14 @@ class UploadFileResource(ResourceMixin, Resource):
             return self.to_json(
                 searchindex, status_code=HTTP_STATUS_CODE_CREATED)
         else:
-            raise ApiHTTPError(
-                message=form.errors[u'file'][0],
-                status_code=HTTP_STATUS_CODE_BAD_REQUEST)
+            if u'file' in form.errors:
+                raise ApiHTTPError(
+                    message=form.errors[u'file'][0],
+                    status_code=HTTP_STATUS_CODE_BAD_REQUEST)
+            elif not UPLOAD_ENABLED:
+                raise ApiHTTPError(
+                   message="UPLOAD_ENABLED set to False. Check configuration.",
+                   status_code=HTTP_STATUS_CODE_BAD_REQUEST)
 
 
 class TaskResource(ResourceMixin, Resource):

--- a/timesketch/api/v1/resources.py
+++ b/timesketch/api/v1/resources.py
@@ -618,7 +618,7 @@ class ExploreResource(ResourceMixin, Resource):
 
             result = self.datastore.search(
                 sketch_id, form.query.data, query_filter, query_dsl, indices,
-                aggregations=None, return_results=True)
+                aggregations=None)
 
             # Get labels for each event that matches the sketch.
             # Remove all other labels.

--- a/timesketch/lib/aggregators.py
+++ b/timesketch/lib/aggregators.py
@@ -41,7 +41,7 @@ def heatmap(
 
     search_result = es_client.search(
         sketch_id, query_string, query_filter, query_dsl, indices,
-        aggregations=aggregation, return_results=False)
+        aggregations=aggregation)
 
     try:
         aggregation_result = search_result[u'aggregations']
@@ -92,7 +92,7 @@ def histogram(
 
     search_result = es_client.search(
         sketch_id, query_string, query_filter, query_dsl, indices,
-        aggregations=aggregation, return_results=False)
+        aggregations=aggregation)
 
     try:
         aggregation_result = search_result[u'aggregations']

--- a/timesketch/lib/datastore.py
+++ b/timesketch/lib/datastore.py
@@ -24,7 +24,7 @@ class DataStore(object):
     @abc.abstractmethod
     def search(
             self, sketch_id, query, query_filter, query_dsl, indices,
-            aggregations, return_results):
+            aggregations):
         """Return search results.
 
         Args:
@@ -33,7 +33,6 @@ class DataStore(object):
             query_filter: Dictionary containing filters to apply
             indices: List of indices to query
             aggregations: Dict of Elasticsearch aggregations
-            return_results: Boolean indicating if results should be returned
         """
 
     @abc.abstractmethod

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -55,11 +55,9 @@ class ElasticsearchDataStore(datastore.DataStore):
             Elasticsearch query as a dictionary.
         """
         query_dict = {
-            u'query': {
-                u'filtered': {
-                    u'filter': {
+                    u'query': {
                         u'nested': {
-                            u'filter': {
+                            u'query': {
                                 u'bool': {
                                     u'must': [
                                         {
@@ -81,8 +79,6 @@ class ElasticsearchDataStore(datastore.DataStore):
                         }
                     }
                 }
-            }
-        }
         return query_dict
 
     @staticmethod

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -150,8 +150,8 @@ class ElasticsearchDataStore(datastore.DataStore):
             if not query_dsl:
                 query_dsl = {
                     u'query': {
-                        u'filtered': {
-                            u'query': {
+                        u'bool': {
+                            u'must': {
                                 u'query_string': {
                                     u'query': query_string
                                 }
@@ -160,7 +160,7 @@ class ElasticsearchDataStore(datastore.DataStore):
                     }
                 }
             if query_filter.get(u'time_start', None):
-                query_dsl[u'query'][u'filtered'][u'filter'] = {
+                query_dsl[u'query'][u'bool'][u'filter'] = {
                     u'range': {
                         u'datetime': {
                             u'gte': query_filter[u'time_start'],
@@ -194,13 +194,13 @@ class ElasticsearchDataStore(datastore.DataStore):
         # Add any pre defined aggregations
         if aggregations:
             if isinstance(aggregations, dict):
-                query_dsl[u'aggregations'] = aggregations
+                query_dsl[u'aggs'] = aggregations
 
         return query_dsl
 
     def search(
             self, sketch_id, query_string, query_filter, query_dsl, indices,
-            aggregations=None, return_results=True):
+            aggregations=None):
         """Search ElasticSearch. This will take a query string from the UI
         together with a filter definition. Based on this it will execute the
         search request on ElasticSearch and get result back.
@@ -212,7 +212,6 @@ class ElasticsearchDataStore(datastore.DataStore):
             query_dsl: Dictionary containing Elasticsearch DSL query
             indices: List of indices to query
             aggregations: Dict of Elasticsearch aggregations
-            return_results: Boolean indicating if results should be returned
 
         Returns:
             Set of event documents in JSON format
@@ -237,8 +236,6 @@ class ElasticsearchDataStore(datastore.DataStore):
 
         # Default search type for elasticsearch is query_then_fetch.
         search_type = u'query_then_fetch'
-        if not return_results:
-            search_type = u'count'
 
         # Suppress the lint error because elasticsearch-py adds parameters
         # to the function with a decorator and this makes pylint sad.

--- a/timesketch/lib/testlib.py
+++ b/timesketch/lib/testlib.py
@@ -118,7 +118,7 @@ class MockDataStore(datastore.DataStore):
 
     def search(
             self, unused_sketch_id, unused_query, unused_query_filter,
-            unused_query_dsl, unused_indices, aggregations, return_results):
+            unused_query_dsl, unused_indices, aggregations):
         """Mock a search query.
 
         Returns:

--- a/timesketch/lib/utils.py
+++ b/timesketch/lib/utils.py
@@ -59,8 +59,8 @@ def read_and_validate_csv(path):
         for row in reader:
             if u'timestamp' not in csv_header and u'datetime' in csv_header:
                 try:
-                    row['timestamp'] = str(int(time.mktime(
-                        parser.parse(row["datetime"]).timetuple())))
+                    parsed = parser.parse(row[u'datetime'])
+                    row[u'timestamp'] = int(time.mktime(parsed.timetuple()))
                 except ValueError:
                     continue
 

--- a/timesketch/ui/static/components/explore/explore-json-editor-directive.js
+++ b/timesketch/ui/static/components/explore/explore-json-editor-directive.js
@@ -47,10 +47,8 @@
                         if (!currentQueryDsl) {
                             currentQueryDsl = {
                                 "query": {
-                                    "filtered": {
-                                        "query": {
-                                            "query_string": {
-                                                "query": scope.query}}}},
+                                    "query_string": {
+                                        "query": scope.query}},
                                 "sort": {
                                     "datetime": "asc"}
                             };

--- a/timesketch/ui/static/components/explore/explore-search-directive.js
+++ b/timesketch/ui/static/components/explore/explore-search-directive.js
@@ -200,7 +200,7 @@ limitations under the License.
                     // Set the query string input to reflect the current DSL.
                     try {
                         var currentQueryDsl = JSON.parse($scope.queryDsl);
-                        $scope.query = currentQueryDsl['query']['filtered']['query']['query_string']['query'];
+                        $scope.query = currentQueryDsl['query']['query_string']['query'];
                     } catch(err) {}
                     $scope.queryDsl = "";
                     $scope.showAdvanced = false;
@@ -284,4 +284,3 @@ limitations under the License.
     }]);
 
 })();
-

--- a/timesketch/ui/views/sketch.py
+++ b/timesketch/ui/views/sketch.py
@@ -265,7 +265,7 @@ def export(sketch_id):
 
     result = datastore.search(
         sketch_id, view.query_string, query_filter, query_dsl, indices,
-        aggregations=None, return_results=True)
+        aggregations=None)
 
     csv_out = StringIO()
     csv_writer = csv.DictWriter(


### PR DESCRIPTION
This PR launches Timesketch into the future with Elasticsearch 5 support!

Also changed, it is now possible to build timelines from CSVs that do not necessarily have a timestamp (they will generate the timestamp based on the datetime field). Particularly handy since not it can ingest the output from psort.