### PR TITLE
Enable file import/export support for search templates.

### DIFF
--- a/timesketch/models/__init__.py
+++ b/timesketch/models/__init__.py
@@ -107,15 +107,6 @@ class BaseModel(object):
     updated_at = Column(DateTime(), default=func.now(), onupdate=func.now())
 
     @classmethod
-    def get(cls, **kwargs):
-        """Get a database object.
-
-        Returns:
-            A model instance or None.
-        """
-        return cls.query.filter_by(**kwargs).first()
-
-    @classmethod
     def get_or_create(cls, **kwargs):
         """Get or create a database object.
 

--- a/timesketch/models/__init__.py
+++ b/timesketch/models/__init__.py
@@ -107,6 +107,15 @@ class BaseModel(object):
     updated_at = Column(DateTime(), default=func.now(), onupdate=func.now())
 
     @classmethod
+    def get(cls, **kwargs):
+        """Get a database object.
+
+        Returns:
+            A model instance or None.
+        """
+        return cls.query.filter_by(**kwargs).first()
+
+    @classmethod
     def get_or_create(cls, **kwargs):
         """Get or create a database object.
 

--- a/timesketch/models/sketch.py
+++ b/timesketch/models/sketch.py
@@ -287,6 +287,18 @@ class SearchTemplate(AccessControlMixin, LabelMixin, StatusMixin, CommentMixin,
         self.name = name
         self.user = user
         self.query_string = query_string
+        if not query_filter:
+            filter_template = {
+                u'exclude': [],
+                u'indices': u'_all',
+                u'time_start': None,
+                u'time_end': None,
+                u'limit': 40,
+                u'from': 0,
+                u'order': u'asc',
+                u'size': u'40'
+            }
+            query_filter = json.dumps(filter_template, ensure_ascii=False)
         self.query_filter = query_filter
         self.query_dsl = query_dsl
 

--- a/tsctl
+++ b/tsctl
@@ -16,6 +16,8 @@
 
 import json
 import sys
+import os
+import yaml
 from uuid import uuid4
 
 from flask import current_app
@@ -39,6 +41,7 @@ from timesketch.models import drop_all
 from timesketch.models.user import Group
 from timesketch.models.user import User
 from timesketch.models.sketch import SearchIndex
+from timesketch.models.sketch import SearchTemplate
 from timesketch.models.sketch import Timeline
 
 
@@ -500,6 +503,52 @@ class SimilarityScore(Command):
         sys.stdout.write(u'{0}'.format(result))
 
 
+class SearchTemplateManager(Command):
+    """Command Module to manipulate Search templates."""
+    option_list = (
+        Option(u'--import', u'-i', dest=u'import_location', required=False),
+        Option(u'--export', u'-e', dest=u'export_location', required=False),
+    )
+
+    def run(self, import_location, export_location):
+        """Export/Import search templates to/from file.
+
+        Args:
+            import_location: Path to the yaml file to import templates.
+            export_location: Path to the yaml file to export templates.
+        """
+
+        if export_location:
+            search_templates = []
+            for search_template in SearchTemplate.query.all():
+                search_templates.append({
+                    u'name': search_template.name,
+                    u'query_string': search_template.query_string,
+                    u'query_dsl': search_template.query_dsl
+                })
+
+            with open(export_location, 'w') as fh:
+                yaml.safe_dump(search_templates, stream=fh)
+
+        if import_location:
+            try:
+                with open(import_location, 'rb') as fh:
+                    search_templates = yaml.load(fh)
+                    for search_template in search_templates:
+                        if not SearchTemplate.get(name=search_template[u'name']):
+                            imported_template = SearchTemplate(
+                                name=search_template[u'name'],
+                                user=User(None),
+                                query_string=search_template[u'query_string'],
+                                query_dsl=search_template[u'query_dsl'])
+                            db_session.add(imported_template)
+                            db_session.commit()
+            except IOError as e:
+                sys.stdout.write(u'Unable to open file: {0:s}\n'.format(e))
+                sys.exit(1)
+
+
+
 if __name__ == '__main__':
     # Setup Flask-script command manager and register commands.
     shell_manager = Manager(create_app)
@@ -513,6 +562,7 @@ if __name__ == '__main__':
     shell_manager.add_command(u'drop_db', DropDataBaseTables())
     shell_manager.add_command(u'json2ts', CreateTimelineFromJson())
     shell_manager.add_command(u'purge', PurgeTimeline())
+    shell_manager.add_command(u'search_template', SearchTemplateManager())
     shell_manager.add_command(u'similarity_score', SimilarityScore())
     shell_manager.add_command(u'runserver',
                               Server(host=u'127.0.0.1', port=5000))

--- a/tsctl
+++ b/tsctl
@@ -535,12 +535,16 @@ class SearchTemplateManager(Command):
                 with open(import_location, 'rb') as fh:
                     search_templates = yaml.load(fh)
                     for search_template in search_templates:
-                        if not SearchTemplate.get(name=search_template[u'name']):
+                        name = search_template[u'name']
+                        query_string = search_template[u'query_string'],
+                        query_dsl = search_template[u'query_dsl']
+
+                        if not SearchTemplate.query.filter_by(name=name):
                             imported_template = SearchTemplate(
-                                name=search_template[u'name'],
+                                name=name,
                                 user=User(None),
-                                query_string=search_template[u'query_string'],
-                                query_dsl=search_template[u'query_dsl'])
+                                query_string=query_string,
+                                query_dsl=query_dsl)
                             db_session.add(imported_template)
                             db_session.commit()
             except IOError as e:


### PR DESCRIPTION
First iteration to enable support for a search template repository. this change includes the following:

- export search templates into a given file.
   * exported as yaml file.
- import search templates from a given yaml file.
   * it skips the template if the name is already present in the database.