### PR TITLE
Bug fixes

### DIFF
--- a/api_client/python/timesketch_api_client/client.py
+++ b/api_client/python/timesketch_api_client/client.py
@@ -505,6 +505,10 @@ class Sketch(BaseResource):
             if view.query_string:
                 query_string = view.query_string
             query_filter = json.loads(view.query_filter)
+
+            query_filter['size'] = self.DEFAULT_SIZE_LIMIT
+            query_filter['terminate_after'] = self.DEFAULT_SIZE_LIMIT
+
             if view.query_dsl:
                 query_dsl = json.loads(view.query_dsl)
 

--- a/timesketch/lib/analyzers/browser_timeframe.py
+++ b/timesketch/lib/analyzers/browser_timeframe.py
@@ -22,6 +22,9 @@ def get_list_of_consecutive_sequences(hour_list):
         of (1,3), (7, 9).
     """
     runs = []
+    if not hour_list:
+        return runs
+
     start = hour_list[0]
     now = start
     for hour in hour_list[1:]:
@@ -57,6 +60,9 @@ def fix_gap_in_list(hour_list):
         two runs. Therefore if there are more than two runs after
         all gaps have been filled the "extra" runs will be dropped.
     """
+    if not hour_list:
+        return hour_list
+
     runs = get_list_of_consecutive_sequences(hour_list)
     len_runs = len(runs)
 
@@ -179,6 +185,9 @@ class BrowserTimeframeSketchPlugin(interface.BaseSketchAnalyzer):
 
         total_count = data_frame.shape[0]
         activity_hours, threshold, aggregation = get_active_hours(data_frame)
+
+        if not activity_hours:
+            return 'Did not discover any activity hours.'
 
         hour_count = dict(aggregation.values.tolist())
         data_frame_outside = data_frame[~data_frame.hour.isin(activity_hours)]

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -330,10 +330,10 @@ class ElasticsearchDataStore(object):
         """
 
         if not query_filter.get(u'size'):
-            query_filter[u'size'] = self.DEFAULT_STREAM_LIMIT
+            query_filter[u'size'] = self.DEFAULT_STREAM_LIMIT / 2
 
         if not query_filter.get(u'terminate_after'):
-            query_filter[u'terminate_after'] = self.DEFAULT_STREAM_LIMIT
+            query_filter[u'terminate_after'] = self.DEFAULT_STREAM_LIMIT / 2
 
         result = self.search(
             sketch_id=sketch_id,
@@ -352,7 +352,7 @@ class ElasticsearchDataStore(object):
 
         while scroll_size > 0:
             # pylint: disable=unexpected-keyword-arg
-            result = self.client.scroll(scroll_id=scroll_id, scroll=u'1m')
+            result = self.client.scroll(scroll_id=scroll_id, scroll=u'5m')
             scroll_id = result[u'_scroll_id']
             scroll_size = len(result[u'hits'][u'hits'])
             for event in result[u'hits'][u'hits']:

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -65,7 +65,7 @@ class ElasticsearchDataStore(object):
     DEFAULT_SIZE = 100
     DEFAULT_LIMIT = DEFAULT_SIZE  # Max events to return
     DEFAULT_FROM = 0
-    DEFAULT_STREAM_LIMIT = 10000  # Max events to return when streaming results
+    DEFAULT_STREAM_LIMIT = 5000 # Max events to return when streaming results
 
     def __init__(self, host=u'127.0.0.1', port=9200):
         """Create a Elasticsearch client."""
@@ -330,10 +330,10 @@ class ElasticsearchDataStore(object):
         """
 
         if not query_filter.get(u'size'):
-            query_filter[u'size'] = self.DEFAULT_STREAM_LIMIT / 2
+            query_filter[u'size'] = self.DEFAULT_STREAM_LIMIT
 
         if not query_filter.get(u'terminate_after'):
-            query_filter[u'terminate_after'] = self.DEFAULT_STREAM_LIMIT / 2
+            query_filter[u'terminate_after'] = self.DEFAULT_STREAM_LIMIT
 
         result = self.search(
             sketch_id=sketch_id,


### PR DESCRIPTION
Few bugs:

1. In the client API, if querying by a view you get back only 40 records
2. Increasing the scrolling timeout, in case there is a lot of traffic/many timelines

Also changing a bit about the size limits in search_streams