### PR TITLE
Added pandas support into the API and analyzers interface.

### DIFF
--- a/api_client/python/timesketch_api_client/client.py
+++ b/api_client/python/timesketch_api_client/client.py
@@ -18,10 +18,9 @@ import uuid
 import BeautifulSoup
 import requests
 
-import pandas
-
 from requests.exceptions import ConnectionError
 
+import pandas
 from .definitions import HTTP_STATUS_CODE_20X
 
 

--- a/api_client/python/timesketch_api_client/client.py
+++ b/api_client/python/timesketch_api_client/client.py
@@ -18,6 +18,8 @@ import uuid
 import BeautifulSoup
 import requests
 
+import pandas
+
 from requests.exceptions import ConnectionError
 
 from .definitions import HTTP_STATUS_CODE_20X
@@ -328,6 +330,25 @@ class Sketch(BaseResource):
         sketch = self.lazyload_data()
         return sketch[u'objects'][0][u'status'][0][u'status']
 
+    def _build_pandas_dataframe(self, search_response):
+        """Return a Pandas DataFrame from a query result dict.
+
+        Args:
+            search_response: dictionary with query results.
+
+        Returns:
+            pandas DataFrame with the results.
+        """
+        return_list = []
+        for result in search_response.get('objects', []):
+            source = result.get('_source', {})
+            source['_id'] = result.get('_id')
+            source['_type'] = result.get('_id')
+            source['_index'] = result.get('_id')
+            return_list.append(source)
+
+        return pandas.DataFrame(return_list)
+
     def list_views(self):
         """List all saved views for this sketch.
 
@@ -419,7 +440,8 @@ class Sketch(BaseResource):
                 query_dsl=None,
                 query_filter=None,
                 view=None,
-                return_fields=None):
+                return_fields=None,
+                as_pandas=False):
         """Explore the sketch.
 
         Args:
@@ -429,9 +451,12 @@ class Sketch(BaseResource):
             view: View object instance (optional).
             return_fields: List of fields that should be included in the
                 response.
+            as_pandas: Optional bool that determines if the results should
+                be returned back as a dictionary or a Pandas DataFrame.
 
         Returns:
-            Dictionary with query results.
+            Dictionary with query results or a pandas DataFrame if as_pandas
+            is set to True.
 
         Raises:
             ValueError: if unable to query for the results.
@@ -444,6 +469,10 @@ class Sketch(BaseResource):
             u'indices': u'_all',
             u'order': u'asc'
         }
+
+        if as_pandas:
+            default_filter['size'] = 10000
+            default_filter['terminate_after'] = 10000
 
         if not (query_string or query_filter or query_dsl or view):
             raise RuntimeError(u'You need to supply a query or view')
@@ -467,8 +496,12 @@ class Sketch(BaseResource):
             u'dsl': query_dsl,
             u'fields': return_fields,
         }
+
         response = self.api.session.post(resource_url, json=form_data)
         if response.status_code == 200:
+            if as_pandas:
+                return self._build_pandas_dataframe(response.json())
+
             return response.json()
 
         raise ValueError(

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,6 +50,7 @@ mock==2.0.0
 neo4jrestclient==2.1.1
 nose==1.3.7
 numpy==1.13.3             # via datasketch
+pandas>=0.23
 parameterized==0.6.1
 pbr==3.1.1                # via mock
 pycparser==2.18           # via cffi

--- a/timesketch/lib/analyzers/interface.py
+++ b/timesketch/lib/analyzers/interface.py
@@ -22,8 +22,8 @@ import yaml
 import pandas
 
 from flask import current_app
-from timesketch.lib.datastores.elastic import ElasticsearchDataStore
 from timesketch.lib import definitions
+from timesketch.lib.datastores.elastic import ElasticsearchDataStore
 from timesketch.models import db_session
 from timesketch.models.sketch import Event as SQLEvent
 from timesketch.models.sketch import Sketch as SQLSketch
@@ -312,8 +312,8 @@ class BaseIndexAnalyzer(object):
             self.sketch = None
 
     def event_stream(
-        self, query_string=None, query_filter=None, query_dsl=None,
-        indices=None, return_fields=None):
+            self, query_string=None, query_filter=None, query_dsl=None,
+            indices=None, return_fields=None):
         """Search ElasticSearch.
 
         Args:
@@ -437,8 +437,8 @@ class BaseSketchAnalyzer(BaseIndexAnalyzer):
         super(BaseSketchAnalyzer, self).__init__(index_name)
 
     def event_pandas(
-        self, query_string=None, query_filter=None, query_dsl=None,
-        indices=None, return_fields=None):
+            self, query_string=None, query_filter=None, query_dsl=None,
+            indices=None, return_fields=None):
         """Search ElasticSearch.
 
         Args:

--- a/timesketch/lib/analyzers/interface.py
+++ b/timesketch/lib/analyzers/interface.py
@@ -19,8 +19,11 @@ import logging
 import os
 import yaml
 
+import pandas
+
 from flask import current_app
 from timesketch.lib.datastores.elastic import ElasticsearchDataStore
+from timesketch.lib import definitions
 from timesketch.models import db_session
 from timesketch.models.sketch import Event as SQLEvent
 from timesketch.models.sketch import Sketch as SQLSketch
@@ -308,8 +311,9 @@ class BaseIndexAnalyzer(object):
         if not hasattr(self, 'sketch'):
             self.sketch = None
 
-    def event_stream(self, query_string, query_filter=None, query_dsl=None,
-                     indices=None, return_fields=None):
+    def event_stream(
+        self, query_string=None, query_filter=None, query_dsl=None,
+        indices=None, return_fields=None):
         """Search ElasticSearch.
 
         Args:
@@ -431,6 +435,73 @@ class BaseSketchAnalyzer(BaseIndexAnalyzer):
         """
         self.sketch = Sketch(sketch_id=sketch_id)
         super(BaseSketchAnalyzer, self).__init__(index_name)
+
+    def event_pandas(
+        self, query_string=None, query_filter=None, query_dsl=None,
+        indices=None, return_fields=None):
+        """Search ElasticSearch.
+
+        Args:
+            query_string: Query string.
+            query_filter: Dictionary containing filters to apply.
+            query_dsl: Dictionary containing Elasticsearch DSL query.
+            indices: List of indices to query.
+            return_fields: List of fields to be included in the search results,
+                if not included all fields will be included in the results.
+
+        Returns:
+            A python pandas object with all the events.
+
+        Raises:
+            ValueError: if neither query_string or query_dsl is provided.
+        """
+        if not (query_string or query_dsl):
+            raise ValueError('Both query_string and query_dsl are missing')
+
+        if not query_filter:
+            query_filter = {'indices': self.index_name, 'size': 10000}
+
+        if not indices:
+            indices = [self.index_name]
+
+        # Refresh the index to make sure it is searchable.
+        for index in indices:
+            self.datastore.client.indices.refresh(index=index)
+
+        if return_fields:
+            default_fields = definitions.DEFAULT_SOURCE_FIELDS
+            return_fields.extend(default_fields)
+            return_fields = list(set(return_fields))
+            results = self.datastore.search(
+                sketch_id=self.sketch.id,
+                query_string=query_string,
+                query_filter=query_filter,
+                query_dsl=query_dsl,
+                indices=indices,
+                return_fields=','.join(return_fields)
+            )
+        else:
+            results = self.datastore.search(
+                sketch_id=self.sketch.id,
+                query_string=query_string,
+                query_filter=query_filter,
+                query_dsl=query_dsl,
+                indices=indices,
+            )
+
+        raw_events = results.get('hits', {}).get('hits')
+        if not raw_events:
+            return pandas.DataFrame()
+
+        events = []
+        for event in raw_events:
+            source = event.get('_source')
+            source['_id'] = event.get('_id')
+            source['_type'] = event.get('_type')
+            source['_index'] = event.get('_index')
+            events.append(source)
+
+        return pandas.DataFrame(events)
 
     def run(self):
         """Entry point for the analyzer."""


### PR DESCRIPTION
This is part of #736 , both adding the ability to requests pandas instead of dict from search results in the API client as well as inside the analyzer interface for sketch analyzers.

The PR adds the _id, _type and _index fields to the pandas DataFrame in order to "get back" an event in the interface, with the option of 

```
event_dict = dict(_id=ID, _type=TYPE, _index=INDEX)
event = interface.Event(event_dict, self.datastore)
```

Where the ID, TYPE and INDEX are derived from the pandas DataFrame's columns _id, _type and _index.