### PR TITLE
Added a browser timeframe analyzer plugin

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       - TIMESKETCH_USER=${TIMESKETCH_USER}
       - TIMESKETCH_PASSWORD=${TIMESKETCH_PASSWORD}
     restart: always
+    volumes:
+      - ../:/usr/local/src/timesketch/
 
   elasticsearch:
     # uncomment the following lines to control JVM memory utilization

--- a/timesketch/lib/analyzers/__init__.py
+++ b/timesketch/lib/analyzers/__init__.py
@@ -15,6 +15,7 @@
 
 # Register all analyzers here by importing them.
 from timesketch.lib.analyzers import browser_search
+from timesketch.lib.analyzers import browser_timeframe
 from timesketch.lib.analyzers import domain
 from timesketch.lib.analyzers import feature_extraction
 from timesketch.lib.analyzers import login

--- a/timesketch/lib/analyzers/browser_timeframe.py
+++ b/timesketch/lib/analyzers/browser_timeframe.py
@@ -82,7 +82,7 @@ def fix_gap_in_list(hour_list):
     return sorted(hours)
 
 
-def get_hours(frame):
+def get_active_hours(frame):
     """Return a list of the hours with the most activity within a frame.
 
     Args:
@@ -158,7 +158,7 @@ class BrowserTimeframeSketchPlugin(interface.BaseSketchAnalyzer):
         data_frame['hour'] = pd.to_numeric(
             data_frame.datetime.dt.strftime('%H'))
 
-        activity_hours = get_hours(data_frame)
+        activity_hours = get_active_hours(data_frame)
         data_frame_outside = data_frame[~data_frame.hour.isin(activity_hours)]
 
         for event in utils.get_events_from_data_frame(

--- a/timesketch/lib/analyzers/browser_timeframe.py
+++ b/timesketch/lib/analyzers/browser_timeframe.py
@@ -1,15 +1,120 @@
 """Sketch analyzer plugin for browser timeframe."""
 from __future__ import unicode_literals
 
-from timesketch.lib import emojis
+import pandas as pd
+
 from timesketch.lib.analyzers import interface
 from timesketch.lib.analyzers import manager
+
+
+def GetEventFromFrame(frame, datastore):
+  """Return."""
+  for row in frame.iterrows():
+      _, entry = row
+      event_id = entry.get('_id')
+      if not event_id:
+          continue
+      event_index = entry.get('_index')
+      if not event_index:
+          continue
+      event_type = entry.get('_type')
+
+      event_dict = dict(_id=event_id, _type=event_type, _index=index_name)
+      yield interface.Event(event_dict, datastore)
+
+
+def GetRuns(hour_list):
+    runs = []
+    start = hour_list[0]
+    now = start
+    for hour in hour_list[1:]:
+        if hour == (now + 1):
+            now = hour
+            continue
+
+        runs.append((start, now))
+        start = hour
+        now = start
+
+    if not runs:
+        runs = [(hour_list[0], hour_list[-1])]
+
+    last_start, last_end = runs[-1]
+
+    if (start != last_start) and (last_end != now):
+        runs.append((start, now))
+
+    return runs
+
+
+def FixGap(hour_list):
+    runs = GetRuns(hour_list)
+    len_runs = len(runs)
+
+    for i in range(0, len_runs - 1):
+        _, upper = runs[i]
+        next_lower, _ = runs[i+1]
+        if (upper + 1) == (next_lower - 1):
+            hour_list.append(upper + 1)
+
+    hours = sorted(hour_list)
+    runs = GetRuns(hour_list)
+
+    if len(runs) <= 2:
+        return hours
+    elif len_runs < len(runs):
+        return FixGap(hours)
+
+    # Now we need to remove runs, we only need the first and last.
+    run_start = runs[0]
+    run_end = runs[-1]
+    hours = list(range(0, run_start[1] + 1))
+    hours.extend(range(run_end[0], run_end[1] + 1))
+
+    return sorted(hours)
+
+
+def GetHours(frame):
+    """Attempt to define a function to get the hours, based on frequency of counts."""
+    # Aggregate based on hours.
+    fc = frame[['datetime' ,'hour']].groupby('hour',
+    as_index=False).count()
+    fc['count'] = fc['datetime']
+    del fc['datetime']
+
+    # Get all the stats values.
+    a = fc['count'].describe()
+    # We are looking at the 75% count and reduce it by the mean to find the lower value count.
+    c_value = a['75%'] - a['mean']
+
+    # Now we've got a "bar" we can compare against to find all hours.
+
+    # Get a list of all hours where the count is higher or equal to the bar we defined above.
+    hours = list(fc[fc['count'] >= c_value].hour.values)
+    hours = sorted(hours)
+
+    # let's find out if these are contigious or not.
+    runs = GetRuns(hours)
+
+    # It should be either a single run, or two at most.
+    number_runs = len(runs)
+
+    if number_runs == 1:
+        # contigious
+        return hours
+
+    elif number_runs == 2 and runs[0][0] == 0:
+        # First run starts at zero.
+        return hours
+
+    return FixGap(hours)
 
 
 class BrowserTimeframeSketchPlugin(interface.BaseSketchAnalyzer):
     """Sketch analyzer for BrowserTimeframe."""
 
     NAME = 'browser_timeframe'
+    DEPENDENCIES = frozenset()
 
     def __init__(self, index_name, sketch_id):
         """Initialize The Sketch Analyzer.
@@ -28,35 +133,29 @@ class BrowserTimeframeSketchPlugin(interface.BaseSketchAnalyzer):
         Returns:
             String with summary of the analyzer result
         """
-        # TODO: Add Elasticsearch query to get the events you need.
-        query = ''
+        query = 'source_short:"WEBHIST"'
+        return_fields = ['timestamp', 'url']
 
-        # TODO: Specify what returned fields you need for your analyzer.
-        return_fields = ['message']
-
-        # Generator of events based on your query.
-        events = self.event_stream(
+        data_frame = self.event_pandas(
             query_string=query, return_fields=return_fields)
 
-        # TODO: If an emoji is needed fetch it here.
-        # my_emoji = emojis.get_emoji('emoji_name')
+        data_frame['datetime'] = pd.to_datetime(
+            data_frame.timestamp / 1e6, utc=True, unit='s')
+        data_frame['hour'] = pd.to_numeric(
+            data_frame.datetime.dt.strftime('%H'))
 
-        # TODO: Add analyzer logic here.
-        # Methods available to use for sketch analyzers:
-        # sketch.get_all_indices()
-        # sketch.add_view(name, query_string, query_filter={})
-        # event.add_attributes({'foo': 'bar'})
-        # event.add_tags(['tag_name'])
-        # event_add_label('label')
-        # event.add_star()
-        # event.add_comment('comment')
-        # event.add_emojis([my_emoji])
-        # event.add_human_readable('human readable text', self.NAME)
-        for event in events:
-            pass
+        activity_hours = GetHours(data_frame)
 
-        # TODO: Return a summary from the analyzer.
-        return 'String to be returned'
+        data_frame_outside = data_frame[~data_frame.hour.isin(activity_hours)]
+
+        counter = 0
+        for event in GetEventFromFrame(data_frame_outside, self.datastore):
+          event.add_tags(['outside-active-hours'])
+          counter += 1
+          event.commit()
+
+        return 'Tagged {0:d} as outside of normal active hours.'.format(
+            counter)
 
 
 manager.AnalysisManager.register_analyzer(BrowserTimeframeSketchPlugin)

--- a/timesketch/lib/analyzers/browser_timeframe.py
+++ b/timesketch/lib/analyzers/browser_timeframe.py
@@ -178,7 +178,7 @@ class BrowserTimeframeSketchPlugin(interface.BaseSketchAnalyzer):
             hour = event.source.get('hour')
             event.add_attributes(
                 {'activity_summary': (
-                    'Number of events for this hour ({0:d): {1:d}, with the '
+                    'Number of events for this hour ({0:d}): {1:d}, with the '
                     'threshold value: {2:0.2f}').format(
                         hour, hour_count.get(hour), threshold)})
             event.commit()

--- a/timesketch/lib/analyzers/browser_timeframe.py
+++ b/timesketch/lib/analyzers/browser_timeframe.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import pandas as pd
 
+from timesketch.lib import emojis
 from timesketch.lib.analyzers import interface
 from timesketch.lib.analyzers import manager
 from timesketch.lib.analyzers import utils
@@ -161,6 +162,8 @@ class BrowserTimeframeSketchPlugin(interface.BaseSketchAnalyzer):
         if not data_frame.shape[0]:
             return 'No browser events discovered.'
 
+        sleeping_emoji = emojis.get_emoji('SLEEPING_FACE')
+
         data_frame['timestamp'] = pd.to_numeric(data_frame.timestamp)
         data_frame['datetime'] = pd.to_datetime(
             data_frame.timestamp / 1e6, utc=True, unit='s')
@@ -177,11 +180,14 @@ class BrowserTimeframeSketchPlugin(interface.BaseSketchAnalyzer):
                 data_frame_outside, self.datastore):
             event.add_tags(['outside-active-hours'])
             hour = event.source.get('hour')
+            this_hour_count = hour_count.get(hour)
             event.add_attributes(
                 {'activity_summary': (
                     'Number of events for this hour ({0:d}): {1:d}, with the '
                     'threshold value: {2:0.2f}').format(
-                        hour, hour_count.get(hour), threshold)})
+                        hour, this_hour_count, threshold),
+                 'hour_count': this_hour_count})
+            event.add_emojis([sleeping_emoji])
             event.commit()
 
         return (

--- a/timesketch/lib/analyzers/browser_timeframe.py
+++ b/timesketch/lib/analyzers/browser_timeframe.py
@@ -91,7 +91,7 @@ def get_hours(frame):
     Returns:
         A list of hours where the most activity within the DataFrame occurs.
     """
-    frame_count = frame[['datetime' ,'hour']].groupby(
+    frame_count = frame[['datetime', 'hour']].groupby(
         'hour', as_index=False).count()
     frame_count['count'] = frame_count['datetime']
     del frame_count['datetime']
@@ -162,7 +162,7 @@ class BrowserTimeframeSketchPlugin(interface.BaseSketchAnalyzer):
         data_frame_outside = data_frame[~data_frame.hour.isin(activity_hours)]
 
         for event in utils.get_events_from_data_frame(
-            data_frame_outside, self.datastore):
+                data_frame_outside, self.datastore):
             event.add_tags(['outside-active-hours'])
             event.commit()
 

--- a/timesketch/lib/analyzers/browser_timeframe.py
+++ b/timesketch/lib/analyzers/browser_timeframe.py
@@ -164,7 +164,6 @@ class BrowserTimeframeSketchPlugin(interface.BaseSketchAnalyzer):
 
         sleeping_emoji = emojis.get_emoji('SLEEPING_FACE')
 
-        print data_frame.columns
         data_frame['timestamp'] = pd.to_numeric(data_frame.timestamp)
         data_frame['datetime'] = pd.to_datetime(
             data_frame.timestamp / 1e6, utc=True, unit='s')

--- a/timesketch/lib/analyzers/browser_timeframe.py
+++ b/timesketch/lib/analyzers/browser_timeframe.py
@@ -154,6 +154,7 @@ class BrowserTimeframeSketchPlugin(interface.BaseSketchAnalyzer):
         # updated to include all user generated events instead of focusing
         # solely on browser events.
         query = 'source_short:"WEBHIST"'
+
         return_fields = ['timestamp', 'url', 'tag', '__ts_emojis']
 
         data_frame = self.event_pandas(
@@ -164,6 +165,10 @@ class BrowserTimeframeSketchPlugin(interface.BaseSketchAnalyzer):
 
         sleeping_emoji = emojis.get_emoji('SLEEPING_FACE')
 
+        # This query filters out all timestamps that have a zero timestamp as
+        # well as those that occure after 2035-01-01, this may need to be
+        # changed in the future.
+        data_frame = data_frame[data_frame.timestamp < 2051222400000000]
         data_frame['timestamp'] = pd.to_numeric(data_frame.timestamp)
         data_frame['datetime'] = pd.to_datetime(
             data_frame.timestamp / 1e6, utc=True, unit='s')

--- a/timesketch/lib/analyzers/browser_timeframe.py
+++ b/timesketch/lib/analyzers/browser_timeframe.py
@@ -118,11 +118,11 @@ def get_active_hours(frame):
     # There should either be a single run or at most two.
     number_runs = len(runs)
     if number_runs == 1:
-        return hours
+        return hours, threshold, frame_count
 
     elif number_runs == 2 and runs[0][0] == 0:
         # Two runs, first one starts at hour zero.
-        return hours
+        return hours, threshold, frame_count
 
     return fix_gap_in_list(hours), threshold, frame_count
 

--- a/timesketch/lib/analyzers/browser_timeframe.py
+++ b/timesketch/lib/analyzers/browser_timeframe.py
@@ -144,7 +144,7 @@ class BrowserTimeframeSketchPlugin(interface.BaseSketchAnalyzer):
             String with summary of the analyzer result
         """
         query = 'source_short:"WEBHIST"'
-        return_fields = ['timestamp', 'url']
+        return_fields = ['timestamp', 'url', 'tag']
 
         data_frame = self.event_pandas(
             query_string=query, return_fields=return_fields)

--- a/timesketch/lib/analyzers/browser_timeframe.py
+++ b/timesketch/lib/analyzers/browser_timeframe.py
@@ -154,7 +154,7 @@ class BrowserTimeframeSketchPlugin(interface.BaseSketchAnalyzer):
         # updated to include all user generated events instead of focusing
         # solely on browser events.
         query = 'source_short:"WEBHIST"'
-        return_fields = ['timestamp', 'url', 'tag']
+        return_fields = ['timestamp', 'url', 'tag', '__ts_emojis']
 
         data_frame = self.event_pandas(
             query_string=query, return_fields=return_fields)

--- a/timesketch/lib/analyzers/browser_timeframe.py
+++ b/timesketch/lib/analyzers/browser_timeframe.py
@@ -1,0 +1,62 @@
+"""Sketch analyzer plugin for browser timeframe."""
+from __future__ import unicode_literals
+
+from timesketch.lib import emojis
+from timesketch.lib.analyzers import interface
+from timesketch.lib.analyzers import manager
+
+
+class BrowserTimeframeSketchPlugin(interface.BaseSketchAnalyzer):
+    """Sketch analyzer for BrowserTimeframe."""
+
+    NAME = 'browser_timeframe'
+
+    def __init__(self, index_name, sketch_id):
+        """Initialize The Sketch Analyzer.
+
+        Args:
+            index_name: Elasticsearch index name
+            sketch_id: Sketch ID
+        """
+        self.index_name = index_name
+        super(BrowserTimeframeSketchPlugin, self).__init__(
+            index_name, sketch_id)
+
+    def run(self):
+        """Entry point for the analyzer.
+
+        Returns:
+            String with summary of the analyzer result
+        """
+        # TODO: Add Elasticsearch query to get the events you need.
+        query = ''
+
+        # TODO: Specify what returned fields you need for your analyzer.
+        return_fields = ['message']
+
+        # Generator of events based on your query.
+        events = self.event_stream(
+            query_string=query, return_fields=return_fields)
+
+        # TODO: If an emoji is needed fetch it here.
+        # my_emoji = emojis.get_emoji('emoji_name')
+
+        # TODO: Add analyzer logic here.
+        # Methods available to use for sketch analyzers:
+        # sketch.get_all_indices()
+        # sketch.add_view(name, query_string, query_filter={})
+        # event.add_attributes({'foo': 'bar'})
+        # event.add_tags(['tag_name'])
+        # event_add_label('label')
+        # event.add_star()
+        # event.add_comment('comment')
+        # event.add_emojis([my_emoji])
+        # event.add_human_readable('human readable text', self.NAME)
+        for event in events:
+            pass
+
+        # TODO: Return a summary from the analyzer.
+        return 'String to be returned'
+
+
+manager.AnalysisManager.register_analyzer(BrowserTimeframeSketchPlugin)

--- a/timesketch/lib/analyzers/browser_timeframe.py
+++ b/timesketch/lib/analyzers/browser_timeframe.py
@@ -9,7 +9,7 @@ from timesketch.lib.analyzers import manager
 from timesketch.lib.analyzers import utils
 
 
-def get_runs(hour_list):
+def get_list_of_consecutive_sequences(hour_list):
     """Returns a list of runs from a list of numbers.
 
     Args:
@@ -57,7 +57,7 @@ def fix_gap_in_list(hour_list):
         two runs. Therefore if there are more than two runs after
         all gaps have been filled the "extra" runs will be dropped.
     """
-    runs = get_runs(hour_list)
+    runs = get_list_of_consecutive_sequences(hour_list)
     len_runs = len(runs)
 
     for i in range(0, len_runs - 1):
@@ -67,7 +67,7 @@ def fix_gap_in_list(hour_list):
             hour_list.append(upper + 1)
 
     hours = sorted(hour_list)
-    runs = get_runs(hour_list)
+    runs = get_list_of_consecutive_sequences(hour_list)
 
     if len(runs) <= 2:
         return hours
@@ -113,7 +113,7 @@ def get_active_hours(frame):
     hours = list(frame_count[threshold_filter].hour.values)
     hours = sorted(hours)
 
-    runs = get_runs(hours)
+    runs = get_list_of_consecutive_sequences(hours)
 
     # There should either be a single run or at most two.
     number_runs = len(runs)
@@ -153,7 +153,7 @@ class BrowserTimeframeSketchPlugin(interface.BaseSketchAnalyzer):
         # TODO: Once we can identify user generated events this should be
         # updated to include all user generated events instead of focusing
         # solely on browser events.
-        query = 'source_short:"WEBHIST"'
+        query = 'source_short:"WEBHIST" OR source:"WEBHIST"'
 
         return_fields = ['timestamp', 'url', 'tag', '__ts_emojis']
 
@@ -166,9 +166,9 @@ class BrowserTimeframeSketchPlugin(interface.BaseSketchAnalyzer):
         sleeping_emoji = emojis.get_emoji('SLEEPING_FACE')
 
         # This query filters out all timestamps that have a zero timestamp as
-        # well as those that occure after 2035-01-01, this may need to be
+        # well as those that occure after 2038-01-01, this may need to be
         # changed in the future.
-        data_frame = data_frame[data_frame.timestamp < 2051222400000000]
+        data_frame = data_frame[data_frame.timestamp < 2145916800000000]
         data_frame['timestamp'] = pd.to_numeric(data_frame.timestamp)
         data_frame['datetime'] = pd.to_datetime(
             data_frame.timestamp / 1e6, utc=True, unit='s')

--- a/timesketch/lib/analyzers/browser_timeframe.py
+++ b/timesketch/lib/analyzers/browser_timeframe.py
@@ -168,7 +168,9 @@ class BrowserTimeframeSketchPlugin(interface.BaseSketchAnalyzer):
         # This query filters out all timestamps that have a zero timestamp as
         # well as those that occure after 2038-01-01, this may need to be
         # changed in the future.
-        data_frame = data_frame[data_frame.timestamp < 2145916800000000]
+        data_frame = data_frame[
+            (data_frame.timestamp > 0) & (
+                data_frame.timestamp < 2145916800000000)]
         data_frame['timestamp'] = pd.to_numeric(data_frame.timestamp)
         data_frame['datetime'] = pd.to_datetime(
             data_frame.timestamp / 1e6, utc=True, unit='s')

--- a/timesketch/lib/analyzers/browser_timeframe.py
+++ b/timesketch/lib/analyzers/browser_timeframe.py
@@ -167,6 +167,7 @@ class BrowserTimeframeSketchPlugin(interface.BaseSketchAnalyzer):
         data_frame['hour'] = pd.to_numeric(
             data_frame.datetime.dt.strftime('%H'))
 
+        total_count = data_frame.shape[0]
         activity_hours, threshold, aggregation = get_active_hours(data_frame)
 
         hour_count = dict(aggregation.values.tolist())
@@ -183,8 +184,9 @@ class BrowserTimeframeSketchPlugin(interface.BaseSketchAnalyzer):
                         hour, hour_count.get(hour), threshold)})
             event.commit()
 
-        return 'Tagged {0:d} events as outside of normal active hours.'.format(
-            data_frame_outside.shape[0])
+        return (
+            'Tagged {0:d} out of {1:d} events as outside of normal '
+            'active hours.').format(data_frame_outside.shape[0], total_count)
 
 
 manager.AnalysisManager.register_analyzer(BrowserTimeframeSketchPlugin)

--- a/timesketch/lib/analyzers/browser_timeframe.py
+++ b/timesketch/lib/analyzers/browser_timeframe.py
@@ -164,6 +164,7 @@ class BrowserTimeframeSketchPlugin(interface.BaseSketchAnalyzer):
 
         sleeping_emoji = emojis.get_emoji('SLEEPING_FACE')
 
+        print data_frame.columns
         data_frame['timestamp'] = pd.to_numeric(data_frame.timestamp)
         data_frame['datetime'] = pd.to_datetime(
             data_frame.timestamp / 1e6, utc=True, unit='s')

--- a/timesketch/lib/analyzers/browser_timeframe.py
+++ b/timesketch/lib/analyzers/browser_timeframe.py
@@ -139,6 +139,10 @@ class BrowserTimeframeSketchPlugin(interface.BaseSketchAnalyzer):
         data_frame = self.event_pandas(
             query_string=query, return_fields=return_fields)
 
+        if not data_frame.shape[0]:
+            return 'No browser events discovered.'
+
+        data_frame['timestamp'] = pd.to_numeric(data_frame.timestamp)
         data_frame['datetime'] = pd.to_datetime(
             data_frame.timestamp / 1e6, utc=True, unit='s')
         data_frame['hour'] = pd.to_numeric(

--- a/timesketch/lib/analyzers/browser_timeframe_test.py
+++ b/timesketch/lib/analyzers/browser_timeframe_test.py
@@ -59,5 +59,5 @@ class TestBrowserTimeframePlugin(BaseTest):
             'datetime': date_array})
 
         expected_hours = [0, 1, 18, 19, 20, 21, 22, 23]
-        active_hours = browser_timeframe.get_active_hours(data_frame)
+        active_hours, _, _ = browser_timeframe.get_active_hours(data_frame)
         self.assertEquals(active_hours, expected_hours)

--- a/timesketch/lib/analyzers/browser_timeframe_test.py
+++ b/timesketch/lib/analyzers/browser_timeframe_test.py
@@ -1,0 +1,24 @@
+"""Tests for BrowserTimeframePlugin."""
+from __future__ import unicode_literals
+
+import mock
+
+from timesketch.lib.analyzers import browser_timeframe
+from timesketch.lib.testlib import BaseTest
+from timesketch.lib.testlib import MockDataStore
+
+
+class TestBrowserTimeframePlugin(BaseTest):
+    """Tests the functionality of the analyzer."""
+
+    def __init__(self, *args, **kwargs):
+        super(TestBrowserTimeframePlugin, self).__init__(*args, **kwargs)
+
+    # Mock the Elasticsearch datastore.
+    @mock.patch(
+        u'timesketch.lib.analyzers.interface.ElasticsearchDataStore',
+        MockDataStore)
+    def test_analyzer(self):
+        """Test analyzer."""
+        # TODO: Write actual tests here.
+        self.assertIsEqual(True, False)

--- a/timesketch/lib/analyzers/browser_timeframe_test.py
+++ b/timesketch/lib/analyzers/browser_timeframe_test.py
@@ -1,24 +1,39 @@
 """Tests for BrowserTimeframePlugin."""
 from __future__ import unicode_literals
 
-import mock
-
 from timesketch.lib.analyzers import browser_timeframe
 from timesketch.lib.testlib import BaseTest
-from timesketch.lib.testlib import MockDataStore
 
 
 class TestBrowserTimeframePlugin(BaseTest):
     """Tests the functionality of the analyzer."""
 
-    def __init__(self, *args, **kwargs):
-        super(TestBrowserTimeframePlugin, self).__init__(*args, **kwargs)
+    def test_get_runs(self):
+        """Test the get_runs function."""
+        hours = [0, 1, 2, 3, 9, 10, 11, 12, 13, 14]
+        runs = browser_timeframe.get_runs(hours)
 
-    # Mock the Elasticsearch datastore.
-    @mock.patch(
-        u'timesketch.lib.analyzers.interface.ElasticsearchDataStore',
-        MockDataStore)
-    def test_analyzer(self):
-        """Test analyzer."""
-        # TODO: Write actual tests here.
-        self.assertIsEqual(True, False)
+        self.assertEquals(len(runs), 2)
+
+        first_run = runs[0]
+        self.assertEquals(first_run[0], 0)
+        self.assertEquals(first_run[1], 3)
+
+        second_run = runs[1]
+        self.assertEquals(second_run[0], 9)
+        self.assertEquals(second_run[1], 14)
+
+        hours = [0, 2, 3, 9, 10, 12, 14]
+        runs = browser_timeframe.get_runs(hours)
+        self.assertEquals(len(runs), 5)
+
+    def test_fix_gap_in_list(self):
+        """Test the fix_gap_in_list function."""
+        hours = [0, 6, 10, 11, 13, 14]
+        fixed_hours = browser_timeframe.fix_gap_in_list(hours)
+
+        self.assertEquals(fixed_hours, [0, 10, 11, 12, 13, 14])
+
+    def test_get_hours(self):
+        """Test get_hours function."""
+        self.assertEquals(1, 1)

--- a/timesketch/lib/analyzers/browser_timeframe_test.py
+++ b/timesketch/lib/analyzers/browser_timeframe_test.py
@@ -1,6 +1,9 @@
 """Tests for BrowserTimeframePlugin."""
 from __future__ import unicode_literals
 
+import numpy as np
+import pandas as pd
+
 from timesketch.lib.analyzers import browser_timeframe
 from timesketch.lib.testlib import BaseTest
 
@@ -34,6 +37,27 @@ class TestBrowserTimeframePlugin(BaseTest):
 
         self.assertEquals(fixed_hours, [0, 10, 11, 12, 13, 14])
 
-    def test_get_hours(self):
-        """Test get_hours function."""
-        self.assertEquals(1, 1)
+    def test_get_active_hours(self):
+        """Test get_active_hours function."""
+        date_array = np.random.randn(500)
+        hours = [
+            np.repeat(0, 80),
+            np.repeat(1, 50),
+            np.repeat(4, 10),
+            np.repeat(7, 8),
+            np.repeat(12, 12),
+            np.repeat(18, 40),
+            np.repeat(19, 50),
+            np.repeat(20, 10),
+            np.repeat(21, 90),
+            np.repeat(22, 50),
+            np.repeat(23, 100),
+        ]
+
+        data_frame = pd.DataFrame({
+            'hour': np.concatenate(hours),
+            'datetime': date_array})
+
+        expected_hours = [0, 1, 18, 19, 20, 21, 22, 23]
+        active_hours = browser_timeframe.get_active_hours(data_frame)
+        self.assertEquals(active_hours, expected_hours)

--- a/timesketch/lib/analyzers/browser_timeframe_test.py
+++ b/timesketch/lib/analyzers/browser_timeframe_test.py
@@ -11,10 +11,10 @@ from timesketch.lib.testlib import BaseTest
 class TestBrowserTimeframePlugin(BaseTest):
     """Tests the functionality of the analyzer."""
 
-    def test_get_runs(self):
-        """Test the get_runs function."""
+    def test_get_list_of_consecutive_sequences(self):
+        """Test the get_list_of_consecutive_sequences function."""
         hours = [0, 1, 2, 3, 9, 10, 11, 12, 13, 14]
-        runs = browser_timeframe.get_runs(hours)
+        runs = browser_timeframe.get_list_of_consecutive_sequences(hours)
 
         self.assertEquals(len(runs), 2)
 
@@ -27,7 +27,7 @@ class TestBrowserTimeframePlugin(BaseTest):
         self.assertEquals(second_run[1], 14)
 
         hours = [0, 2, 3, 9, 10, 12, 14]
-        runs = browser_timeframe.get_runs(hours)
+        runs = browser_timeframe.get_list_of_consecutive_sequences(hours)
         self.assertEquals(len(runs), 5)
 
     def test_fix_gap_in_list(self):

--- a/timesketch/lib/analyzers/interface.py
+++ b/timesketch/lib/analyzers/interface.py
@@ -500,22 +500,17 @@ class BaseSketchAnalyzer(BaseIndexAnalyzer):
             default_fields = definitions.DEFAULT_SOURCE_FIELDS
             return_fields.extend(default_fields)
             return_fields = list(set(return_fields))
-            results = self.datastore.search(
-                sketch_id=self.sketch.id,
-                query_string=query_string,
-                query_filter=query_filter,
-                query_dsl=query_dsl,
-                indices=indices,
-                return_fields=','.join(return_fields)
-            )
-        else:
-            results = self.datastore.search(
-                sketch_id=self.sketch.id,
-                query_string=query_string,
-                query_filter=query_filter,
-                query_dsl=query_dsl,
-                indices=indices,
-            )
+            return_fields = ','.join(return_fields)
+
+        results = self.datastore.search(
+            sketch_id=self.sketch.id,
+            query_string=query_string,
+            query_filter=query_filter,
+            query_dsl=query_dsl,
+            indices=indices,
+            return_fields=','.join(return_fields),
+            enable_scroll=True
+        )
 
         raw_events = results.get('hits', {}).get('hits')
         if not raw_events:
@@ -528,6 +523,22 @@ class BaseSketchAnalyzer(BaseIndexAnalyzer):
             source['_type'] = event.get('_type')
             source['_index'] = event.get('_index')
             events.append(source)
+
+        scroll_id = results.get('_scroll_id', '')
+        scroll_size = results[u'hits'][u'total']
+
+        while scroll_size > 0:
+            # pylint: disable=unexpected-keyword-arg
+            result = self.datastore.client.scroll(
+                scroll_id=scroll_id, scroll=u'1m')
+            scroll_size = result[u'hits'][u'total']
+
+            for event in result[u'hits'][u'hits']:
+                source = event.get('_source')
+                source['_id'] = event.get('_id')
+                source['_type'] = event.get('_type')
+                source['_index'] = event.get('_index')
+                events.append(source)
 
         return pandas.DataFrame(events)
 

--- a/timesketch/lib/analyzers/interface.py
+++ b/timesketch/lib/analyzers/interface.py
@@ -508,7 +508,7 @@ class BaseSketchAnalyzer(BaseIndexAnalyzer):
             query_filter=query_filter,
             query_dsl=query_dsl,
             indices=indices,
-            return_fields=','.join(return_fields),
+            return_fields=return_fields,
         )
 
         events = []

--- a/timesketch/lib/analyzers/interface.py
+++ b/timesketch/lib/analyzers/interface.py
@@ -182,6 +182,8 @@ class Event(object):
             return
 
         existing_emoji_list = self.source.get('__ts_emojis', [])
+        if not isinstance(existing_emoji_list, (list, tuple)):
+            existing_emoji_list = []
         new_emoji_list = list(set().union(existing_emoji_list, emojis))
         updated_event_attribute = {'__ts_emojis': new_emoji_list}
         self._update(updated_event_attribute)

--- a/timesketch/lib/analyzers/utils.py
+++ b/timesketch/lib/analyzers/utils.py
@@ -220,26 +220,25 @@ def get_cdn_provider(domain):
 
 
 def get_events_from_data_frame(frame, datastore):
-  """Generates events from a data frame.
+    """Generates events from a data frame.
 
-  Args:
-      frame: a pandas DataFrame object.
-      datastore: Elasticsearch datastore client.
+    Args:
+        frame: a pandas DataFrame object.
+        datastore: Elasticsearch datastore client.
 
-  Yields:
-      An event (interface.Event) object for each row
-      in the DataFrame.
-  """
-  for row in frame.iterrows():
-      _, entry = row
-      event_id = entry.get('_id')
-      if not event_id:
-          continue
-      event_index = entry.get('_index')
-      if not event_index:
-          continue
-      event_type = entry.get('_type')
+    Yields:
+        An event (interface.Event) object for each row
+        in the DataFrame.
+    """
+    for row in frame.iterrows():
+        _, entry = row
+        event_id = entry.get('_id')
+        if not event_id:
+            continue
+        event_index = entry.get('_index')
+        if not event_index:
+            continue
+        event_type = entry.get('_type')
 
-      event_dict = dict(_id=event_id, _type=event_type, _index=index_name)
-      yield interface.Event(event_dict, datastore)
-
+        event_dict = dict(_id=event_id, _type=event_type, _index=event_index)
+        yield interface.Event(event_dict, datastore)

--- a/timesketch/lib/analyzers/utils.py
+++ b/timesketch/lib/analyzers/utils.py
@@ -240,5 +240,7 @@ def get_events_from_data_frame(frame, datastore):
             continue
         event_type = entry.get('_type')
 
-        event_dict = dict(_id=event_id, _type=event_type, _index=event_index)
+        event_dict = dict(
+            _id=event_id, _type=event_type, _index=event_index,
+            _source=entry.to_dict())
         yield interface.Event(event_dict, datastore)

--- a/timesketch/lib/analyzers/utils_test.py
+++ b/timesketch/lib/analyzers/utils_test.py
@@ -15,6 +15,8 @@
 
 from __future__ import unicode_literals
 
+import pandas as pd
+
 from timesketch.lib.testlib import BaseTest
 from timesketch.lib.analyzers import utils
 
@@ -66,3 +68,20 @@ class TestAnalyzerUtils(BaseTest):
         provider = utils.get_cdn_provider(domain)
         self.assertIsInstance(provider, basestring)
         self.assertEquals(provider, '')
+
+    def test_get_events_from_data_frame(self):
+        """Test getting all events from data frame."""
+        lines = [
+            {'_id': '123', '_type': 'manual', '_index': 'asdfasdf',
+             'tool': 'isskeid'},
+            {'_id': '124', '_type': 'manual', '_index': 'asdfasdf',
+             'tool': 'tong'},
+            {'_id': '125', '_type': 'manual', '_index': 'asdfasdf',
+             'tool': 'klemma'},
+        ]
+        frame = pd.DataFrame(lines)
+
+        events = list(utils.get_events_from_data_frame(frame, None))
+        self.assertEquals(len(events), 3)
+        ids = [x.event_id for x in events]
+        self.assertEquals(set(ids), set(['123', '124', '125']))

--- a/timesketch/lib/emojis.py
+++ b/timesketch/lib/emojis.py
@@ -33,6 +33,7 @@ EMOJI_MAP = {
     'SATELLITE': emoji('&#x1F4E1', 'Domain activity'),
     'SCREEN': emoji('&#x1F5B5', 'Screensaver activity'),
     'SKULL_CROSSBONE': emoji('&#x2620', 'Suspicious entry'),
+    'SLEEPING_FACE': emoji('&#1F634', 'Activity outside of regular hours'),
     'UNLOCK': emoji('&#x1F513', 'Logoff activity'),
     'WASTEBASKET': emoji('&#x1F5D1', 'Deletion activity')
 }

--- a/timesketch/lib/emojis.py
+++ b/timesketch/lib/emojis.py
@@ -33,7 +33,7 @@ EMOJI_MAP = {
     'SATELLITE': emoji('&#x1F4E1', 'Domain activity'),
     'SCREEN': emoji('&#x1F5B5', 'Screensaver activity'),
     'SKULL_CROSSBONE': emoji('&#x2620', 'Suspicious entry'),
-    'SLEEPING_FACE': emoji('&#1F634', 'Activity outside of regular hours'),
+    'SLEEPING_FACE': emoji('&#x1F634', 'Activity outside of regular hours'),
     'UNLOCK': emoji('&#x1F513', 'Logoff activity'),
     'WASTEBASKET': emoji('&#x1F5D1', 'Deletion activity')
 }


### PR DESCRIPTION
Added a timeframe analyzer plugin.

What this analyzer does is the following:

- Extract hour from each browser event
- Aggregate based on the hour, counting each occurrence
- Finding a threshold of what an active hour constitutes.
- Construct a range of hours where the most activity occurs 
- Tag the events that fall outside of that range.

