### PR TITLE
Remove vagrant from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Timesketch is an open source tool for collaborative forensic timeline analysis. 
 
 #### Installation
 * [Install Timesketch manually](docs/Installation.md)
-* [Use Vagrant](vagrant)
 * [Use Docker](docker)
 * [Upgrade from existing installation](docs/Upgrading.md)
 


### PR DESCRIPTION
as per https://github.com/google/timesketch/pull/979 Vagrant support was dropped, so should not be in the readme