### PR TITLE
Show all active timelines

### DIFF
--- a/timesketch/templates/sketch/timelines.html
+++ b/timesketch/templates/sketch/timelines.html
@@ -58,7 +58,7 @@
                                 <th>Created</th>
                                 </thead>
                                 {% for timeline in timelines %}
-                                    {% if timeline.get_status.status == 'ready' %}
+                                    {% if timeline.get_status.status == 'ready' or timeline.get_status.status == 'new' %}
                                         <tr>
                                             <td><input name="timelines" type="checkbox" value={{ timeline.id }}></td>
                                             <td>{{ timeline.name }}</td>


### PR DESCRIPTION
We only show timelines that has the status "ready". To support older timelines where the status was "new" for ready to use timelines we need to filter in those as well.