### PR TITLE
tests(travis): remove deprecated option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 python: '2.7'
 node_js: '8'


### PR DESCRIPTION
Removing the line has the same effect it had, and Travis is going to remove the `false` option soon so it is better to get rid of it.  