### PR TITLE
Changing the OAUTH flow in the client to add a web server to catch response

### DIFF
--- a/api_client/python/setup.py
+++ b/api_client/python/setup.py
@@ -21,7 +21,7 @@ from setuptools import setup
 
 setup(
     name='timesketch-api-client',
-    version='20191114',
+    version='20191118',
     description='Timesketch API client',
     license='Apache License, Version 2.0',
     url='http://www.timesketch.org/',

--- a/api_client/python/timesketch_api_client/client.py
+++ b/api_client/python/timesketch_api_client/client.py
@@ -172,7 +172,8 @@ class TimesketchApi(object):
                 raise RuntimeError(
                     'Unable to log in, client secret files does not exist.')
             flow = googleauth_flow.InstalledAppFlow.from_client_secrets_file(
-                client_secrets_file, scopes=self.DEFAULT_OAUTH_SCOPE)
+                client_secrets_file, scopes=self.DEFAULT_OAUTH_SCOPE,
+                autogenerate_code_verifier=True)
         else:
             provider_url = self.DEFAULT_OAUTH_PROVIDER_URL
             client_config = {
@@ -187,7 +188,8 @@ class TimesketchApi(object):
             }
 
             flow = googleauth_flow.InstalledAppFlow.from_client_config(
-                client_config, self.DEFAULT_OAUTH_SCOPE)
+                client_config, self.DEFAULT_OAUTH_SCOPE,
+                autogenerate_code_verifier=True)
 
             flow.redirect_uri = self.DEFAULT_OAUTH_OOB_URL
 

--- a/api_client/python/timesketch_api_client/client.py
+++ b/api_client/python/timesketch_api_client/client.py
@@ -14,6 +14,7 @@
 """Timesketch API client."""
 from __future__ import unicode_literals
 
+import os
 import json
 import uuid
 


### PR DESCRIPTION
Adding the ability to run a local webserver to catch the OAUTH flow, to remove the need to copy/paste a token into the client.