### PR TITLE
upgrade to docker-compose v3 and fix docker support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,8 @@ RUN cp /usr/local/share/timesketch/timesketch.conf /etc
 RUN chmod 600 /etc/timesketch.conf
 
 # Copy the entrypoint script into the container
-COPY docker-entrypoint.sh /
+COPY docker/docker-entrypoint.sh /
+RUN chmod a+x /docker-entrypoint.sh
 
 # Expose the port used by Timesketch
 EXPOSE 5000

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,29 +1,36 @@
-timesketch:
-  build: .
-  ports:
-    - "5000:5000"
-  links:
-    - elasticsearch
-    - postgres
-  environment:
-    - POSTGRES_USER=timesketch
-    - POSTGRES_PASSWORD=password
-    - POSTGRES_ADDRESS=postgres
-    - POSTGRES_PORT=5432
-    - ELASTIC_ADDRESS=elastic
-    - ELASTIC_PORT=9200
-  restart: always
-elasticsearch:
-  image: elasticsearch:2.4
-  ports:
-    - "9200:9200"
-    - "9300:9300"
-  restart: always
-postgres:
-  image: postgres:9.6
-  ports:
-    - "5432:5432"
-  environment:
-    - POSTGRES_USER=timesketch
-    - POSTGRES_PASSWORD=password
-  restart: always
+version: '3'
+services:
+  timesketch:
+    build:
+      context: ../
+      dockerfile: ./docker/Dockerfile
+    ports:
+      - "5000:5000"
+    links:
+      - elasticsearch
+      - postgres
+      - redis
+    environment:
+      - POSTGRES_USER=timesketch
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_ADDRESS=postgres
+      - POSTGRES_PORT=5432
+      - ELASTIC_ADDRESS=elastic
+      - ELASTIC_PORT=9200
+    restart: always
+  elasticsearch:
+    image: elasticsearch:2.4
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    restart: always
+  postgres:
+    image: postgres:9.6
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=timesketch
+      - POSTGRES_PASSWORD=password
+    restart: always
+  redis:
+    image: redis:3

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -27,6 +27,10 @@ if [ "$1" = 'timesketch' ]; then
 		echo "Please pass values for the ELASTIC_ADDRESS and ELASTIC_PORT environment variables"
 	fi
 
+	# Replace Redis Hostname
+	sed -i "s#^CELERY_BROKER_URL=.*#CELERY_BROKER_URL='redis://redis:6379'#" /etc/timesketch.conf
+	sed -i "s#^CELERY_RESULT_BACKEND=.*#CELERY_RESULT_BACKEND='redis://redis:6379'#" /etc/timesketch.conf
+	
 	# Set up web credentials
 	if [ -z ${TIMESKETCH_USER+x} ]; then
 		TIMESKETCH_USER="admin"


### PR DESCRIPTION
Notes:
* This fixes docker support now that docker files are in `/docker/`. 
* Upgrades docker-compose to v3 format
* Adds a redis container and sets .conf accordingly

Note that the docker [docs](https://github.com/google/timesketch/wiki/Docker) are now out of date.  What do you think about converting the wiki file into a new `docker/README.md` that's versioned for inline docs on using these properly? 