### PR TITLE
Changed domain analyzer, removing human readable manipulation, issue #847

### DIFF
--- a/timesketch/lib/analyzers/domain.py
+++ b/timesketch/lib/analyzers/domain.py
@@ -73,10 +73,10 @@ class DomainSketchPlugin(interface.BaseSketchAnalyzer):
 
         common_domains = [
             x for x, y in domain_counter.most_common()
-                if y >= domain_85th_percentile]
+            if y >= domain_85th_percentile]
         rare_domains = [
             x for x, y in domain_counter.most_common()
-                if y <= domain_20th_percentile]
+            if y <= domain_20th_percentile]
 
         satellite_emoji = emojis.get_emoji('SATELLITE')
         for domain, count in iter(domain_counter.items()):

--- a/timesketch/lib/analyzers/domain.py
+++ b/timesketch/lib/analyzers/domain.py
@@ -67,7 +67,7 @@ class DomainSketchPlugin(interface.BaseSketchAnalyzer):
             tld = '.'.join(domain.split('.')[-2:])
             tld_counter[tld] += 1
 
-        domain_count_array = numpy.array(domain_counter.values())
+        domain_count_array = numpy.array(list(domain_counter.values()))
         domain_20th_percentile = int(numpy.percentile(domain_count_array, 20))
         domain_85th_percentile = int(numpy.percentile(domain_count_array, 85))
 

--- a/timesketch/lib/analyzers/domain.py
+++ b/timesketch/lib/analyzers/domain.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import collections
+import numpy
 
 from timesketch.lib import emojis
 from timesketch.lib.analyzers import interface
@@ -66,22 +67,37 @@ class DomainSketchPlugin(interface.BaseSketchAnalyzer):
             tld = '.'.join(domain.split('.')[-2:])
             tld_counter[tld] += 1
 
+        domain_count_array = numpy.array(domain_counter.values())
+        domain_20th_percentile = int(numpy.percentile(domain_count_array, 20))
+        domain_85th_percentile = int(numpy.percentile(domain_count_array, 85))
+
+        top_domains = [
+            x for x, y in domain_counter.most_common()
+                if y >= domain_85th_percentile]
+        rare_domains = [
+            x for x, y in domain_counter.most_common()
+                if y <= domain_20th_percentile]
+
         satellite_emoji = emojis.get_emoji('SATELLITE')
         for domain, count in iter(domain_counter.items()):
             emojis_to_add = [satellite_emoji]
             tags_to_add = []
-            text = '{0:s} seen {1:d} times'.format(domain, count)
 
             cdn_provider = utils.get_cdn_provider(domain)
             if cdn_provider:
                 tags_to_add.append('known-cdn')
                 cdn_counter[cdn_provider] += 1
 
+            if domain in top_domains:
+                tags_to_add.append('top_domain')
+
+            if domain in rare_domains:
+                tags_to_add.append('rare_domain')
+
             for event in domains.get(domain, []):
                 event.add_tags(tags_to_add)
                 event.add_emojis(emojis_to_add)
 
-                event.add_human_readable(text, self.NAME, append=False)
                 new_attributes = {'domain': domain, 'domain_count': count}
                 if cdn_provider:
                     new_attributes['cdn_provider'] = cdn_provider

--- a/timesketch/lib/analyzers/domain.py
+++ b/timesketch/lib/analyzers/domain.py
@@ -71,7 +71,7 @@ class DomainSketchPlugin(interface.BaseSketchAnalyzer):
         domain_20th_percentile = int(numpy.percentile(domain_count_array, 20))
         domain_85th_percentile = int(numpy.percentile(domain_count_array, 85))
 
-        top_domains = [
+        common_domains = [
             x for x, y in domain_counter.most_common()
                 if y >= domain_85th_percentile]
         rare_domains = [
@@ -88,8 +88,8 @@ class DomainSketchPlugin(interface.BaseSketchAnalyzer):
                 tags_to_add.append('known-cdn')
                 cdn_counter[cdn_provider] += 1
 
-            if domain in top_domains:
-                tags_to_add.append('top_domain')
+            if domain in common_domains:
+                tags_to_add.append('common_domain')
 
             if domain in rare_domains:
                 tags_to_add.append('rare_domain')


### PR DESCRIPTION
Instead of changing the human readable string to include the domain count, only add a tag for the top 85th percentile and the rare occurrences of domains, otherwise leave the human readable field "alone".