### PR TITLE
Changed phishy domain analyzer to return early if no results.

### DIFF
--- a/timesketch/lib/analyzers/phishy_domains.py
+++ b/timesketch/lib/analyzers/phishy_domains.py
@@ -188,6 +188,9 @@ class PhishyDomainsSketchPlugin(interface.BaseSketchAnalyzer):
             tld = utils.get_tld_from_domain(domain)
             tld_counter[tld] += 1
 
+        if not domain_counter:
+            return 'No domains discovered, so no phishy domains.'
+
         watched_domains_list = current_app.config.get(
             'DOMAIN_ANALYZER_WATCHED_DOMAINS', [])
         domain_threshold = current_app.config.get(


### PR DESCRIPTION
When the phishy analyzer inspects timelines with no results it can lead to longer time or halting execution of celery workers.