### PR TITLE
Added dependencies into analyzers to affect ordering they are run in.

### DIFF
--- a/timesketch/lib/analyzers/browser_search.py
+++ b/timesketch/lib/analyzers/browser_search.py
@@ -23,6 +23,8 @@ class BrowserSearchSketchPlugin(interface.BaseSketchAnalyzer):
 
     NAME = 'browser_search'
 
+    DEPENDENCIES = frozenset()
+
     # Here we define filters and callback methods for all hits on each filter.
     _URL_FILTERS = frozenset([
         ('Bing', re.compile(r'bing\.com/search'),

--- a/timesketch/lib/analyzers/interface.py
+++ b/timesketch/lib/analyzers/interface.py
@@ -255,6 +255,11 @@ class BaseIndexAnalyzer(object):
     NAME = 'name'
     IS_SKETCH_ANALYZER = False
 
+    # If this analyzer depends on another analyzer
+    # it needs to be included in this frozenset by using
+    # the indexer names.
+    DEPENDENCIES = frozenset()
+
     def __init__(self, index_name):
         """Initialize the analyzer object.
 

--- a/timesketch/lib/analyzers/manager.py
+++ b/timesketch/lib/analyzers/manager.py
@@ -26,8 +26,8 @@ class AnalysisManager(object):
         """Build a dependency list of analyzers.
 
         Returns:
-            A list of sets, each one representing each priority
-            of analyzers.
+            A list of sets of analyzer names. Each set represents
+            one dependency group.
 
         Raises:
             KeyError: if class introduces circular dependencies.
@@ -47,7 +47,7 @@ class AnalysisManager(object):
             # Find items without a dependency.
             dependency_set = set(dependency_list) - set(dependencies.keys())
             dependency_set.update(
-                d for d, v in iter(dependencies.items()) if not v)
+                name for name, dep in iter(dependencies.items()) if not dep)
 
             if not dependency_set:
                 raise KeyError((
@@ -56,7 +56,7 @@ class AnalysisManager(object):
 
             dependency_tree.append(dependency_set)
 
-            # Let's remove these entries from the dependencies dict.
+            # Let's remove the entries already in the tree and start again.
             new_dependencies = {}
             for name, analyzer_dependencies in dependencies.items():
                 if not analyzer_dependencies:
@@ -65,8 +65,6 @@ class AnalysisManager(object):
                     set(analyzer_dependencies) - dependency_set)
             dependencies = new_dependencies
 
-        #print 'AND NOW'
-        #print cls._class_ordering
         return dependency_tree
 
     @classmethod

--- a/timesketch/lib/analyzers/manager_test.py
+++ b/timesketch/lib/analyzers/manager_test.py
@@ -64,7 +64,11 @@ class MockAnalyzerFail2(object):
 class TestAnalysisManager(BaseTest):
     """Tests for the functionality of the manager module."""
 
-    manager.AnalysisManager.register_analyzer(MockAnalyzer)
+    def setUp(self):
+        """Set up the tests."""
+        super(TestAnalysisManager, self).setUp()
+        manager.AnalysisManager.clear_registration()
+        manager.AnalysisManager.register_analyzer(MockAnalyzer)
 
     def test_get_analyzers(self):
         """Test to get analyzer class objects."""
@@ -92,7 +96,21 @@ class TestAnalysisManager(BaseTest):
         analyzer_list = [x for x, _ in analyzers]
         self.assertEquals(len(analyzer_list), 4)
         self.assertIn('mockanalyzer', analyzer_list)
-        print analyzer_list
+
+        # pylint: disable=protected-access
+        dependency_tree = manager.AnalysisManager._build_dependencies()
+        self.assertEquals(len(dependency_tree), 3)
+        self.assertIn('mockanalyzer', dependency_tree[0])
+        self.assertIn('mockanalyzer3', dependency_tree[0])
+        self.assertIn('mockanalyzer2', dependency_tree[1])
+        self.assertIn('mockanalyzer4', dependency_tree[2])
+
+        manager.AnalysisManager.clear_registration()
+        manager.AnalysisManager.register_analyzer(MockAnalyzerFail1)
+        manager.AnalysisManager.register_analyzer(MockAnalyzerFail2)
+        with self.assertRaises(KeyError):
+            analyzers = manager.AnalysisManager.get_analyzers()
+            analyzer_list = [x for x, _ in analyzers]
 
     def test_get_analyzer(self):
         """Test to get analyzer class from registry."""

--- a/timesketch/lib/analyzers/manager_test.py
+++ b/timesketch/lib/analyzers/manager_test.py
@@ -23,6 +23,43 @@ class MockAnalyzer(object):
     """Mock analyzer class,"""
     NAME = 'MockAnalyzer'
 
+    DEPENDENCIES = frozenset()
+
+
+class MockAnalyzer2(object):
+    """Mock analyzer class,"""
+    NAME = 'MockAnalyzer2'
+
+    DEPENDENCIES = frozenset(['MockAnalyzer'])
+
+
+class MockAnalyzer3(object):
+    """Mock analyzer class,"""
+    NAME = 'MockAnalyzer3'
+
+    DEPENDENCIES = frozenset()
+
+
+class MockAnalyzer4(object):
+    """Mock analyzer class,"""
+    NAME = 'MockAnalyzer4'
+
+    DEPENDENCIES = frozenset(['MockAnalyzer2', 'MockAnalyzer3'])
+
+
+class MockAnalyzerFail1(object):
+    """Mock analyzer class,"""
+    NAME = 'MockAnalyzerFail1'
+
+    DEPENDENCIES = frozenset(['MockAnalyzerFail2'])
+
+
+class MockAnalyzerFail2(object):
+    """Mock analyzer class,"""
+    NAME = 'MockAnalyzerFail2'
+
+    DEPENDENCIES = frozenset(['MockAnalyzerFail1'])
+
 
 class TestAnalysisManager(BaseTest):
     """Tests for the functionality of the manager module."""
@@ -40,6 +77,22 @@ class TestAnalysisManager(BaseTest):
         self.assertIn('mockanalyzer', analyzer_dict)
         analyzer_class = analyzer_dict.get('mockanalyzer')
         self.assertEqual(analyzer_class, MockAnalyzer)
+
+        manager.AnalysisManager.clear_registration()
+        analyzers = manager.AnalysisManager.get_analyzers()
+        analyzer_list = [x for x in analyzers]
+        self.assertEquals(analyzer_list, [])
+
+        manager.AnalysisManager.register_analyzer(MockAnalyzer)
+        manager.AnalysisManager.register_analyzer(MockAnalyzer2)
+        manager.AnalysisManager.register_analyzer(MockAnalyzer3)
+        manager.AnalysisManager.register_analyzer(MockAnalyzer4)
+
+        analyzers = manager.AnalysisManager.get_analyzers()
+        analyzer_list = [x for x, _ in analyzers]
+        self.assertEquals(len(analyzer_list), 4)
+        self.assertIn('mockanalyzer', analyzer_list)
+        print analyzer_list
 
     def test_get_analyzer(self):
         """Test to get analyzer class from registry."""

--- a/timesketch/lib/analyzers/similarity_scorer.py
+++ b/timesketch/lib/analyzers/similarity_scorer.py
@@ -86,6 +86,8 @@ class SimilarityScorer(interface.BaseIndexAnalyzer):
 
     NAME = 'SimilarityScorer'
 
+    DEPENDENCIES = frozenset()
+
     def __init__(self, index_name, data_type=None):
         """Initializes a similarity scorer.
 


### PR DESCRIPTION
Adding the ability to define dependencies on analyzers in order to run them in a certain order. This makes it possible for one analyzer to depend on another, eg. if one does some extraction/labeling another one can use those extractions or labels to find anomalies, etc.