### PR TITLE
Don't delete index on error

### DIFF
--- a/timesketch/lib/tasks.py
+++ b/timesketch/lib/tasks.py
@@ -44,10 +44,6 @@ def _set_timeline_status(index_name, status, error_msg=None):
         searchindex = SearchIndex.query.filter_by(index_name=index_name).first()
         timelines = Timeline.query.filter_by(searchindex=searchindex).all()
 
-        es = ElasticsearchDataStore(
-            host=current_app.config[u'ELASTIC_HOST'],
-            port=current_app.config[u'ELASTIC_PORT'])
-
         # Set status
         searchindex.set_status(status)
         for timeline in timelines:
@@ -58,7 +54,6 @@ def _set_timeline_status(index_name, status, error_msg=None):
         if error_msg and status == u'fail':
             # TODO: Don't overload the description field.
             searchindex.description = error_msg
-            es.delete_index(index_name)
 
         # Commit changes to database
         db_session.add(searchindex)

--- a/timesketch/templates/sketch/timeline.html
+++ b/timesketch/templates/sketch/timeline.html
@@ -52,7 +52,9 @@
                     <strong>Oops.. something is wrong with this timeline:</strong>
                     <br>
                     <br>
-                    {{ timeline.searchindex.description }}
+                    <pre>
+                        {{ timeline.searchindex.description }}
+                    </pre>
                 </div>
                 {% endif %}
 


### PR DESCRIPTION
In the case of ES being totally broken, we don't want to remove the index. We should do that with cleanup scripts instead.

Also, wrap error in <pre> to make it more readable.

![screen shot 2018-01-25 at 17 51 49](https://user-images.githubusercontent.com/316362/35401026-b0d1be80-01f8-11e8-8d16-c0e2dd8d5326.png)
