### PR TITLE
Analyzer index performance fix

### DIFF
--- a/timesketch/lib/analyzers/browser_search.py
+++ b/timesketch/lib/analyzers/browser_search.py
@@ -212,6 +212,9 @@ class BrowserSearchSketchPlugin(interface.BaseSketchAnalyzer):
                 # We break at the first hit of a successful search engine.
                 break
 
+            # Commit the event to the datastore.
+            event.commit()
+
         if simple_counter > 0:
             self.sketch.add_view(
                 view_name='Browser Search', analyzer_name=self.NAME,

--- a/timesketch/lib/analyzers/domain.py
+++ b/timesketch/lib/analyzers/domain.py
@@ -55,7 +55,6 @@ class DomainSketchPlugin(interface.BaseSketchAnalyzer):
                 if not url:
                     continue
                 domain = utils.get_domain_from_url(url)
-                event.add_attributes({'domain': domain})
 
             if not domain:
                 continue
@@ -81,11 +80,15 @@ class DomainSketchPlugin(interface.BaseSketchAnalyzer):
             for event in domains.get(domain, []):
                 event.add_tags(tags_to_add)
                 event.add_emojis(emojis_to_add)
+
                 event.add_human_readable(text, self.NAME, append=False)
-                new_attributes = {'domain_count': count}
+                new_attributes = {'domain': domain, 'domain_count': count}
                 if cdn_provider:
                     new_attributes['cdn_provider'] = cdn_provider
                 event.add_attributes(new_attributes)
+
+                # Commit the event to the datastore.
+                event.commit()
 
         return (
             '{0:d} domains discovered ({1:d} TLDs) and {2:d} known '

--- a/timesketch/lib/analyzers/feature_extraction.py
+++ b/timesketch/lib/analyzers/feature_extraction.py
@@ -115,11 +115,11 @@ class FeatureExtractionSketchPlugin(interface.BaseSketchAnalyzer):
 
             event_counter += 1
             event.add_attributes({store_as: result[0]})
-            if emojis_to_add:
-                event.add_emojis(emojis_to_add)
+            event.add_emojis(emojis_to_add)
+            event.add_tags(tags)
 
-            if tags:
-                event.add_tags(tags)
+            # Commit the event to the datastore.
+            event.commit()
 
         create_view = config.get('create_view', False)
         if create_view and event_counter:

--- a/timesketch/lib/analyzers/interface.py
+++ b/timesketch/lib/analyzers/interface.py
@@ -117,6 +117,7 @@ class Event(object):
 
         Args:
             event_dict: (optional) Dictionary with updated event attributes.
+            Defaults to self.updated_event.
         """
         if event_dict:
             event_to_commit = event_dict

--- a/timesketch/lib/analyzers/interface.py
+++ b/timesketch/lib/analyzers/interface.py
@@ -117,13 +117,11 @@ class Event(object):
 
         Args:
             event_dict: (optional) Dictionary with updated event attributes.
-
-        Returns:
-            None if the event dictionary is empty.
         """
-        event_to_commit = self.updated_event
         if event_dict:
             event_to_commit = event_dict
+        else:
+            event_to_commit = self.updated_event
 
         if not event_to_commit:
             return

--- a/timesketch/lib/analyzers/login.py
+++ b/timesketch/lib/analyzers/login.py
@@ -200,11 +200,11 @@ class LoginSketchPlugin(interface.BaseSketchAnalyzer):
             if attribute_dict.get('logon_type', '') == screensaver_logon:
                 emojis_to_add.append(screen_emoji)
 
-            if emojis_to_add:
-                event.add_emojis(emojis_to_add)
+            event.add_emojis(emojis_to_add)
+            event.add_tags(tags_to_add)
 
-            if tags_to_add:
-                event.add_tags(tags_to_add)
+            # Commit the event to the datastore.
+            event.commit()
 
         # TODO: Add support for Linux syslog logon/logoff events.
         # TODO: Add support for Mac OS X logon/logoff events.

--- a/timesketch/lib/analyzers/phishy_domains.py
+++ b/timesketch/lib/analyzers/phishy_domains.py
@@ -235,6 +235,9 @@ class PhishyDomainsSketchPlugin(interface.BaseSketchAnalyzer):
                 if text:
                     event.add_human_readable(text, self.NAME, append=False)
 
+                # Commit the event to the datastore.
+                event.commit()
+
         if similar_domain_counter:
             self.sketch.add_view(
                 view_name='Phishy Domains', analyzer_name=self.NAME,

--- a/timesketch/lib/analyzers/similarity_scorer.py
+++ b/timesketch/lib/analyzers/similarity_scorer.py
@@ -153,6 +153,8 @@ class SimilarityScorer(interface.BaseIndexAnalyzer):
             score = similarity.calculate_score(lsh, minhash, total_num_events)
             attributes_to_add = {'similarity_score': score}
             event.add_attributes(attributes_to_add)
+            # Commit the event to the datastore.
+            event.commit()
 
         msg = 'Similarity scorer processed {0:d} events for data_type {1:s}'
         return msg.format(total_num_events, self._config.data_type)


### PR DESCRIPTION
With the current implementation the updated event will be re-indexed in ES on every action, e.g. add_tag, add emoji etc. This results in way too many ES index requests and put a lot of strain on the server.

This PR fixes this by only sending the re-index action once for every analyzer.