### PR TITLE
Mention the disksize plugin

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -18,6 +18,7 @@ Follow the official instructions [here](https://www.vagrantup.com/docs/installat
 
 ### Create Timesketch Vagrant box
     $ cd timesketch/vagrant
+    $ vagrant plugin install vagrant-disksize
     $ vagrant up
     .. wait until the installation process is complete
     $ vagrant ssh


### PR DESCRIPTION
Without it, you will end up:

There was an error loading a Vagrantfile. The file being loaded
and the error message are shown below. This is usually caused by
a syntax error.

Path: /Users/foo/timesketch/vagrant/Vagrantfile
Line number: 8
Message: RuntimeError: vagrant-disksize is not installed ("vagrant plugin install vagrant-disksize")

Not a big deal and it will tell you what to do anyway, but mentioning it lowers the bar to use it I hope.