### PR TITLE
Remove Xenial from Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 matrix:
   include:
-  - name: "Pylint on Ubuntu Bionic (18.04) (Docker) with Python 3.6"
+  - name: "Ubuntu Bionic (18.04) (Docker) Pylint with Python 3.6"
     env: [TARGET="pylint", UBUNTU_VERSION="18.04"]
     os: linux
     dist: xenial
@@ -10,22 +10,6 @@ matrix:
     python: 3.6
     services:
     - docker
-  - name: "Ubuntu Xenial (16.04) with Python 2.7 (pip)"
-    env: TARGET="linux-python27"
-    os: linux
-    dist: xenial
-    group: edge
-    language: python
-    python: 2.7
-    node_js: '8'
-  - name: "Ubuntu Xenial (16.04) with Python 3.6 (pip)"
-    env: TARGET="linux-python36"
-    os: linux
-    dist: xenial
-    group: edge
-    language: python
-    python: 3.6
-    node_js: '8'
   - name: "Ubuntu Bionic (18.04) (Docker) with Python 2.7"
     env: UBUNTU_VERSION="18.04"
     os: linux


### PR DESCRIPTION
We don't use Xenial anymore, and Plaso isn't supported in that version. Dropping support.