### PR TITLE
Add Docker Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
     - "2.7"
 
 before_install:
-    - docker build -t jessemillar/timesketch .
+    - docker build -t timesketch .
 
 # command to install dependencies
 install:
@@ -18,9 +18,3 @@ install:
 
 # command to run tests
 script: nosetests
-
-after_success:
-    - if [ "$TRAVIS_BRANCH" == "master" ]; then
-      docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
-      docker push jessemillar/timesketch;
-      fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Pull and use the official Docker Hub Ubuntu 14.04 base image
-FROM ubuntu:14.04
+# Use the official Docker Hub Ubuntu 14.04 base image
+FROM ubuntu:16.04
 
 # Update the base image
 RUN apt-get update
@@ -9,17 +9,22 @@ RUN apt-get -y dist-upgrade
 # Install Timesketch dependencies
 RUN apt-get -y install python-pip python-dev libffi-dev python-psycopg2
 
+# Install Plaso
+RUN apt-get -y install software-properties-common
+RUN add-apt-repository ppa:gift/stable
+RUN apt-get update
+RUN apt-get -y install python-plaso
+
 # Use pip to install Timesketch
-# RUN pip install timesketch
-# Install from source (master branch of repository) because flask_login is currently broken (https://github.com/google/timesketch/pull/244)
-RUN pip install https://github.com/google/timesketch/archive/master.zip
+ADD . /tmp/timesketch
+RUN pip install /tmp/timesketch
 
 # Copy the Timesketch configuration file into /etc
 RUN cp /usr/local/share/timesketch/timesketch.conf /etc
 RUN chmod 600 /etc/timesketch.conf
 
 # Copy the entrypoint script into the container
-COPY docker-entrypoint.sh / 
+COPY docker-entrypoint.sh /
 
 # Expose the port used by Timesketch
 EXPOSE 5000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,32 +1,29 @@
 timesketch:
-    build: .
-    ports:
-        - "5000:5000"
-    links:
-        - elasticsearch
-        - postgres
-    environment:
-        - POSTGRES_USER=timesketch
-        - POSTGRES_PASSWORD=password
-        - TIMESKETCH_USER=admin
-        - TIMESKETCH_PASSWORD=password
-        - POSTGRES_ADDRESS=postgres # Use hostname linking
-        - POSTGRES_PORT=5432
-        - ELASTIC_ADDRESS=elastic # Use hostname linking
-        - ELASTIC_PORT=9200
-    restart: always
+  build: .
+  ports:
+    - "5000:5000"
+  links:
+    - elasticsearch
+    - postgres
+  environment:
+    - POSTGRES_USER=timesketch
+    - POSTGRES_PASSWORD=password
+    - POSTGRES_ADDRESS=postgres
+    - POSTGRES_PORT=5432
+    - ELASTIC_ADDRESS=elastic
+    - ELASTIC_PORT=9200
+  restart: always
 elasticsearch:
-    image: elasticsearch:2.4.1
-    command: elasticsearch -Des.node.name="TimesketchNode" -Des.script.groovy.sandbox.enabled=true
-    ports:
-        - "9200:9200"
-        - "9300:9300"
-    restart: always
+  image: elasticsearch:2.4
+  ports:
+    - "9200:9200"
+    - "9300:9300"
+  restart: always
 postgres:
-    image: postgres:9.3.14
-    ports:
-        - "5432:5432"
-    environment:
-        - POSTGRES_USER=timesketch
-        - POSTGRES_PASSWORD=password
-    restart: always
+  image: postgres:9.6
+  ports:
+    - "5432:5432"
+  environment:
+    - POSTGRES_USER=timesketch
+    - POSTGRES_PASSWORD=password
+  restart: always

--- a/timesketch/lib/utils.py
+++ b/timesketch/lib/utils.py
@@ -60,8 +60,7 @@ def read_and_validate_csv(path):
             if u'timestamp' not in csv_header and u'datetime' in csv_header:
                 try:
                     parsed_datetime = parser.parse(row[u'datetime'])
-                    row[u'timestamp'] = str(int(
-                        time.mktime(parsed_datetime.timetuple())))
+                    row[u'timestamp'] = int(time.mktime(parsed_datetime.timetuple()))
                 except ValueError:
                     continue
 


### PR DESCRIPTION
**Problem**
Timesketch is currently difficult to deploy in a dockerized environment, which is desirable to simplify deployments.

**Usage**
This adds docker support for simpler local development and test. Test with:

```shell 
docker-compose build
docker-compose up
# view at http://localhost:5000
``` 

**Notes**
Builds on @jessemillar's work in https://github.com/google/timesketch/pull/249.