### PR TITLE
Adding the ability to store aggregation into analyzer interface

### DIFF
--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -143,7 +143,7 @@ class Sketch(resource.BaseResource):
             List of aggregations (instances of Aggregation objects)
         """
         aggregations = []
-        data = self.lazyload_data()
+        data = self.lazyload_data(refresh_cache=True)
 
         objects = data.get('objects')
         if not objects:

--- a/timesketch/lib/analyzers/browser_search.py
+++ b/timesketch/lib/analyzers/browser_search.py
@@ -212,9 +212,17 @@ class BrowserSearchSketchPlugin(interface.BaseSketchAnalyzer):
             event.commit()
 
         if simple_counter > 0:
-            self.sketch.add_view(
+            view = self.sketch.add_view(
                 view_name='Browser Search', analyzer_name=self.NAME,
                 query_string='tag:"browser-search"')
+            params = {
+                'field': 'search_string',
+                'limit': 20,
+            }
+            self.sketch.add_aggregation(
+                name='Top 20 browser search queries.', agg_name='field_bucket',
+                agg_params=params, view_id=view.id, chart_type='hbarchart',
+                description='Created by the browser search analyzer')
 
         return (
             'Browser Search completed with {0:d} search results '

--- a/timesketch/lib/analyzers/feature_extraction.py
+++ b/timesketch/lib/analyzers/feature_extraction.py
@@ -144,11 +144,8 @@ class FeatureExtractionSketchPlugin(interface.BaseSketchAnalyzer):
             create_view = True
 
         if create_view and event_counter:
-            if query:
-                query_string = query
-            else:
-                query_string = query_dsl
-            view = self.sketch.add_view(name, query_string)
+            view = self.sketch.add_view(
+                name, self.NAME, query_string=query, query_dsl=query_dsl)
 
             if aggregate_results:
                 params = {

--- a/timesketch/lib/analyzers/feature_extraction.py
+++ b/timesketch/lib/analyzers/feature_extraction.py
@@ -140,7 +140,9 @@ class FeatureExtractionSketchPlugin(interface.BaseSketchAnalyzer):
 
         aggregate_results = config.get('aggregate', False)
         create_view = config.get('create_view', False)
-        if not create_view and aggregate_results:
+
+        # If aggregation is turned on, we automatically create an aggregation.
+        if aggregate_results:
             create_view = True
 
         if create_view and event_counter:

--- a/timesketch/lib/analyzers/interface.py
+++ b/timesketch/lib/analyzers/interface.py
@@ -26,6 +26,7 @@ from flask import current_app
 from timesketch.lib import definitions
 from timesketch.lib.datastores.elastic import ElasticsearchDataStore
 from timesketch.models import db_session
+from timesketch.models.sketch import Aggregation
 from timesketch.models.sketch import Event as SQLEvent
 from timesketch.models.sketch import Sketch as SQLSketch
 from timesketch.models.sketch import SearchIndex
@@ -264,6 +265,38 @@ class Sketch(object):
 
         if not self.sql_sketch:
             raise RuntimeError('No such sketch')
+
+    def add_aggregation(
+            self, name, agg_name, agg_params, description='', view_id=None,
+            chart_type=None):
+        """Add aggregation to the sketch.
+
+        Args:
+            name: the name of the aggregation run.
+            agg_name: the name of the aggregation class to run.
+            agg_params: a dictionary of the parameters for the aggregation.
+            description: description of the aggregation, visible in the UI,
+                this is optional.
+            view_id: optional ID of the view to attach the aggregation to.
+            chart_type: string representing the chart type.
+        """
+        if not agg_name:
+            raise ValueError('Aggregator name needs to be defined.')
+        if not agg_params:
+            raise ValueError('Aggregator parameters have to be defined.')
+
+        if view_id:
+            view = View.query.get(view_id)
+        else:
+            view = None
+
+        aggregation = SQLSketch.get_or_create(
+            name=name, description=description, agg_type=agg_name,
+            parameters=agg_params, chart_type=chart_type, user=None,
+            sketch=self.sql_sketch, view=view)
+        db_session.add(aggregation)
+        db_session.commit()
+        return aggregation
 
     def add_view(self, view_name, analyzer_name, query_string=None,
                  query_dsl=None, query_filter=None):

--- a/timesketch/lib/analyzers/interface.py
+++ b/timesketch/lib/analyzers/interface.py
@@ -15,6 +15,7 @@
 
 from __future__ import unicode_literals
 
+import json
 import logging
 import os
 import traceback
@@ -290,9 +291,10 @@ class Sketch(object):
         else:
             view = None
 
-        aggregation = SQLSketch.get_or_create(
+        agg_json = json.dumps(agg_params)
+        aggregation = Aggregation.get_or_create(
             name=name, description=description, agg_type=agg_name,
-            parameters=agg_params, chart_type=chart_type, user=None,
+            parameters=agg_json, chart_type=chart_type, user=None,
             sketch=self.sql_sketch, view=view)
         db_session.add(aggregation)
         db_session.commit()

--- a/timesketch/models/user.py
+++ b/timesketch/models/user.py
@@ -58,6 +58,7 @@ class User(UserMixin, BaseModel):
     timelines = relationship('Timeline', backref='user', lazy='dynamic')
     views = relationship('View', backref='user', lazy='dynamic')
     stories = relationship('Story', backref='user', lazy='dynamic')
+    aggregations = relationship('Aggregation', backref='user', lazy='dynamic')
     my_groups = relationship('Group', backref='user', lazy='dynamic')
     groups = relationship(
         'Group',


### PR DESCRIPTION
Added the following things:

- Added `add_aggregation` into the analyzer interface, so that aggregations can be stored by analyzers.
- Changed the feature extraction analyzer so that it stores aggregations.
- Changed the browser search analyzer, storing aggregation if there are search results.