### PR TITLE
Update upstream image source in Vagrantfile

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -36,3 +36,6 @@ Vagrant.configure(2) do |config|
   config.vm.provision :shell, keep_color: true, path: "bootstrap.sh"
   config.vm.hostname = "timesketch-dev"
 end
+
+## Needed due to moved base image hosting, ref: https://github.com/hashicorp/vagrant/issues/9442#issuecomment-363080565
+Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')


### PR DESCRIPTION
This line got me past a blocking error due to the relocation of the base images used by the Vagrant build. It's likely needed now to build on Vagrant less than 2.x. I did not discover the fix and all credit to @Val in this issue thread:
https://github.com/hashicorp/vagrant/issues/9442#issuecomment-363080565 

hth,
adric