### PR TITLE
Added scrolling support to API calls

### DIFF
--- a/api_client/python/timesketch_api_client/client.py
+++ b/api_client/python/timesketch_api_client/client.py
@@ -520,6 +520,8 @@ class Sketch(BaseResource):
             more_response_json = more_response.json()
             count = len(more_response_json.get('objects', []))
             response_json['objects'].extend(more_response_json.get('objects', []))
+            added_time = more_response_json['meta']['es_time']
+            response_json['meta']['es_time'] += added_time
 
         if as_pandas:
             return self._build_pandas_dataframe(response_json)

--- a/api_client/python/timesketch_api_client/client.py
+++ b/api_client/python/timesketch_api_client/client.py
@@ -283,6 +283,8 @@ class Sketch(BaseResource):
         api: An instance of TimesketchApi object.
     """
 
+    DEFAULT_SIZE_LIMIT = 10000
+
     def __init__(self, sketch_id, api, sketch_name=None):
         """Initializes the Sketch object.
 
@@ -463,8 +465,8 @@ class Sketch(BaseResource):
         default_filter = {
             u'time_start': None,
             u'time_end': None,
-            u'size': 100,
-            u'terminate_after': 100,
+            u'size': self.DEFAULT_SIZE_LIMIT,
+            u'terminate_after': self.DEFAULT_SIZE_LIMIT,
             u'indices': u'_all',
             u'order': u'asc'
         }
@@ -497,15 +499,33 @@ class Sketch(BaseResource):
         }
 
         response = self.api.session.post(resource_url, json=form_data)
-        if response.status_code == 200:
-            if as_pandas:
-                return self._build_pandas_dataframe(response.json())
+        if response.status_code != 200:
+            raise ValueError(
+                u'Unable to query results, with error: [{0:d}] {1:s}'.format(
+                    response.status_code, response.reason))
 
-            return response.json()
+        response_json = response.json()
 
-        raise ValueError(
-            u'Unable to query results, with error: [{0:d}] {1:s}'.format(
-                response.status_code, response.reason))
+        scroll_id = response_json.get('meta',{}).get('scroll_id', 0)
+        form_data['scroll_id'] = scroll_id
+
+        count = len(response_json.get('objects', []))
+        while count > 0:
+            more_response = self.api.session.post(resource_url, json=form_data)
+            if more_response.status_code != 200:
+                raise ValueError((
+                    u'Unable to query results, with error: '
+                    u'[{0:d}] {1:s}').format(
+                        response.status_code, response.reason))
+            more_response_json = more_response.json()
+            count = len(more_response_json.get('objects', []))
+            response_json['objects'].extend(more_response_json.get('objects', []))
+
+        if as_pandas:
+            return self._build_pandas_dataframe(response_json)
+
+        return response_json
+
 
     def label_events(self, events, label_name):
         """Labels one or more events with label_name.

--- a/api_client/python/timesketch_api_client/client.py
+++ b/api_client/python/timesketch_api_client/client.py
@@ -506,7 +506,7 @@ class Sketch(BaseResource):
 
         response_json = response.json()
 
-        scroll_id = response_json.get('meta',{}).get('scroll_id', 0)
+        scroll_id = response_json.get('meta', {}).get('scroll_id', 0)
         form_data['scroll_id'] = scroll_id
 
         count = len(response_json.get('objects', []))
@@ -519,7 +519,8 @@ class Sketch(BaseResource):
                         response.status_code, response.reason))
             more_response_json = more_response.json()
             count = len(more_response_json.get('objects', []))
-            response_json['objects'].extend(more_response_json.get('objects', []))
+            response_json['objects'].extend(
+                more_response_json.get('objects', []))
             added_time = more_response_json['meta']['es_time']
             response_json['meta']['es_time'] += added_time
 

--- a/timesketch/api/v1/resources.py
+++ b/timesketch/api/v1/resources.py
@@ -624,6 +624,7 @@ class ExploreResource(ResourceMixin, Resource):
             abort(HTTP_STATUS_CODE_BAD_REQUEST)
 
         if scroll_id:
+            # pylint: disable=unexpected-keyword-arg
             result = self.datastore.client.scroll(
                 scroll_id=scroll_id, scroll=u'1m')
         else:
@@ -675,7 +676,7 @@ class ExploreResource(ResourceMixin, Resource):
             u'es_total_count': result[u'hits'][u'total'],
             u'timeline_colors': tl_colors,
             u'timeline_names': tl_names,
-            u'scroll_id': result[u'_scroll_id'],
+            u'scroll_id': result.get(u'_scroll_id', ''),
         }
         schema = {u'meta': meta, u'objects': result[u'hits'][u'hits']}
         return jsonify(schema)

--- a/timesketch/api/v1/resources_test.py
+++ b/timesketch/api/v1/resources_test.py
@@ -179,7 +179,8 @@ class ExploreResourceTest(BaseTest):
                 u'test': u'FFFFFF'
             },
             u'es_total_count': 1,
-            u'es_time': 5
+            u'es_time': 5,
+            u'scroll_id': ''
         },
         u'objects': [{
             u'sort': [1410593223000],

--- a/timesketch/lib/forms.py
+++ b/timesketch/lib/forms.py
@@ -168,6 +168,7 @@ class ExploreForm(BaseForm):
     filter = StringField(u'Filter')
     dsl = StringField(u'DSL')
     fields = StringField(u'Fields', default='')
+    scroll_id = StringField(u'Scroll ID', default='')
 
 
 class GraphExploreForm(BaseForm):


### PR DESCRIPTION
Adding scrolling support to the API explore. This enables you to get more than 10k events from Explore requests.

