### PR TITLE
Fix duplicate sorting order in sketch explore sort order dropdown

### DIFF
--- a/timesketch/frontend/src/views/SketchExplore.vue
+++ b/timesketch/frontend/src/views/SketchExplore.vue
@@ -222,7 +222,6 @@ limitations under the License.
                 <div class="level-item">
                   <div v-if="eventList.objects.length" class="select is-small">
                     <select v-model="currentQueryFilter.order" @change="search">
-                      <option v-bind:value="currentQueryFilter.order">{{ currentQueryFilter.order }}</option>
                       <option value="desc">desc</option>
                       <option value="asc">asc</option>
                     </select>


### PR DESCRIPTION
Fixes: #1052

Vue will handle the selected value by itself, it does not need to be explicitly specified. See https://vuejs.org/v2/guide/forms.html#Select