### PR TITLE
Don't remove session when engine is created

### DIFF
--- a/timesketch/models/__init__.py
+++ b/timesketch/models/__init__.py
@@ -42,7 +42,6 @@ def configure_engine(url):
     # TODO: Can we wrap this in a class?
     global engine, session_maker, db_session
     engine = create_engine(url)
-    db_session.remove()
     # Set the query class to our own AclBaseQuery
     session_maker.configure(
         autocommit=False, autoflush=False, bind=engine, query_cls=AclBaseQuery)


### PR DESCRIPTION
the way Flask operates has changed in regards to how database engines and sessions are handled. In our DB engine code there is a session.close() call that can lead to detached state in some circumstances.

Fixes:  #711 