### PR TITLE
Fixing aggregations in the API client

### DIFF
--- a/api_client/python/setup.py
+++ b/api_client/python/setup.py
@@ -21,7 +21,7 @@ from setuptools import setup
 
 setup(
     name='timesketch-api-client',
-    version='20190513',
+    version='20190925',
     description='Timesketch API client',
     license='Apache License, Version 2.0',
     url='http://www.timesketch.org/',

--- a/api_client/python/timesketch_api_client/client.py
+++ b/api_client/python/timesketch_api_client/client.py
@@ -25,7 +25,6 @@ import requests
 from requests.exceptions import ConnectionError
 import altair
 import pandas
-import numpy
 from .definitions import HTTP_STATUS_CODE_20X
 
 
@@ -728,7 +727,7 @@ class Sketch(BaseResource):
             self.api.api_root, self.id)
 
         form_data = {
-            'name': aggregator_name,
+            'name': name,
             'description': description,
             'agg_type': aggregator_name,
             'chart_type': chart_type,
@@ -741,7 +740,7 @@ class Sketch(BaseResource):
 
         objects = response_dict.get('objects', [])
         if not objects:
-          return
+            return
 
         _ = self.lazyload_data(refresh_cache=True)
         return self.get_aggregation(objects[0].get('id'))
@@ -948,7 +947,7 @@ class Aggregation(BaseResource):
             return altair.Chart(pandas.DataFrame()).mark_point()
 
         vega_spec_string = json.dumps(vega_spec)
-        return alt.Chart.from_json(vega_spec_string)
+        return altair.Chart.from_json(vega_spec_string)
 
     def run(self, as_pandas=False):
         """Returns the results from an aggregator run."""

--- a/api_client/python/timesketch_api_client/client.py
+++ b/api_client/python/timesketch_api_client/client.py
@@ -947,8 +947,8 @@ class Aggregation(BaseResource):
         if not vega_spec:
             return altair.Chart(pandas.DataFrame()).mark_point()
 
-        vega_string = json.dumps(vega_spec)
-        return alt.Chart.from_json(vega_string)
+        vega_spec_string = json.dumps(vega_spec)
+        return alt.Chart.from_json(vega_spec_string)
 
     def run(self, as_pandas=False):
         """Returns the results from an aggregator run."""

--- a/api_client/python/timesketch_api_client/client.py
+++ b/api_client/python/timesketch_api_client/client.py
@@ -709,7 +709,9 @@ class Sketch(BaseResource):
 
         return response_json
 
-    def store_aggregation(self, name, description, aggregator_name, aggregator_parameters, chart_type=''):
+    def store_aggregation(
+        self, name, description, aggregator_name, aggregator_parameters,
+        chart_type=''):
         """Store an aggregation in the sketch.
 
         Args:

--- a/api_client/python/timesketch_api_client/client.py
+++ b/api_client/python/timesketch_api_client/client.py
@@ -399,6 +399,7 @@ class Sketch(BaseResource):
             List of aggregations (instances of Aggregation objects)
         """
         sketch = self.lazyload_data()
+        aggregations = []
         for aggregation in sketch['meta']['saved_aggregations']:
             aggregation_obj = Aggregation(
                 aggregation_id=aggregation['id'],
@@ -408,6 +409,28 @@ class Sketch(BaseResource):
                 api=self.api)
             aggregations.append(aggregation_obj)
         return aggregations
+
+    def get_aggregation(self, aggregation_id):
+        """Return a stored aggregation.
+
+        Args:
+            aggregation_id: id of the stored aggregation.
+
+        Returns:
+            An aggregation object, if stored (instance of Aggregation),
+            otherwise None object.
+        """
+        sketch = self.lazyload_data()
+        for aggregation in sketch['meta']['saved_aggregations']:
+            if aggregation['id'] != aggregation_id:
+                continue
+            aggregation_obj = Aggregation(
+                aggregation_id=aggregation['id'],
+                aggregation_name=aggregation['name'],
+                sketch=self,
+                sketch_id=self.id,
+                api=self.api)
+            return aggregation_obj
 
     def list_views(self):
         """List all saved views for this sketch.
@@ -686,6 +709,41 @@ class Sketch(BaseResource):
 
         return response_json
 
+    def store_aggregation(self, name, description, aggregator_name, aggregator_parameters, chart_type=''):
+        """Store an aggregation in the sketch.
+
+        Args:
+            name: a name that will be associated with the aggregation.
+            description: description of the aggregation, visible in the UI.
+            aggregator_name: name of the aggregator class.
+            aggregator_parameters: parameters of the aggregator.
+            chart_type: string representing the chart type.
+
+        Returns:
+          A stored aggregation object or None if not stored.
+        """
+        resource_url = '{0:s}/sketches/{1:d}/aggregation/'.format(
+            self.api.api_root, self.id)
+
+        form_data = {
+            'name': aggregator_name,
+            'description': description,
+            'agg_type': aggregator_name,
+            'chart_type': chart_type,
+            'sketch': self.id,
+            'parameters': aggregator_parameters
+        }
+
+        response = self.api.session.post(resource_url, json=form_data)
+        response_dict = response.json()
+
+        objects = response_dict.get('objects', [])
+        if not objects:
+          return
+
+        _ = self.lazyload_data(refresh_cache=True)
+        return self.get_aggregation(objects[0].get('id'))
+
     def label_events(self, events, label_name):
         """Labels one or more events with label_name.
 
@@ -884,11 +942,11 @@ class Aggregation(BaseResource):
         meta = data.get('meta', {})
         vega_spec = meta.get('vega_spec')
 
-        if vega_spec:
-            return vega_spec
+        if not vega_spec:
+            return altair.Chart(pandas.DataFrame()).mark_point()
 
-        return altair.Chart(pandas.DataFrame()).mark_point()
-
+        vega_string = json.dumps(vega_spec)
+        return alt.Chart.from_json(vega_string)
 
     def run(self, as_pandas=False):
         """Returns the results from an aggregator run."""

--- a/api_client/python/timesketch_api_client/client.py
+++ b/api_client/python/timesketch_api_client/client.py
@@ -710,8 +710,8 @@ class Sketch(BaseResource):
         return response_json
 
     def store_aggregation(
-        self, name, description, aggregator_name, aggregator_parameters,
-        chart_type=''):
+            self, name, description, aggregator_name, aggregator_parameters,
+            chart_type=''):
         """Store an aggregation in the sketch.
 
         Args:

--- a/api_client/python/timesketch_api_client/client.py
+++ b/api_client/python/timesketch_api_client/client.py
@@ -740,7 +740,7 @@ class Sketch(BaseResource):
 
         objects = response_dict.get('objects', [])
         if not objects:
-            return
+            return None
 
         _ = self.lazyload_data(refresh_cache=True)
         return self.get_aggregation(objects[0].get('id'))

--- a/timesketch/api/v1/resources.py
+++ b/timesketch/api/v1/resources.py
@@ -770,7 +770,7 @@ class AggregationResource(ResourceMixin, Resource):
 
     @login_required
     def get(self, sketch_id, aggregation_id):  # pylint: disable=unused-argument
-        """Handles POST request to the resource.
+        """Handles GET request to the resource.
 
         Handler for /api/v1/sketches/:sketch_id/aggregation/:aggregation_id
 


### PR DESCRIPTION
Removing the need to depend on the aggregation manager, and thus removing dependencies on timesketch library in the API client.

Also adding support for storing and listing stored aggregations.