### PR TITLE
Travis CI: Add Python 3 to testing in allow_failures mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,28 @@
-sudo: false
 language: python
-python: '2.7'
+python:
+  - '2.7'
+  - '3.6'
 node_js: '8'
 cache:
   - yarn
   - pip
 
+matrix:
+  allow_failures:
+    - python: '3.6'
+
 install:
+  - pip install --upgrade pip
+  - pip install flake8 -r requirements.txt
   - pip install .
   - yarn install
+
+before_script:
+  - EXCLUDE=./.*,node_modules/node-gyp/gyp
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --exclude=$EXCLUDE --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --ignore=E111,E114 --max-complexity=10 --max-line-length=127 --statistics
 
 script:
   - ./run_tests.py --full

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,8 @@ asn1crypto==0.24.0        # via cryptography
 astroid==1.5.3            # via pylint
 backports.functools-lru-cache==1.4  # via astroid, pylint
 bcrypt==3.1.3             # via flask-bcrypt
-beautifulsoup==3.2.1
+beautifulsoup==3.2.1; python_version < '3.0'
+beautifulsoup4==4.6.3; python_version >= '3.0'
 billiard==3.5.0.3         # via celery
 blinker==1.4
 celery==4.1.0
@@ -63,7 +64,7 @@ pyyaml==3.13
 redis==2.10.6
 requests==2.20.1
 singledispatch==3.4.0.3   # via astroid, pylint
-six==1.10.0               # via astroid, bcrypt, cryptography, flask-restful, mock, pylint, python-dateutil, singledispatch
+six==1.12.0               # via astroid, bcrypt, cryptography, flask-restful, mock, pylint, python-dateutil, singledispatch
 sqlalchemy==1.1.13
 urllib3==1.22             # via elasticsearch, requests
 vine==1.1.4               # via amqp


### PR DESCRIPTION
With [one year left](http://pythonclock.org) until the end of life of Python 2, let's see where there are Python 3 compatibility issues.

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree