### PR TITLE
Surface celery task errors

### DIFF
--- a/timesketch/api/v1/resources.py
+++ b/timesketch/api/v1/resources.py
@@ -107,6 +107,7 @@ class ResourceMixin(object):
     searchindex_fields = {
         u'id': fields.Integer,
         u'name': fields.String,
+        u'description': fields.String,
         u'index_name': fields.String,
         u'status': fields.Nested(status_fields),
         u'deleted': fields.Boolean,

--- a/timesketch/api/v1/resources.py
+++ b/timesketch/api/v1/resources.py
@@ -940,8 +940,9 @@ class UploadFileResource(ResourceMixin, Resource):
                     sketch=sketch,
                     user=current_user,
                     searchindex=searchindex)
-                db_session.add(timeline)
+                timeline.set_status(u'processing')
                 sketch.timelines.append(timeline)
+                db_session.add(timeline)
                 db_session.commit()
 
             # Run the task in the background

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -452,6 +452,18 @@ class ElasticsearchDataStore(datastore.DataStore):
         doc_type = unicode(doc_type.decode(encoding=u'utf-8'))
         return index_name, doc_type
 
+    def delete_index(self, index_name):
+        """Delete Elasticsearch index.
+
+        Args:
+            index_name: Name of the index to delete.
+        """
+        if self.client.indices.exists(index_name):
+            try:
+                self.client.indices.delete(index=index_name)
+            except ConnectionError:
+                raise RuntimeError(u'Unable to connect to Timesketch backend.')
+
     def import_event(
             self, index_name, event_type, event=None,
             event_id=None, flush_interval=DEFAULT_FLUSH_INTERVAL):

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -461,8 +461,10 @@ class ElasticsearchDataStore(datastore.DataStore):
         if self.client.indices.exists(index_name):
             try:
                 self.client.indices.delete(index=index_name)
-            except ConnectionError:
-                raise RuntimeError(u'Unable to connect to Timesketch backend.')
+            except ConnectionError as e:
+                raise RuntimeError(
+                    u'Unable to connect to Timesketch backend: {}'.format(e)
+                )
 
     def import_event(
             self, index_name, event_type, event=None,

--- a/timesketch/lib/tasks.py
+++ b/timesketch/lib/tasks.py
@@ -86,11 +86,8 @@ def run_plaso(source_file_path, timeline_name, index_name, username=None):
         cmd.append(u'--username')
         cmd.append(username)
 
-    import time
-
     # Run psort.py
     try:
-        time.sleep(10)
         cmd_output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
         # Mark the searchindex and timelines as failed and exit the task

--- a/timesketch/lib/tasks.py
+++ b/timesketch/lib/tasks.py
@@ -32,7 +32,7 @@ flask_app = create_app()
 
 
 def _set_timeline_status(index_name, status, error_msg=None):
-    """Helper function to set searchindex and all related timelines status.
+    """Helper function to set status for searchindex and all related timelines.
 
     Args:
         index_name: Name of the datastore index.

--- a/timesketch/lib/tasks.py
+++ b/timesketch/lib/tasks.py
@@ -28,6 +28,40 @@ from timesketch.models.sketch import SearchIndex
 from timesketch.models.sketch import Timeline
 
 celery = create_celery_app()
+flask_app = create_app()
+es = ElasticsearchDataStore(
+    host=current_app.config[u'ELASTIC_HOST'],
+    port=current_app.config[u'ELASTIC_PORT'])
+
+
+def _set_timeline_status(index_name, status, error_msg=None):
+    """Helper function to set searchindex and all related timelines status.
+
+    Args:
+        index_name: Name of the datastore index.
+        status: Status to set.
+        error_msg: Error message.
+    """
+    # Run within Flask context so we can make database changes
+    with flask_app.app_context():
+        searchindex = SearchIndex.query.filter_by(index_name=index_name).first()
+        timelines = Timeline.query.filter_by(searchindex=searchindex).all()
+
+        # Set status
+        searchindex.set_status(status)
+        for timeline in timelines:
+            timeline.set_status(status)
+            db_session.add(timeline)
+
+        # Update description if there was a failure in ingestion
+        if error_msg and status == u'fail':
+            # TODO: Don't overload the description field.
+            searchindex.description = error_msg
+            es.delete_index(index_name)
+
+        # Commit changes to database
+        db_session.add(searchindex)
+        db_session.commit()
 
 
 @celery.task(track_started=True)
@@ -43,8 +77,6 @@ def run_plaso(source_file_path, timeline_name, index_name, username=None):
     Returns:
         String with summary of processed events.
     """
-    app = create_app()
-    fail = False
     cmd = [
         u'psort.py', u'-o', u'timesketch', source_file_path, u'--name',
         timeline_name, u'--status_view', u'none', u'--index', index_name
@@ -53,38 +85,17 @@ def run_plaso(source_file_path, timeline_name, index_name, username=None):
         cmd.append(u'--username')
         cmd.append(username)
 
-    es = ElasticsearchDataStore(
-        host=current_app.config[u'ELASTIC_HOST'],
-        port=current_app.config[u'ELASTIC_PORT'])
-
     # Run psort.py
     try:
         cmd_output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
-        fail = True
-        cmd_output = e.output
+        # Mark the searchindex and timelines as failed and exit the task
+        _set_timeline_status(index_name, status=u'fail', error_msg=e.output)
+        logging.error(e.output)
+        return
 
-    # Run within Flask context so we can make database changes.
-    with app.app_context():
-        searchindex = SearchIndex.query.filter_by(index_name=index_name).first()
-        timelines = Timeline.query.filter_by(searchindex=searchindex).all()
-
-        if fail:
-            # Cleanup if psort failed.
-            searchindex.set_status(u'fail')
-            searchindex.description = cmd_output
-            for timeline in timelines:
-                timeline.set_status(u'fail')
-                timeline.description = cmd_output
-                db_session.add(timeline)
-            # Delete index in Elasticsearch.
-            es.delete_index(index_name)
-        else:
-            searchindex.set_status(u'ready')
-
-        # Commit changes to database.
-        db_session.add(searchindex)
-        db_session.commit()
+    # Mark the searchindex and timelines as ready
+    _set_timeline_status(index_name, status=u'ready')
 
     return cmd_output
 
@@ -103,17 +114,12 @@ def run_csv(source_file_path, timeline_name, index_name, username=None):
         Dictionary with count of processed events.
     """
     event_type = u'generic_event'  # Document type for Elasticsearch
-    app = create_app()
 
     # Log information to Celery
     logging.info(u'Index name: %s', index_name)
     logging.info(u'Timeline name: %s', timeline_name)
     logging.info(u'Document type: %s', event_type)
     logging.info(u'Owner: %s', username)
-
-    es = ElasticsearchDataStore(
-        host=current_app.config[u'ELASTIC_HOST'],
-        port=current_app.config[u'ELASTIC_PORT'])
 
     es.create_index(index_name=index_name, doc_type=event_type)
     for event in read_and_validate_csv(source_file_path):
@@ -122,10 +128,8 @@ def run_csv(source_file_path, timeline_name, index_name, username=None):
     # Import the remaining events
     total_events = es.import_event(index_name, event_type)
 
-    # Set status to ready when done.
-    with app.app_context():
-        searchindex = SearchIndex.query.filter_by(index_name=index_name).first()
-        searchindex.set_status(u'ready')
+    # Set status to ready when done
+    _set_timeline_status(index_name, status=u'ready')
 
     return {u'Events processed': total_events}
 
@@ -144,17 +148,12 @@ def run_jsonl(source_file_path, timeline_name, index_name, username=None):
         Dictionary with count of processed events.
     """
     event_type = u'generic_event'  # Document type for Elasticsearch
-    app = create_app()
 
     # Log information to Celery
     logging.info(u'Index name: %s', index_name)
     logging.info(u'Timeline name: %s', timeline_name)
     logging.info(u'Document type: %s', event_type)
     logging.info(u'Owner: %s', username)
-
-    es = ElasticsearchDataStore(
-        host=current_app.config[u'ELASTIC_HOST'],
-        port=current_app.config[u'ELASTIC_PORT'])
 
     es.create_index(index_name=index_name, doc_type=event_type)
     for event in read_and_validate_jsonl(source_file_path):
@@ -163,9 +162,7 @@ def run_jsonl(source_file_path, timeline_name, index_name, username=None):
     # Import the remaining events
     total_events = es.import_event(index_name, event_type)
 
-    # Set status to ready when done.
-    with app.app_context():
-        searchindex = SearchIndex.query.filter_by(index_name=index_name).first()
-        searchindex.set_status(u'ready')
+    # Set status to ready when done
+    _set_timeline_status(index_name, status=u'ready')
 
     return {u'Events processed': total_events}

--- a/timesketch/models/sketch.py
+++ b/timesketch/models/sketch.py
@@ -71,6 +71,22 @@ class Sketch(AccessControlMixin, LabelMixin, StatusMixin, CommentMixin,
         return views
 
     @property
+    def active_timelines(self):
+        """List timelines that are ready for analysis.
+
+        Returns:
+            List of instances of timesketch.models.sketch.Timeline
+        """
+        _timelines = []
+        for timeline in self.timelines:
+            timeline_status = timeline.get_status.status
+            index_status = timeline.searchindex.get_status.status
+            if (timeline_status or index_status) in [u'processing', u'fail']:
+                continue
+            _timelines.append(timeline)
+        return _timelines
+
+    @property
     def get_search_templates(self):
         """Get search templates."""
         return SearchTemplate.query.all()

--- a/timesketch/templates/sketch/timeline.html
+++ b/timesketch/templates/sketch/timeline.html
@@ -46,6 +46,16 @@
 
         <div class="row">
             <div class="col-md-12">
+
+                {% if timeline.get_status.status == 'fail' %}
+                <div class="card" style="background:#d9534f; color:#fff;">
+                    <strong>Oops.. something is wrong with this timeline:</strong>
+                    <br>
+                    <br>
+                    {{ timeline.searchindex.description }}
+                </div>
+                {% endif %}
+
                 <div class="card card-top">
                     <div class="pull-left" style="width:50px;height:50px;background:#{{ timeline.color }};cursor: pointer" data-toggle="modal" data-target="#edit-timeline-modal"></div>
                     {% if sketch.has_permission(user=current_user, permission='write') %}

--- a/timesketch/ui/api/models.ts
+++ b/timesketch/ui/api/models.ts
@@ -21,6 +21,7 @@ export interface SearchIndex {
   id: number
   name: string
   index_name: string
+  description: string
   status: Status
   deleted: boolean
   created_at: DateTime
@@ -71,6 +72,7 @@ export interface Sketch {
   description: string
   user: User
   timelines: Timeline[]
+  active_timelines: Timeline[]
   status: Status
   created_at: DateTime
   updated_at: DateTime

--- a/timesketch/ui/api/models.ts
+++ b/timesketch/ui/api/models.ts
@@ -35,6 +35,7 @@ export interface Timeline {
   color: string
   searchindex: SearchIndex
   deleted: boolean
+  status: Status
   created_at: DateTime
   updated_at: DateTime
 }

--- a/timesketch/ui/explore/filter.directive.ts
+++ b/timesketch/ui/explore/filter.directive.ts
@@ -55,7 +55,7 @@ export const tsFilter = function () {
 
             scope.enableAllTimelines = function () {
                 scope.filter.indices = []
-                for (const timeline of scope.sketch.timelines) {
+                for (const timeline of scope.sketch.active_timelines) {
                     scope.filter.indices.push(timeline.searchindex.index_name)
                 }
                 ctrl.search(scope.query, scope.filter, scope.queryDsl)

--- a/timesketch/ui/explore/filter.html
+++ b/timesketch/ui/explore/filter.html
@@ -23,7 +23,7 @@
         <button class="btn btn-default" ng-click="disableAllTimelines()"><i class="fa fa-ban"></i> Disable all</button>
     </div>
     <br><br>
-    <div ng-repeat="timeline in sketch.timelines" class="pull-left timeline-box">
+    <div ng-repeat="timeline in sketch.active_timelines" class="pull-left timeline-box">
         <ts-timeline-picker-item timeline="timeline" query="query" filter="filter" query-dsl="queryDsl"></ts-timeline-picker-item>
     </div>
 

--- a/timesketch/ui/explore/search.directive.ts
+++ b/timesketch/ui/explore/search.directive.ts
@@ -52,7 +52,7 @@ export const tsSearch = ['$location', 'timesketchApi', function ($location, time
                         // Special case where all indices should be queried.
                         if (filter.indices == '_all') {
                             filter.indices = []
-                            for (const timeline of scope.sketch.timelines) {
+                            for (const timeline of scope.sketch.active_timelines) {
                                 filter.indices.push(timeline.searchindex.index_name)
                             }
                         }
@@ -72,7 +72,7 @@ export const tsSearch = ['$location', 'timesketchApi', function ($location, time
                 $scope.sketch.views = data.meta.views
                 $scope.sketch.searchtemplates = data.meta.searchtemplates
                 $scope.filter.indices = []
-                for (const timeline of $scope.sketch.timelines) {
+                for (const timeline of $scope.sketch.active_timelines) {
                     $scope.filter.indices.push(timeline.searchindex.index_name)
                 }
             })

--- a/timesketch/ui/sketch/timelines-list.html
+++ b/timesketch/ui/sketch/timelines-list.html
@@ -27,7 +27,7 @@
         </div>
 
         <div ng-show="timeline.status == 'fail'">
-            <div class="pull-left color-box" style="margin-top:-5px; background:#d1d1d1;" title="{{ timeline.description }}"></div>
+            <div class="pull-left color-box" style="margin-top:-5px; background:#d1d1d1;" title="{{ timeline.searchindex.description }}"></div>
             <div class="title">
                 <span style="color:#999999;">{{ timeline.name }}</span>
                 <span style="margin-left:10px;">[<a href="/sketch/{{ sketchId }}/timelines/{{ timeline.id }}/">error details</a>]</span>

--- a/timesketch/ui/sketch/timelines-list.html
+++ b/timesketch/ui/sketch/timelines-list.html
@@ -17,17 +17,30 @@
             <span>{{ timeline.updated_at }}</span>
         </div>
 
-        <div ng-show="!timeline.ready" class="pull-left" style="margin-right:10px;margin-left:10px;">
-            <i class="fa fa-spin fa-circle-o-notch"></i>
+        <div ng-show="timeline.status == 'processing'">
+            <div class="pull-left" style="margin-right:10px;margin-left:10px;">
+                <i class="fa fa-spin fa-circle-o-notch"></i>
+            </div>
+            <div class="title">
+                <span style="color:#999999;">{{ timeline.name }}</span>
+            </div>
         </div>
 
-        <div ng-show="timeline.ready" class="pull-left" style="margin-top:-5px">
-            <div class="color-box" style="background:#{{ timeline.color }};"></div>
+        <div ng-show="timeline.status == 'fail'">
+            <div class="pull-left color-box" style="margin-top:-5px; background:#d1d1d1;" title="{{ timeline.description }}"></div>
+            <div class="title">
+                <span style="color:#999999;">{{ timeline.name }}</span>
+                <span style="margin-left:10px;">[<a href="/sketch/{{ sketchId }}/timelines/{{ timeline.id }}/">error details</a>]</span>
+            </div>
         </div>
-        <div class="title">
-            <a ng-show="timeline.ready" style="text-decoration: none; font-weight: 500;font-size: 1.1em;" href="/sketch/{{ sketchId }}/explore/?q=*&index={{ timeline.searchindex.index_name }}&limit=40">{{ timeline.name }}</a>
-            <span ng-show="!timeline.ready" style="color:#999999; font-weight: 500;font-size: 1.1em;">{{ timeline.name }}</span>
+
+        <div ng-show="timeline.status == 'ready' || timeline.status == 'new'">
+            <div class="pull-left color-box" style="background:#{{ timeline.color }}; margin-top:-5px"></div>
+            <div class="title">
+                <a style="text-decoration: none;" href="/sketch/{{ sketchId }}/explore/?q=*&index={{ timeline.searchindex.index_name }}&limit=40">{{ timeline.name }}</a>
+            </div>
         </div>
+
     </li>
 </ul>
 

--- a/timesketch/ui/sketch/timelines.directive.ts
+++ b/timesketch/ui/sketch/timelines.directive.ts
@@ -31,43 +31,39 @@ export const tsTimelinesList = ['$interval', 'timesketchApi', function ($interva
 
             const getTimelines = function () {
                 timesketchApi.getTimelines($scope.sketchId).success(function (data) {
-                    $scope.timelines = []
-                    const timelines = data.objects[0]
+                    $scope.timelines = [];
+                    const timelines = data.objects[0];
                     if (timelines) {
                         for (const timeline of timelines) {
-                            timeline.updated_at = moment.utc(timeline.updated_at).format('YYYY-MM-DD')
-                            timeline.ready = true
-                            const status = timeline.searchindex.status[0].status
-                            if (status == 'processing') {
-                                timeline.ready = false
-                            }
+                            timeline.updated_at = moment.utc(timeline.updated_at).format('YYYY-MM-DD');
+                            timeline.status = timeline.status[0].status;
                             $scope.timelines.push(timeline)
                         }
                     }
                 })
-            }
+            };
 
             $scope.deleteTimeline = function (timeline) {
-                timesketchApi.deleteTimeline($scope.sketchId, timeline.id)
-                const index = $scope.timelines.indexOf(timeline)
+                timesketchApi.deleteTimeline($scope.sketchId, timeline.id);
+                const index = $scope.timelines.indexOf(timeline);
                 if (index > -1) {
                     $scope.timelines.splice(index, 1)
                 }
-            }
+            };
 
             this.updateTimelines = function (timeline) {
                 $scope.timelines.unshift(timeline)
-            }
+            };
 
             // Get initial list of timelines
-            getTimelines()
+            getTimelines();
 
             // Fetch list of timelines periodically to update status.
-            const pollIntervall = 10000
+            const pollInterval = 10000;
             $interval(function () {
                 getTimelines()
-            }, pollIntervall)
+            }, pollInterval)
 
         },
     }
-}]
+}];

--- a/timesketch/ui/sketch/views-list.html
+++ b/timesketch/ui/sketch/views-list.html
@@ -11,7 +11,7 @@
             <span>{{ view.updated_at }}</span>
         </div>
         <div class="title">
-            <a style="text-decoration: none; font-weight: 500;font-size: 1.1em;" href="/sketch/{{ sketchId }}/explore/view/{{ view.id }}/">{{ view.name }}</a>
+            <a style="text-decoration: none;" href="/sketch/{{ sketchId }}/explore/view/{{ view.id }}/">{{ view.name }}</a>
         </div>
     </li>
 </ul>

--- a/tslint.json
+++ b/tslint.json
@@ -9,7 +9,7 @@
       "options": [150]
     },
     "indent": [true, "spaces", 4],
-    "semicolon": [true, "never"],
+    "semicolon": [false, "never"],
     "quotemark": [true, "single", "avoid-escape"],
     "only-arrow-functions": false,
     "ordered-imports": false,

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -18,6 +18,7 @@ Follow the official instructions [here](https://www.vagrantup.com/docs/installat
 
 ### Create Timesketch Vagrant box
     $ cd timesketch/vagrant
+    $ vagrant plugin install vagrant-disksize
     $ vagrant up
     .. wait until the installation process is complete
     $ vagrant ssh


### PR DESCRIPTION
Timesketch uses Celery to handle upload request and to ingest timelines. When a background task fails it is currently invisible to the user.

This PR fixes this. It will now:
* Set status on both searchindex and timeline to "fail" if anything goes wrong.
* Cleanup Elasticsearch when fail (i.e. remove broken index)
* Display error message and status in the UI
* Filter out broken timelines from explore view

![screen shot 2018-01-22 at 15 07 25](https://user-images.githubusercontent.com/316362/35224649-fe2d6640-ff85-11e7-92ad-728177d80691.png)

