### PR TITLE
Added mybinder config to TS, making it possible to run jupyterlab notebooks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/google/timesketch.svg?branch=master)](https://travis-ci.org/google/timesketch)
 [![Version](https://img.shields.io/pypi/v/timesketch.svg)](https://pypi.python.org/pypi/timesketch)
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/timesketch/blob/master/notebooks/colab-timesketch-demo.ipynb)
-[![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/google/timesketch/master?urlpath=notebooks)
+[![Open In Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/google/timesketch/master?urlpath=%2Flab)
 [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=Digital%20Forensic%20Timeline%20Analysis&url=https://github.com/google/timesketch/&via=jberggren&hashtags=dfir)
 
 ## Table of Contents

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -2,4 +2,4 @@
 timesketch_api_client>=20190123
 altair>=2.3.0
 vega_datasets
-jupyterlab>=0.32.0
+jupyterlab>=0.34.0

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,2 +1,5 @@
 # This requirements file is only used for binder.
 timesketch_api_client>=20190123
+altair>=2.3.0
+vega_datasets
+jupyterlab>=0.32.0

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,2 @@
+# This requirements file is only used for binder.
+timesketch_api_client>=20190123

--- a/notebooks/jupyter-timesketch-demo.ipynb
+++ b/notebooks/jupyter-timesketch-demo.ipynb
@@ -100,7 +100,7 @@
     "id": "aKC_0-qlfzYA"
    },
    "source": [
-    "To enable graphing rendering you'll need to run ONE of these cells below... by default it is set to the JupyterLab rendering, but if you are running this on a local runtime jupyter notebook, please uncomment the \"notebook\" line and comment out the \"default\" one."
+    "If you are running a Jupyter notebook and not JupyterLab you'll need to uncomment a"
    ]
   },
   {

--- a/notebooks/jupyter-timesketch-demo.ipynb
+++ b/notebooks/jupyter-timesketch-demo.ipynb
@@ -100,7 +100,7 @@
     "id": "aKC_0-qlfzYA"
    },
    "source": [
-    "If you are running a Jupyter notebook and not JupyterLab you'll need to uncomment a"
+    "If you are running a Jupyter notebook and not JupyterLab you'll need to uncomment and run the cell below, otherwise there is no action needed."
    ]
   },
   {
@@ -109,10 +109,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# This works in a JupyterLab, as started using mybinder.\n",
-    "# If you are using a jupyter notebook, comment out this line.\n",
-    "alt.renderers.enable('default')\n",
-    "\n",
     "# This works in a Jupyter notebook settings. Uncomment if you are using a jupyter notebook.\n",
     "#alt.renderers.enable('notebook')"
    ]

--- a/notebooks/jupyter-timesketch-demo.ipynb
+++ b/notebooks/jupyter-timesketch-demo.ipynb
@@ -90,10 +90,7 @@
     "USER = 'demo'\n",
     "PASSWORD = 'demo'\n",
     "\n",
-    "ts_client = client.TimesketchApi(SERVER, USER, PASSWORD)\n",
-    "\n",
-    "# To enable altair renderers in the notebook.\n",
-    "alt.renderers.enable('notebook')"
+    "ts_client = client.TimesketchApi(SERVER, USER, PASSWORD)"
    ]
   },
   {
@@ -103,7 +100,21 @@
     "id": "aKC_0-qlfzYA"
    },
    "source": [
-    "(hint the above cell is just a small piece of code, you can see the code by clicking the \"three dots\" and Form/Show code )"
+    "To enable graphing rendering you'll need to run ONE of these cells below... by default it is set to the JupyterLab rendering, but if you are running this on a local runtime jupyter notebook, please uncomment the \"notebook\" line and comment out the \"default\" one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This works in a JupyterLab, as started using mybinder.\n",
+    "# If you are using a jupyter notebook, comment out this line.\n",
+    "alt.renderers.enable('default')\n",
+    "\n",
+    "# This works in a Jupyter notebook settings. Uncomment if you are using a jupyter notebook.\n",
+    "#alt.renderers.enable('notebook')"
    ]
   },
   {


### PR DESCRIPTION
ATM mybinder does not work since it attempts to use the requirements.txt to install all dependencies that TS requires. That is not necessary for the notebook that is being used in demos.

Adding a binder folder for mybinder to read a separate set of configs just for mybinder, as well as making minor adjustments to the notebook so that it can be used both for jupyter and jupyterlabs.