### PR TITLE
Create timestamp from datetime string when importing CSV

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,5 +63,6 @@ setup(
         u'redis',
         u'blinker',
         u'elasticsearch',
+        u'python-dateutil',
     ])
 )

--- a/timesketch/lib/utils.py
+++ b/timesketch/lib/utils.py
@@ -46,7 +46,7 @@ def read_and_validate_csv(path):
 
     with open(path, u'rb') as fh:
 
-        reader = csv.DictReader((x.replace('\x00', '') for x in fh))
+        reader = csv.DictReader(fh)
         csv_header = reader.fieldnames
         missing_fields = []
         # Validate the CSV header
@@ -59,8 +59,8 @@ def read_and_validate_csv(path):
         for row in reader:
             if u'timestamp' not in csv_header and u'datetime' in csv_header:
                 try:
-                    parsed = parser.parse(row[u'datetime'])
-                    row[u'timestamp'] = int(time.mktime(parsed.timetuple()))
+                    parsed_datetime = parser.parse(row[u'datetime'])
+                    row[u'timestamp'] = int(time.mktime(parsed_datetime.timetuple()))
                 except ValueError:
                     continue
 

--- a/timesketch/lib/utils.py
+++ b/timesketch/lib/utils.py
@@ -59,8 +59,8 @@ def read_and_validate_csv(path):
         for row in reader:
             if u'timestamp' not in csv_header and u'datetime' in csv_header:
                 try:
-                    row['timestamp'] = str(int(time.mktime(
-                        parser.parse(row["datetime"]).timetuple())))
+                    parsed = parser.parse(row[u'datetime'])
+                    row[u'timestamp'] = int(time.mktime(parsed.timetuple()))
                 except ValueError:
                     continue
 


### PR DESCRIPTION
It is now possible to build timelines from CSVs that do not necessarily have a timestamp (they will fall-back to the datetime field). Particularly handy since now it can ingest the output from psort.