### PR TITLE
Fix Angular bootstrap broken in #423

### DIFF
--- a/timesketch/ui/main.ts
+++ b/timesketch/ui/main.ts
@@ -1,9 +1,10 @@
+import * as $ from 'jquery'
 import angular from 'angularjs-for-webpack'
 import {downgradeModule} from '@angular/upgrade/static'
 
 import {tsAppModule, AppModule} from 'app.module'
 
-angular.element(function () {
+$(function () {
 
   // @ngtools/webpack should automatically convert AppModule to
   // AppModuleNgFactory. We are casting it through any to make TypeScript happy


### PR DESCRIPTION
Reordering of import statements caused `angular.element` to be Angular's implementation of JQuery that cannot be used as a shorthand for attaching handlers to 'document ready' event.