### PR TITLE
Move dependency install to Dockerfile

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -1,6 +1,10 @@
 # Use the latest Timesketch development base image
 FROM timesketch/timesketch-dev-base:20190603
 
+# Install dependencies for Timesketch
+COPY requirements.txt /timesketch-requirements.txt
+RUN pip3 install -r /timesketch-requirements.txt
+
 # Copy the entrypoint script into the container
 COPY docker/development/docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod a+x /docker-entrypoint.sh

--- a/docker/development/docker-entrypoint.sh
+++ b/docker/development/docker-entrypoint.sh
@@ -3,8 +3,7 @@
 # Run the container the default way
 if [ "$1" = 'timesketch' ]; then
 
-  # Install Timesketch from volume
-  cd /usr/local/src/timesketch && yarn install && yarn run build
+  # Install Timesketch in editable mode from volume
   pip3 install -e /usr/local/src/timesketch/
 
   # Copy config files


### PR DESCRIPTION
Don't install dependencies in bootstrap.sh to remove network dependency when starting the container.