### PR TITLE
Add simple navigation component in Angular 2

### DIFF
--- a/timesketch/templates/sketch/explore.html
+++ b/timesketch/templates/sketch/explore.html
@@ -1,13 +1,7 @@
 {% extends "base.html" %}
 
 {% block navigation %}
-    <ul class="nav nav-tabs">
-        <li role="presentation"><a href="{{ url_for('sketch_views.overview', sketch_id=sketch.id) }}"><i class="fa fa-cube"></i> Overview</a></li>
-        <li role="presentation" class="active"><a href="{{ url_for('sketch_views.explore', sketch_id=sketch.id) }}"><i class="fa fa-search"></i> Explore</a></li>
-        <li role="presentation"><a href="{{ url_for('story_views.story', sketch_id=sketch.id) }}"><i class="fa fa-book"></i> Stories</a></li>
-        <li role="presentation"><a href="{{ url_for('sketch_views.views', sketch_id=sketch.id) }}"><i class="fa fa-eye"></i> Views</a></li>
-        <li role="presentation"><a href="{{ url_for('sketch_views.timelines', sketch_id=sketch.id) }}"><i class="fa fa-clock-o"></i> Timelines</a></li>
-    </ul>
+    <ts-navigation sketch-id="{{ sketch.id }}" active="explore"></ts-navigation>
 {% endblock %}
 
 {% block main %}

--- a/timesketch/templates/sketch/overview.html
+++ b/timesketch/templates/sketch/overview.html
@@ -1,13 +1,7 @@
 {% extends "base.html" %}
 
 {% block navigation %}
-    <ul class="nav nav-tabs">
-        <li role="presentation" class="active"><a href="{{ url_for('sketch_views.overview', sketch_id=sketch.id) }}"><i class="fa fa-cube"></i> Overview</a></li>
-        <li role="presentation"><a href="{{ url_for('sketch_views.explore', sketch_id=sketch.id) }}"><i class="fa fa-search"></i> Explore</a></li>
-        <li role="presentation"><a href="{{ url_for('story_views.story', sketch_id=sketch.id) }}"><i class="fa fa-book"></i> Stories</a></li>
-        <li role="presentation"><a href="{{ url_for('sketch_views.views', sketch_id=sketch.id) }}"><i class="fa fa-eye"></i> Views</a></li>
-        <li role="presentation"><a href="{{ url_for('sketch_views.timelines', sketch_id=sketch.id) }}"><i class="fa fa-clock-o"></i> Timelines</a></li>
-    </ul>
+    <ts-navigation sketch-id="{{ sketch.id }}" active="overview"></ts-navigation>
 {% endblock %}
 
 {% block right_nav %}

--- a/timesketch/templates/sketch/stories.html
+++ b/timesketch/templates/sketch/stories.html
@@ -1,13 +1,7 @@
 {% extends "base.html" %}
 
 {% block navigation %}
-    <ul class="nav nav-tabs">
-        <li role="presentation"><a href="{{ url_for('sketch_views.overview', sketch_id=sketch.id) }}"><i class="fa fa-cube"></i> Overview</a></li>
-        <li role="presentation"><a href="{{ url_for('sketch_views.explore', sketch_id=sketch.id) }}"><i class="fa fa-search"></i> Explore</a></li>
-        <li role="presentation" class="active"><a href="{{ url_for('story_views.story', sketch_id=sketch.id) }}"><i class="fa fa-book"></i> Stories</a></li>
-        <li role="presentation"><a href="{{ url_for('sketch_views.views', sketch_id=sketch.id) }}"><i class="fa fa-eye"></i> Views</a></li>
-        <li role="presentation"><a href="{{ url_for('sketch_views.timelines', sketch_id=sketch.id) }}"><i class="fa fa-clock-o"></i> Timelines</a></li>
-    </ul>
+    <ts-navigation sketch-id="{{ sketch.id }}" active="stories"></ts-navigation>
 {% endblock %}
 
 {% block right_nav %}

--- a/timesketch/templates/sketch/timeline.html
+++ b/timesketch/templates/sketch/timeline.html
@@ -1,13 +1,7 @@
 {% extends "base.html" %}
 
 {% block navigation %}
-    <ul class="nav nav-tabs">
-        <li role="presentation"><a href="{{ url_for('sketch_views.overview', sketch_id=sketch.id) }}"><i class="fa fa-cube"></i> Overview</a></li>
-        <li role="presentation"><a href="{{ url_for('sketch_views.explore', sketch_id=sketch.id) }}"><i class="fa fa-search"></i> Explore</a></li>
-        <li role="presentation"><a href="{{ url_for('story_views.story', sketch_id=sketch.id) }}"><i class="fa fa-book"></i> Stories</a></li>
-        <li role="presentation"><a href="{{ url_for('sketch_views.views', sketch_id=sketch.id) }}"><i class="fa fa-eye"></i> Views</a></li>
-        <li role="presentation" class="active"><a href="{{ url_for('sketch_views.timelines', sketch_id=sketch.id) }}"><i class="fa fa-clock-o"></i> Timelines</a></li>
-    </ul>
+    <ts-navigation sketch-id="{{ sketch.id }}" active="timelines"></ts-navigation>
 {% endblock %}
 
 {% block main %}

--- a/timesketch/templates/sketch/timelines.html
+++ b/timesketch/templates/sketch/timelines.html
@@ -1,13 +1,7 @@
 {% extends "base.html" %}
 
 {% block navigation %}
-    <ul class="nav nav-tabs">
-        <li role="presentation"><a href="{{ url_for('sketch_views.overview', sketch_id=sketch.id) }}"><i class="fa fa-cube"></i> Overview</a></li>
-        <li role="presentation"><a href="{{ url_for('sketch_views.explore', sketch_id=sketch.id) }}"><i class="fa fa-search"></i> Explore</a></li>
-        <li role="presentation"><a href="{{ url_for('story_views.story', sketch_id=sketch.id) }}"><i class="fa fa-book"></i> Stories</a></li>
-        <li role="presentation"><a href="{{ url_for('sketch_views.views', sketch_id=sketch.id) }}"><i class="fa fa-eye"></i> Views</a></li>
-        <li role="presentation" class="active"><a href="{{ url_for('sketch_views.timelines', sketch_id=sketch.id) }}"><i class="fa fa-clock-o"></i> Timelines</a></li>
-    </ul>
+    <ts-navigation sketch-id="{{ sketch.id }}" active="timelines"></ts-navigation>
 {% endblock %}
 
 {% block right_nav %}

--- a/timesketch/templates/sketch/views.html
+++ b/timesketch/templates/sketch/views.html
@@ -1,13 +1,7 @@
 {% extends "base.html" %}
 
 {% block navigation %}
-    <ul class="nav nav-tabs">
-        <li role="presentation"><a href="{{ url_for('sketch_views.overview', sketch_id=sketch.id) }}"><i class="fa fa-cube"></i> Overview</a></li>
-        <li role="presentation"><a href="{{ url_for('sketch_views.explore', sketch_id=sketch.id) }}"><i class="fa fa-search"></i> Explore</a></li>
-        <li role="presentation"><a href="{{ url_for('story_views.story', sketch_id=sketch.id) }}"><i class="fa fa-book"></i> Stories</a></li>
-        <li role="presentation" class="active"><a href="{{ url_for('sketch_views.views', sketch_id=sketch.id) }}"><i class="fa fa-eye"></i> Views</a></li>
-        <li role="presentation"><a href="{{ url_for('sketch_views.timelines', sketch_id=sketch.id) }}"><i class="fa fa-clock-o"></i> Timelines</a></li>
-    </ul>
+    <ts-navigation sketch-id="{{ sketch.id }}" active="views"></ts-navigation>
 {% endblock %}
 
 {% block main %}

--- a/timesketch/ui/app.module.ts
+++ b/timesketch/ui/app.module.ts
@@ -14,10 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import angular from 'angularjs-for-webpack'
+import {NgModule} from '@angular/core'
+import {BrowserModule} from '@angular/platform-browser'
 import {tsApiModule} from './api/api.module'
 import {tsCoreModule} from './core/core.module'
 import {tsExploreModule} from './explore/explore.module'
-import {tsSketchModule} from './sketch/sketch.module'
+import {tsSketchModule, SketchModule} from './sketch/sketch.module'
 import {tsStoryModule} from './story/story.module'
 
 export const tsAppModule = angular.module('timesketch', [
@@ -60,3 +62,10 @@ export const tsAppModule = angular.module('timesketch', [
     const csrftoken = document.getElementsByTagName('meta')[0]['content'];
     $httpProvider.defaults.headers.common['X-CSRFToken'] = csrftoken;
 })
+
+@NgModule({
+  imports: [SketchModule, BrowserModule],
+})
+export class AppModule {
+  ngDoBootstrap() {}
+}

--- a/timesketch/ui/main.ts
+++ b/timesketch/ui/main.ts
@@ -6,11 +6,23 @@ import 'twitter-bootstrap-3.0.0/dist/js/bootstrap.js'
 import 'medium-editor/dist/css/medium-editor.css'
 import 'medium-editor/dist/css/themes/default.css'
 
+import 'zone.js'
+
 import angular from 'angularjs-for-webpack'
+import {downgradeModule} from '@angular/upgrade/static'
 
 import 'css/ts.css'
-import {tsAppModule} from 'app.module'
+import {tsAppModule, AppModule} from 'app.module'
 
 angular.element(function() {
-  angular.bootstrap(document.body, [tsAppModule.name])
+  // @ngtools/webpack should automatically convert AppModule to
+  // AppModuleNgFactory. We are casting it through any to make TypeScript happy
+  // https://github.com/angular/angular-cli/blob/4586abd226090521f2470fa47a27553241415426/packages/%40ngtools/webpack/src/loader.ts#L267
+  // this code rewriting by @ngtools/webpack is one big hack :(
+  // for example, changing from "downgradeModule as any" to "AppModule as any"
+  // will break everything because of the way the code transformation looks for
+  // the bootstrapping code
+  angular.bootstrap(document.body, [
+    tsAppModule.name, (downgradeModule as any)(AppModule),
+  ])
 })

--- a/timesketch/ui/sketch/navigation.component.ts
+++ b/timesketch/ui/sketch/navigation.component.ts
@@ -1,0 +1,10 @@
+import {Component, Input} from '@angular/core'
+
+@Component({
+  selector: 'ts-navigation',
+  templateUrl: './navigation.ng.html',
+})
+export class NavigationComponent {
+  @Input() sketchId: number
+  @Input() active: string
+}

--- a/timesketch/ui/sketch/navigation.ng.html
+++ b/timesketch/ui/sketch/navigation.ng.html
@@ -1,0 +1,27 @@
+<ul class="nav nav-tabs">
+    <li role="presentation" [class.active]="active==='overview'">
+      <a href="/sketch/{{sketchId}}/">
+        <i class="fa fa-cube"></i> Overview
+      </a>
+    </li>
+    <li role="presentation" [class.active]="active==='explore'">
+      <a href="/sketch/{{sketchId}}/explore/">
+        <i class="fa fa-search"></i> Explore
+      </a>
+    </li>
+    <li role="presentation" [class.active]="active==='stories'">
+      <a href="/sketch/{{sketchId}}/stories/">
+        <i class="fa fa-book"></i> Stories
+      </a>
+    </li>
+    <li role="presentation" [class.active]="active==='views'">
+      <a href="/sketch/{{sketchId}}/views/">
+        <i class="fa fa-eye"></i> Views
+      </a>
+    </li>
+    <li role="presentation" [class.active]="active==='timelines'">
+      <a href="/sketch/{{sketchId}}/timelines/">
+        <i class="fa fa-clock-o"></i> Timelines
+      </a>
+    </li>
+</ul>

--- a/timesketch/ui/sketch/sketch.module.ts
+++ b/timesketch/ui/sketch/sketch.module.ts
@@ -14,12 +14,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import angular from 'angularjs-for-webpack'
+import {NgModule} from '@angular/core'
+import {CommonModule} from '@angular/common'
+import {downgradeComponent} from '@angular/upgrade/static'
 import {tsCountEvents} from './count-events.directive'
 import {tsTimelinesList} from './timelines.directive'
 import {tsSavedViewList, tsSearchTemplateList} from './views.directive'
+import {NavigationComponent} from './navigation.component'
 
 export const tsSketchModule = angular.module('timesketch.sketch', [])
   .directive('tsCountEvents', tsCountEvents)
   .directive('tsTimelinesList', tsTimelinesList)
   .directive('tsSavedViewList', tsSavedViewList)
   .directive('tsSearchTemplateList', tsSearchTemplateList)
+  .directive('tsNavigation', downgradeComponent({
+      component: NavigationComponent, propagateDigest: false,
+  }))
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [NavigationComponent],
+  entryComponents: [NavigationComponent],
+})
+export class SketchModule {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,10 @@
     "baseUrl": "./timesketch/ui/",
     "sourceMap": true,
     "noImplicitAny": false,
-    "strictNullChecks": true,
+    "strictNullChecks": false,
     "module": "commonjs",
-    "target": "es5"
+    "target": "es5",
+    "experimentalDecorators": true,
+    "lib": [ "es6", "dom" ]
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,17 @@
-var path = require('path')
-var ExtractTextPlugin = require("extract-text-webpack-plugin")
+const path = require('path')
+const ExtractTextPlugin = require('extract-text-webpack-plugin')
+const AotPlugin = require('@ngtools/webpack').AotPlugin
 
 const extractSass = new ExtractTextPlugin({
-    filename: "bundle.css",
-    disable: false,
+  filename: 'bundle.css',
+  disable: false,
+})
+
+const aotPlugin = new AotPlugin({
+  tsConfigPath: 'tsconfig.json',
+  // entryModule path must be absolute, otherwise it generates really obscure
+  // error message: https://github.com/angular/angular-cli/issues/4913
+  entryModule: path.resolve(__dirname, 'timesketch/ui/app.module#AppModule'),
 })
 
 module.exports = {
@@ -12,7 +20,7 @@ module.exports = {
     rules: [
       {
         test: /\.tsx?$/,
-        use: 'ts-loader',
+        use: '@ngtools/webpack',
         exclude: /node_modules/,
       },
       {
@@ -47,7 +55,5 @@ module.exports = {
     filename: 'bundle.js',
     path: path.resolve(__dirname, 'timesketch/static/dist/'),
   },
-  plugins: [
-    extractSass
-  ],
+  plugins: [extractSass, aotPlugin],
 }


### PR DESCRIPTION
* Register Angular 2 component as AngularJS directive
* Use "independent mode" of ngUpgrade which intends to avoid performance
  issues with propagating digest cycle to Angular 2 change detection:
  downgradeModule({..., propagateDigest: false})
* Use @ngtools/webpack for AOT compilation of Angular 2 templates