### PR TITLE
Overwrite size value for exported events.

### DIFF
--- a/timesketch/views/sketch.py
+++ b/timesketch/views/sketch.py
@@ -451,6 +451,7 @@ def export(sketch_id):
     # Export more than the 500 first results.
     max_events_to_fetch = 10000
     query_filter[u'limit'] = max_events_to_fetch
+    query_filter[u'size'] = max_events_to_fetch
 
     datastore = ElasticsearchDataStore(
         host=current_app.config[u'ELASTIC_HOST'],


### PR DESCRIPTION
This fixes #686 by overwriting the size value on query_filter to 10k