### PR TITLE
Strip domain from username if present

### DIFF
--- a/timesketch/views/sketch.py
+++ b/timesketch/views/sketch.py
@@ -94,6 +94,7 @@ def overview(sketch_id):
         return redirect(url_for(u'sketch_views.overview', sketch_id=sketch.id))
 
     # Toggle public/private form POST
+    # TODO: Move these resources to the API.
     if permission_form.validate_on_submit():
         if not sketch.has_permission(current_user, u'write'):
             abort(HTTP_STATUS_CODE_FORBIDDEN)
@@ -102,8 +103,9 @@ def overview(sketch_id):
         # TODO(jbn): Make write permission off by default
         # and selectable in the UI
         if permission_form.username.data:
-            user = User.query.filter_by(
-                username=permission_form.username.data).first()
+            username = permission_form.username.data
+            base_username = username.split(u'@')[0]
+            user = User.query.filter_by(username=base_username).first()
             if user:
                 sketch.grant_permission(permission=u'read', user=user)
                 sketch.grant_permission(permission=u'write', user=user)


### PR DESCRIPTION
Quick fix to handle email based usernames in the ACL form. Strip on @ and extract the username.
Future: Move this to the API and present validation errors in the form.