### PR TITLE
Add Docker Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
+sudo: required
+services:
+  - docker
 language: python
 python:
   - "2.7"
+before_install:
+    - docker build -t timesketch .
 # command to install dependencies
 install:
   - "pip install ."

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Use the official Docker Hub Ubuntu 14.04 base image
+FROM ubuntu:16.04
+
+# Update the base image
+RUN apt-get update
+RUN apt-get -y upgrade
+RUN apt-get -y dist-upgrade
+
+# Install Timesketch dependencies
+RUN apt-get -y install python-pip python-dev libffi-dev python-psycopg2
+
+# Install Plaso
+RUN apt-get -y install software-properties-common
+RUN add-apt-repository ppa:gift/stable
+RUN apt-get update
+RUN apt-get -y install python-plaso
+
+# Use pip to install Timesketch
+ADD . /tmp/timesketch
+RUN pip install /tmp/timesketch
+
+# Copy the Timesketch configuration file into /etc
+RUN cp /usr/local/share/timesketch/timesketch.conf /etc
+RUN chmod 600 /etc/timesketch.conf
+
+# Copy the entrypoint script into the container
+COPY docker-entrypoint.sh /
+
+# Expose the port used by Timesketch
+EXPOSE 5000
+
+# Load the entrypoint script to be run later
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+# Invoke the entrypoint script
+CMD ["timesketch"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+timesketch:
+  build: .
+  ports:
+    - "5000:5000"
+  links:
+    - elasticsearch
+    - postgres
+  environment:
+    - POSTGRES_USER=timesketch
+    - POSTGRES_PASSWORD=password
+    - POSTGRES_ADDRESS=postgres
+    - POSTGRES_PORT=5432
+    - ELASTIC_ADDRESS=elastic
+    - ELASTIC_PORT=9200
+  restart: always
+elasticsearch:
+  image: elasticsearch:2.4
+  ports:
+    - "9200:9200"
+    - "9300:9300"
+  restart: always
+postgres:
+  image: postgres:9.6
+  ports:
+    - "5432:5432"
+  environment:
+    - POSTGRES_USER=timesketch
+    - POSTGRES_PASSWORD=password
+  restart: always

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Run the container the default way
+if [ "$1" = 'timesketch' ]; then
+	# Set SECRET_KEY in /etc/timesketch.conf if it isn't already set
+	if grep -q "SECRET_KEY = u''" /etc/timesketch.conf; then
+		OPENSSL_RAND=$( openssl rand -base64 32 )
+		# Using the pound sign as a delimiter to avoid problems with / being output from openssl
+		sed -i 's#SECRET_KEY = u\x27\x27#SECRET_KEY = u\x27'$OPENSSL_RAND'\x27#' /etc/timesketch.conf
+	fi
+
+	# Set up the Postgres connection
+	if [ $POSTGRES_USER ] && [ $POSTGRES_PASSWORD ] && [ $POSTGRES_ADDRESS ] && [ $POSTGRES_PORT ]; then
+		sed -i 's#postgresql://<USERNAME>:<PASSWORD>@localhost#postgresql://'$POSTGRES_USER':'$POSTGRES_PASSWORD'@'$POSTGRES_ADDRESS':'$POSTGRES_PORT'#' /etc/timesketch.conf
+	else
+		# Log an error since we need the above-listed environment variables
+		echo "Please pass values for the POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_ADDRESS, and POSTGRES_PORT environment variables"
+		exit 1
+	fi
+
+	# Set up the Elastic connection
+	if [ $ELASTIC_ADDRESS ] && [ $ELASTIC_PORT ]; then
+		sed -i 's#ELASTIC_HOST = u\x27127.0.0.1\x27#ELASTIC_HOST = u\x27'$ELASTIC_ADDRESS'\x27#' /etc/timesketch.conf
+		sed -i 's#ELASTIC_PORT = 9200#ELASTIC_PORT = '$ELASTIC_PORT'#' /etc/timesketch.conf
+	else
+		# Log an error since we need the above-listed environment variables
+		echo "Please pass values for the ELASTIC_ADDRESS and ELASTIC_PORT environment variables"
+	fi
+
+	# Set up web credentials
+	if [ -z ${TIMESKETCH_USER+x} ]; then
+		TIMESKETCH_USER="admin"
+		echo "TIMESKETCH_USER set to default: ${TIMESKETCH_USER}";
+	fi
+	if [ -z ${TIMESKETCH_PASSWORD+x} ]; then
+		TIMESKETCH_PASSWORD="$(openssl rand -base64 32)"
+		echo "TIMESKETCH_PASSWORD set randomly to: ${TIMESKETCH_PASSWORD}";
+	fi
+	tsctl add_user -u "$TIMESKETCH_USER" -p "$TIMESKETCH_PASSWORD"
+
+
+	# Run the Timesketch server (without SSL)
+	exec `tsctl runserver -h 0.0.0.0 -p 5000`
+fi
+
+# Run a custom command on container start
+exec "$@"


### PR DESCRIPTION
**Problem**
Timesketch is currently difficult to deploy in a dockerized environment, which is desirable to simplify deployments.

**Usage**
This adds docker support for simpler local development and test. Test with:

```shell 
docker-compose build
docker-compose up
# view at http://localhost:5000
``` 

**Notes**
- Builds on @jessemillar's work in https://github.com/google/timesketch/pull/249.
- This replaces https://github.com/google/timesketch/pull/323 which had issues with git log emails and the google CLA.