### PR TITLE
Use development_timesketch instead of docker_timesketch

### DIFF
--- a/docker/development/README.md
+++ b/docker/development/README.md
@@ -11,7 +11,7 @@ $  docker-compose up -d
 ### Find out container ID for the timesketch container
 
 ```
-$ CONTAINER_ID="$(sudo docker container list -f name=docker_timesketch -q)"
+$ CONTAINER_ID="$(sudo docker container list -f name=development_timesketch -q)"
 ```
 In the output look for CONTAINER ID for the timesketch container
 


### PR DESCRIPTION
So I tried to set up the dev docker instance but:

````
sudo docker container list -f name=docker_timesketch -q
````

does not give an output, listing all machines:

````
sudo docker container list 
CONTAINER ID        IMAGE                                                 COMMAND                  CREATED             STATUS                  PORTS                                            NAMES
431070b6efe4        development_timesketch                                "/docker-entrypoint.…"   2 hours ago         Up 2 hours              127.0.0.1:5000->5000/tcp                         development_timesketch_1
````
gives an output, so I assume, the readme should be adjusted. However, I did not find a reference in the docker files that set this different name.