### PR TITLE
Fix a Python3 error by encoding before hashing

### DIFF
--- a/timesketch/api/v1/resources.py
+++ b/timesketch/api/v1/resources.py
@@ -1052,7 +1052,7 @@ class EventCreateResource(ResourceMixin, Resource):
 
             # We do not need a human readable filename or
             # datastore index name, so we use UUIDs here.
-            index_name = hashlib.md5(index_name_seed).hexdigest()
+            index_name = hashlib.md5(index_name_seed.encode()).hexdigest()
             if six.PY2:
                 index_name = codecs.decode(index_name, 'utf-8')
 


### PR DESCRIPTION
In a Python3 environment, manually inserting an event fails with the following error, since index_name_seed is considered unicode. This PR fixes the issue.
```
[2019-06-17 16:14:44,420] ERROR in app: Exception on /api/v1/sketches/6/event/create/ [POST]
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/flask/app.py", line 1813, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.6/dist-packages/flask/app.py", line 1799, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/local/lib/python3.6/dist-packages/flask_restful/__init__.py", line 480, in wrapper
    resp = resource(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/flask/views.py", line 88, in view
    return self.dispatch_request(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/flask_restful/__init__.py", line 595, in dispatch_request
    resp = meth(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/flask_login/utils.py", line 228, in decorated_view
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/timesketch/api/v1/resources.py", line 1055, in post
    index_name = hashlib.md5(index_name_seed).hexdigest()
TypeError: Unicode-objects must be encoded before hashing
```