### PR TITLE
Update docker-compose to correct elasticsearch volume 

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -19,13 +19,6 @@ cd timesketch
 ### Verify the Kernel Settings
 Follow the official instructions [here](https://www.elastic.co/guide/en/elasticsearch/reference/6.4/docker.html#docker-cli-run-prod-mode)
 
-### Create elasticsearch directory
-
-```
-mkdir /var/lib/elasticsearch
-chown 1000:1000 /var/lib/elasticsearch
-```
-
 ### Build and Start Containers
 
 ```shell

--- a/docker/README.md
+++ b/docker/README.md
@@ -16,6 +16,16 @@ Follow the official instructions [here](https://docs.docker.com/compose/install/
 git clone https://github.com/google/timesketch.git
 cd timesketch
 ```
+### Verify the Kernel Settings
+Follow the official instructions [here](https://www.elastic.co/guide/en/elasticsearch/reference/6.4/docker.html#docker-cli-run-prod-mode)
+
+### Create elasticsearch directory
+
+```
+mkdir /var/lib/elasticsearch
+chown 1000:1000 /var/lib/elasticsearch
+```
+
 ### Build and Start Containers
 
 ```shell

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - "9300:9300"
     restart: always
     volumes:
-      - /var/lib/elasticsearch:/usr/share/elasticsearch/data/elasticsearch
+      - /var/lib/elasticsearch:/usr/share/elasticsearch/data
 
   postgres:
     image: postgres

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,10 +28,11 @@ services:
       - ../:/usr/local/src/timesketch/
 
   elasticsearch:
+
+    environment:
+      - TAKE_FILE_OWNERSHIP=1
     # uncomment the following lines to control JVM memory utilization
     # in smaller deployments with minimal resources
-
-    #environment:
     #  - ES_JAVA_OPTS= -Xms1g -Xmx1g # 1G min/1G max
     image: elasticsearch:6.4.2
     ports:


### PR DESCRIPTION
**Problem:** Elasticsearch data was not persistent across down/up commands using docker-compose yaml file provided.

**Solution:** 

1. Research found [this](https://www.elastic.co/guide/en/elasticsearch/reference/6.4/docker.html) documentation which revealed  the docker volume for elasticsearch was referencing the incorrect source directory.

1. After fixing the volume reference, testing found a directory permissions problem with /var/lib/elasticsearch.  So added documentation to pre-create the directory and set appropriate permissions.

1. Additional documentation was added to highlight a needed check for max_map_count -- see [here](https://www.elastic.co/guide/en/elasticsearch/reference/6.4/docker.html#docker-cli-run-prod-mode).