### PR TITLE
Fixed a bug in the jsonl importer.

### DIFF
--- a/timesketch/lib/analyzers/interface.py
+++ b/timesketch/lib/analyzers/interface.py
@@ -347,9 +347,11 @@ class BaseIndexAnalyzer(object):
             searchindex.description = ''
 
         # Append the analyzer result.
-        searchindex.description = searchindex.description + '\n' + result
-        db_session.add(searchindex)
-        db_session.commit()
+        if result:
+            searchindex.description = '{0:s}\n{1:s}'.format(
+                searchindex.description, result)
+            db_session.add(searchindex)
+            db_session.commit()
 
         return result
 

--- a/timesketch/lib/analyzers/interface.py
+++ b/timesketch/lib/analyzers/interface.py
@@ -347,8 +347,9 @@ class BaseIndexAnalyzer(object):
             searchindex.description = ''
 
         # Append the analyzer result.
-        searchindex.description = '{0:s}\n{1:s}'.format(
-            searchindex.description, result)
+        if result:
+            searchindex.description = '{0:s}\n{1:s}'.format(
+                searchindex.description, result)
         db_session.add(searchindex)
         db_session.commit()
 

--- a/timesketch/lib/analyzers/interface.py
+++ b/timesketch/lib/analyzers/interface.py
@@ -347,11 +347,10 @@ class BaseIndexAnalyzer(object):
             searchindex.description = ''
 
         # Append the analyzer result.
-        if result:
-            searchindex.description = '{0:s}\n{1:s}'.format(
-                searchindex.description, result)
-            db_session.add(searchindex)
-            db_session.commit()
+        searchindex.description = '{0:s}\n{1:s}'.format(
+            searchindex.description, result)
+        db_session.add(searchindex)
+        db_session.commit()
 
         return result
 

--- a/timesketch/lib/utils.py
+++ b/timesketch/lib/utils.py
@@ -134,7 +134,7 @@ def read_and_validate_redline(path):
             yield row_to_yield
 
 
-def read_and_validate_jsonl(path, _):
+def read_and_validate_jsonl(path):
     """Generator for reading a JSONL (json lines) file.
 
     Args:


### PR DESCRIPTION
Importing a jsonl file produces:

```
[2019-01-11 12:40:24,061: INFO/MainProcess] Received task: timesketch.lib.tasks.run_csv_jsonl[ec11252a-608e-473d-8207-2c9da6c6288c]  
[2019-01-11 12:40:24,066: INFO/ForkPoolWorker-8] Index timeline [db1] to index [dfd94e5e3ad7479da59364503051b840] (source: jsonl)
[2019-01-11 12:40:24,467: WARNING/ForkPoolWorker-8] /usr/local/lib/python2.7/dist-packages/sqlalchemy/sql/sqltypes.py:219: SAWarning: Unicode type received non-unicode bind param value 'Traceback (most recent ca...'. (this warning may be suppressed after 10 occurrences)
  (util.ellipses_string(value),))
[2019-01-11 12:40:24,469: ERROR/ForkPoolWorker-8] Traceback (most recent call last):
  File "/usr/local/src/timesketch/timesketch/lib/tasks.py", line 404, in run_csv_jsonl
    for event in read_and_validate(source_file_path):
TypeError: read_and_validate_jsonl() takes exactly 2 arguments (1 given)
```