### PR TITLE
Reduce container build time

### DIFF
--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -1,4 +1,4 @@
-# Use the official Docker Hub Ubuntu 14.04 base image
+# Use the official Docker Hub Ubuntu 16.04 base image
 FROM ubuntu:16.04
 
 # Update the base image
@@ -21,7 +21,7 @@ RUN VERSION=node_8.x && \
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
 
-# Install Plaso NodeJS and Yarn
+# Install Plaso, NodeJS 8.x, and Yarn
 RUN apt-get -y install software-properties-common
 RUN add-apt-repository ppa:gift/stable && apt-get update
 RUN apt-get update && apt-get -y install python-plaso plaso-tools nodejs yarn

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -1,6 +1,31 @@
 # Use the official Docker Hub Ubuntu 14.04 base image
 FROM ubuntu:16.04
 
+# Update the base image
+RUN apt-get update && apt-get -y upgrade && apt-get -y dist-upgrade
+
+# Setup install environment and Timesketch dependencies
+RUN apt-get -y install apt-transport-https\
+                       curl\
+                       git\
+                       libffi-dev\
+                       lsb-release\
+                       python-dev\
+                       python-pip\
+                       python-psycopg2
+
+RUN curl -sS https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+RUN VERSION=node_8.x && \
+    DISTRO="$(lsb_release -s -c)" && \
+    echo "deb https://deb.nodesource.com/$VERSION $DISTRO main" > /etc/apt/sources.list.d/nodesource.list
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
+
+# Install Plaso NodeJS and Yarn
+RUN apt-get -y install software-properties-common
+RUN add-apt-repository ppa:gift/stable && apt-get update
+RUN apt-get update && apt-get -y install python-plaso plaso-tools nodejs yarn
+
 # Copy the entrypoint script into the container
 COPY docker/timesketch-dev-entrypoint.sh /docker-entrypoint.sh
 RUN chmod a+x /docker-entrypoint.sh

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,11 @@ services:
       dockerfile: ./docker/Dockerfile
     ports:
       - "80:80"
+    depends_on:
+      - postgres
+      - elasticsearch
+      - redis
+      - neo4j
     links:
       - elasticsearch
       - postgres

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -48,11 +48,11 @@ if [ "$1" = 'timesketch' ]; then
   fi
 
   # Set up web credentials
-  if [ -z ${TIMESKETCH_USER+x} ]; then
+  if [ -z ${TIMESKETCH_USER:+x} ]; then
     TIMESKETCH_USER="admin"
     echo "TIMESKETCH_USER set to default: ${TIMESKETCH_USER}";
   fi
-  if [ -z ${TIMESKETCH_PASSWORD+x} ]; then
+  if [ -z ${TIMESKETCH_PASSWORD:+x} ]; then
     TIMESKETCH_PASSWORD="$(openssl rand -base64 32)"
     echo "TIMESKETCH_PASSWORD set randomly to: ${TIMESKETCH_PASSWORD}";
   fi

--- a/docker/timesketch-dev-compose.yml
+++ b/docker/timesketch-dev-compose.yml
@@ -6,6 +6,11 @@ services:
       dockerfile: ./docker/Dockerfile-dev
     ports:
             - "127.0.0.1:5000:5000"
+    depends_on:
+      - postgres
+      - elasticsearch
+      - redis
+      - neo4j
     links:
       - elasticsearch
       - postgres

--- a/docker/timesketch-dev-entrypoint.sh
+++ b/docker/timesketch-dev-entrypoint.sh
@@ -3,31 +3,6 @@
 # Run the container the default way
 if [ "$1" = 'timesketch' ]; then
 
-  # Update the base image
-  apt-get update && apt-get -y upgrade
-
-  # Setup install environment and Timesketch dependencies
-  apt-get -y install apt-transport-https\
-                       curl\
-                       git\
-                       libffi-dev\
-                       lsb-release\
-                       python-dev\
-                       python-pip\
-                       python-psycopg2
-
-  curl -sS https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
-  VERSION=node_8.x
-  DISTRO="$(lsb_release -s -c)"
-  echo "deb https://deb.nodesource.com/$VERSION $DISTRO main" > /etc/apt/sources.list.d/nodesource.list
-  curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-  echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
-
-  # Install Plaso and Yarn
-  apt-get -y install software-properties-common
-  add-apt-repository ppa:gift/stable && apt-get update
-  apt-get update && apt-get -y install python-plaso plaso-tools nodejs yarn
-
   # Install Timesketch from volume
   cd /usr/local/src/timesketch && yarn install && yarn run build
   pip install -e /usr/local/src/timesketch/


### PR DESCRIPTION
Moving package prerequisites to Dockerfile will reduce time to run the instance.

`docker run <timesketch_image> | docker-compose -f dev-compose` will run the entire entrypoint script every time the command is called.

by moving these commands to Dockerfile the above commands will use the latest image built[0], which will have plaso, yarn and nodejs installed.

[0] - timesketch base image
``` 
$ docker image list
REPOSITORY             TAG                 IMAGE ID            CREATED             SIZE
docker_timesketch      latest              123456789        X hours ago         X MB
```