### PR TITLE
Add direct link to specific event (#414)

### DIFF
--- a/timesketch/ui/explore/event.html
+++ b/timesketch/ui/explore/event.html
@@ -60,6 +60,12 @@
                     </table>
                 </div>
                 <div class="col-md-4">
+                  <div style="margin-bottom:10px;">
+                         <a style="color:#666" href="/sketch/{{ sketchId }}/explore/?q=_id:{{event._id}}&index={{ event._index }}">
+                           <i class="fa fa-lg fa-link icon-grey"></i> Direct link to this event
+                        </a>
+                    </div>
+
                     <div ng-repeat="comment in comments">
                         <div class="comment-bubble">
                             <div class="comment-name">{{::comment.user.username}}</div>


### PR DESCRIPTION
Resubmitting because my git skills suck... sorry

Adds a link above the comment section in the event detail view to a query that returns the event being viewed. I figure this probably won't get enough use to warrant its own icon in the event list and you'll probably already be looking at the detail view for any event you care about enough to want a direct link for it.