### PR TITLE
Change default location for config file

### DIFF
--- a/config/dpkg/timesketch-server.timesketch.default
+++ b/config/dpkg/timesketch-server.timesketch.default
@@ -1,6 +1,6 @@
 # Timesketch configuration
 #
-# The default location for this configuration file is in /etc/timesketch.conf
+# The default location for this configuration file is in /etc/timesketch/timesketch.conf
 # If you put it somewhere else you can pass the path to tsctl
 # Example:
 #

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,10 +34,9 @@ RUN cd /tmp/timesketch && yarn install && yarn run build
 RUN sed -i -e '/pyyaml/d' /tmp/timesketch/requirements.txt
 RUN pip3 install /tmp/timesketch/
 
-# Copy the Timesketch configuration file into /etc
-RUN cp /tmp/timesketch/data/timesketch.conf /etc
 # Copy Timesketch config files into /etc/timesketch
 RUN mkdir /etc/timesketch
+RUN cp /tmp/timesketch/data/timesketch.conf /etc/timesketch/
 RUN cp /tmp/timesketch/data/features.yaml /etc/timesketch/
 
 # Copy the entrypoint script into the container

--- a/docker/development/docker-entrypoint.sh
+++ b/docker/development/docker-entrypoint.sh
@@ -8,19 +8,19 @@ if [ "$1" = 'timesketch' ]; then
 
   # Copy config files
   mkdir /etc/timesketch
-  cp /usr/local/src/timesketch/data/timesketch.conf /etc
+  cp /usr/local/src/timesketch/data/timesketch.conf /etc/timesketch/
   cp /usr/local/src/timesketch/data/features.yaml /etc/timesketch/
 
-  # Set SECRET_KEY in /etc/timesketch.conf if it isn't already set
-  if grep -q "SECRET_KEY = '<KEY_GOES_HERE>'" /etc/timesketch.conf; then
+  # Set SECRET_KEY in /etc/timesketch/timesketch.conf if it isn't already set
+  if grep -q "SECRET_KEY = '<KEY_GOES_HERE>'" /etc/timesketch/timesketch.conf; then
     OPENSSL_RAND=$( openssl rand -base64 32 )
     # Using the pound sign as a delimiter to avoid problems with / being output from openssl
-    sed -i 's#SECRET_KEY = \x27\x3CKEY_GOES_HERE\x3E\x27#SECRET_KEY = \x27'$OPENSSL_RAND'\x27#' /etc/timesketch.conf
+    sed -i 's#SECRET_KEY = \x27\x3CKEY_GOES_HERE\x3E\x27#SECRET_KEY = \x27'$OPENSSL_RAND'\x27#' /etc/timesketch/timesketch.conf
   fi
 
   # Set up the Postgres connection
   if [ $POSTGRES_USER ] && [ $POSTGRES_PASSWORD ] && [ $POSTGRES_ADDRESS ] && [ $POSTGRES_PORT ]; then
-    sed -i 's#postgresql://<USERNAME>:<PASSWORD>@localhost#postgresql://'$POSTGRES_USER':'$POSTGRES_PASSWORD'@'$POSTGRES_ADDRESS':'$POSTGRES_PORT'#' /etc/timesketch.conf
+    sed -i 's#postgresql://<USERNAME>:<PASSWORD>@localhost#postgresql://'$POSTGRES_USER':'$POSTGRES_PASSWORD'@'$POSTGRES_ADDRESS':'$POSTGRES_PORT'#' /etc/timesketch/timesketch.conf
   else
     # Log an error since we need the above-listed environment variables
     echo "Please pass values for the POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_ADDRESS, and POSTGRES_PORT environment variables"
@@ -29,8 +29,8 @@ if [ "$1" = 'timesketch' ]; then
 
   # Set up the Elastic connection
   if [ $ELASTIC_ADDRESS ] && [ $ELASTIC_PORT ]; then
-    sed -i 's#ELASTIC_HOST = \x27127.0.0.1\x27#ELASTIC_HOST = \x27'$ELASTIC_ADDRESS'\x27#' /etc/timesketch.conf
-    sed -i 's#ELASTIC_PORT = 9200#ELASTIC_PORT = '$ELASTIC_PORT'#' /etc/timesketch.conf
+    sed -i 's#ELASTIC_HOST = \x27127.0.0.1\x27#ELASTIC_HOST = \x27'$ELASTIC_ADDRESS'\x27#' /etc/timesketch/timesketch.conf
+    sed -i 's#ELASTIC_PORT = 9200#ELASTIC_PORT = '$ELASTIC_PORT'#' /etc/timesketch/timesketch.conf
   else
     # Log an error since we need the above-listed environment variables
     echo "Please pass values for the ELASTIC_ADDRESS and ELASTIC_PORT environment variables"
@@ -38,9 +38,9 @@ if [ "$1" = 'timesketch' ]; then
 
   # Set up the Redis connection
   if [ $REDIS_ADDRESS ] && [ $REDIS_PORT ]; then
-    sed -i 's#UPLOAD_ENABLED = False#UPLOAD_ENABLED = True#' /etc/timesketch.conf
-    sed -i 's#^CELERY_BROKER_URL =.*#CELERY_BROKER_URL = \x27redis://'$REDIS_ADDRESS':'$REDIS_PORT'\x27#' /etc/timesketch.conf
-    sed -i 's#^CELERY_RESULT_BACKEND =.*#CELERY_RESULT_BACKEND = \x27redis://'$REDIS_ADDRESS':'$REDIS_PORT'\x27#' /etc/timesketch.conf
+    sed -i 's#UPLOAD_ENABLED = False#UPLOAD_ENABLED = True#' /etc/timesketch/timesketch.conf
+    sed -i 's#^CELERY_BROKER_URL =.*#CELERY_BROKER_URL = \x27redis://'$REDIS_ADDRESS':'$REDIS_PORT'\x27#' /etc/timesketch/timesketch.conf
+    sed -i 's#^CELERY_RESULT_BACKEND =.*#CELERY_RESULT_BACKEND = \x27redis://'$REDIS_ADDRESS':'$REDIS_PORT'\x27#' /etc/timesketch/timesketch.conf
   else
     # Log an error since we need the above-listed environment variables
     echo "Please pass values for the REDIS_ADDRESS and REDIS_PORT environment variables"
@@ -48,21 +48,21 @@ if [ "$1" = 'timesketch' ]; then
 
   # Set up the Neo4j connection
   if [ $NEO4J_ADDRESS ] && [ $NEO4J_PORT ]; then
-    sed -i 's#GRAPH_BACKEND_ENABLED = False#GRAPH_BACKEND_ENABLED = True#' /etc/timesketch.conf
-    sed -i 's#NEO4J_HOST =.*#NEO4J_HOST = \x27'$NEO4J_ADDRESS'\x27#' /etc/timesketch.conf
-    sed -i 's#NEO4J_PORT =.*#NEO4J_PORT = '$NEO4J_PORT'#' /etc/timesketch.conf
+    sed -i 's#GRAPH_BACKEND_ENABLED = False#GRAPH_BACKEND_ENABLED = True#' /etc/timesketch/timesketch.conf
+    sed -i 's#NEO4J_HOST =.*#NEO4J_HOST = \x27'$NEO4J_ADDRESS'\x27#' /etc/timesketch/timesketch.conf
+    sed -i 's#NEO4J_PORT =.*#NEO4J_PORT = '$NEO4J_PORT'#' /etc/timesketch/timesketch.conf
   else
     # Log an error since we need the above-listed environment variables
     echo "Please pass values for the NEO4J_ADDRESS and NEO4J_PORT environment variables if you want graph support"
   fi
 
   # Enable debug for the development server
-  sed -i s/"DEBUG = False"/"DEBUG = True"/ /etc/timesketch.conf
+  sed -i s/"DEBUG = False"/"DEBUG = True"/ /etc/timesketch/timesketch.conf
 
   # Enable index and sketch analyzers
-  sed -i s/"ENABLE_INDEX_ANALYZERS = False"/"ENABLE_INDEX_ANALYZERS = True"/ /etc/timesketch.conf
-  sed -i s/"ENABLE_SKETCH_ANALYZERS = False"/"ENABLE_SKETCH_ANALYZERS = True"/ /etc/timesketch.conf
-  sed -i s/"ENABLE_EXPERIMENTAL_UI = False"/"ENABLE_EXPERIMENTAL_UI = True"/ /etc/timesketch.conf
+  sed -i s/"ENABLE_INDEX_ANALYZERS = False"/"ENABLE_INDEX_ANALYZERS = True"/ /etc/timesketch/timesketch.conf
+  sed -i s/"ENABLE_SKETCH_ANALYZERS = False"/"ENABLE_SKETCH_ANALYZERS = True"/ /etc/timesketch/timesketch.conf
+  sed -i s/"ENABLE_EXPERIMENTAL_UI = False"/"ENABLE_EXPERIMENTAL_UI = True"/ /etc/timesketch/timesketch.conf
 
   # Add web user
   tsctl add_user --username "${TIMESKETCH_USER}" --password "${TIMESKETCH_USER}"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -2,16 +2,16 @@
 
 # Run the container the default way
 if [ "$1" = 'timesketch' ]; then
-  # Set SECRET_KEY in /etc/timesketch.conf if it isn't already set
-  if grep -q "SECRET_KEY = '<KEY_GOES_HERE>'" /etc/timesketch.conf; then
+  # Set SECRET_KEY in /etc/timesketch/timesketch.conf if it isn't already set
+  if grep -q "SECRET_KEY = '<KEY_GOES_HERE>'" /etc/timesketch/timesketch.conf; then
     OPENSSL_RAND=$( openssl rand -base64 32 )
     # Using the pound sign as a delimiter to avoid problems with / being output from openssl
-    sed -i 's#SECRET_KEY = \x27\x3CKEY_GOES_HERE\x3E\x27#SECRET_KEY = \x27'$OPENSSL_RAND'\x27#' /etc/timesketch.conf
+    sed -i 's#SECRET_KEY = \x27\x3CKEY_GOES_HERE\x3E\x27#SECRET_KEY = \x27'$OPENSSL_RAND'\x27#' /etc/timesketch/timesketch.conf
   fi
 
   # Set up the Postgres connection
   if [ $POSTGRES_USER ] && [ $POSTGRES_PASSWORD ] && [ $POSTGRES_ADDRESS ] && [ $POSTGRES_PORT ]; then
-    sed -i 's#postgresql://<USERNAME>:<PASSWORD>@localhost#postgresql://'$POSTGRES_USER':'$POSTGRES_PASSWORD'@'$POSTGRES_ADDRESS':'$POSTGRES_PORT'#' /etc/timesketch.conf
+    sed -i 's#postgresql://<USERNAME>:<PASSWORD>@localhost#postgresql://'$POSTGRES_USER':'$POSTGRES_PASSWORD'@'$POSTGRES_ADDRESS':'$POSTGRES_PORT'#' /etc/timesketch/timesketch.conf
   else
     # Log an error since we need the above-listed environment variables
     echo "Please pass values for the POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_ADDRESS, and POSTGRES_PORT environment variables"
@@ -20,8 +20,8 @@ if [ "$1" = 'timesketch' ]; then
 
   # Set up the Elastic connection
   if [ $ELASTIC_ADDRESS ] && [ $ELASTIC_PORT ]; then
-    sed -i 's#ELASTIC_HOST = \x27127.0.0.1\x27#ELASTIC_HOST = \x27'$ELASTIC_ADDRESS'\x27#' /etc/timesketch.conf
-    sed -i 's#ELASTIC_PORT = 9200#ELASTIC_PORT = '$ELASTIC_PORT'#' /etc/timesketch.conf
+    sed -i 's#ELASTIC_HOST = \x27127.0.0.1\x27#ELASTIC_HOST = \x27'$ELASTIC_ADDRESS'\x27#' /etc/timesketch/timesketch.conf
+    sed -i 's#ELASTIC_PORT = 9200#ELASTIC_PORT = '$ELASTIC_PORT'#' /etc/timesketch/timesketch.conf
   else
     # Log an error since we need the above-listed environment variables
     echo "Please pass values for the ELASTIC_ADDRESS and ELASTIC_PORT environment variables"
@@ -29,9 +29,9 @@ if [ "$1" = 'timesketch' ]; then
 
   # Set up the Redis connection
   if [ $REDIS_ADDRESS ] && [ $REDIS_PORT ]; then
-    sed -i 's#UPLOAD_ENABLED = False#UPLOAD_ENABLED = True#' /etc/timesketch.conf
-    sed -i 's#^CELERY_BROKER_URL =.*#CELERY_BROKER_URL = \x27redis://'$REDIS_ADDRESS':'$REDIS_PORT'\x27#' /etc/timesketch.conf
-    sed -i 's#^CELERY_RESULT_BACKEND =.*#CELERY_RESULT_BACKEND = \x27redis://'$REDIS_ADDRESS':'$REDIS_PORT'\x27#' /etc/timesketch.conf
+    sed -i 's#UPLOAD_ENABLED = False#UPLOAD_ENABLED = True#' /etc/timesketch/timesketch.conf
+    sed -i 's#^CELERY_BROKER_URL =.*#CELERY_BROKER_URL = \x27redis://'$REDIS_ADDRESS':'$REDIS_PORT'\x27#' /etc/timesketch/timesketch.conf
+    sed -i 's#^CELERY_RESULT_BACKEND =.*#CELERY_RESULT_BACKEND = \x27redis://'$REDIS_ADDRESS':'$REDIS_PORT'\x27#' /etc/timesketch/timesketch.conf
   else
     # Log an error since we need the above-listed environment variables
     echo "Please pass values for the REDIS_ADDRESS and REDIS_PORT environment variables"
@@ -39,9 +39,9 @@ if [ "$1" = 'timesketch' ]; then
 
   # Set up the Neo4j connection
   if [ $NEO4J_ADDRESS ] && [ $NEO4J_PORT ]; then
-    sed -i 's#GRAPH_BACKEND_ENABLED = False#GRAPH_BACKEND_ENABLED = True#' /etc/timesketch.conf
-    sed -i 's#NEO4J_HOST =.*#NEO4J_HOST = \x27'$NEO4J_ADDRESS'\x27#' /etc/timesketch.conf
-    sed -i 's#NEO4J_PORT =.*#NEO4J_PORT = '$NEO4J_PORT'#' /etc/timesketch.conf
+    sed -i 's#GRAPH_BACKEND_ENABLED = False#GRAPH_BACKEND_ENABLED = True#' /etc/timesketch/timesketch.conf
+    sed -i 's#NEO4J_HOST =.*#NEO4J_HOST = \x27'$NEO4J_ADDRESS'\x27#' /etc/timesketch/timesketch.conf
+    sed -i 's#NEO4J_PORT =.*#NEO4J_PORT = '$NEO4J_PORT'#' /etc/timesketch/timesketch.conf
   else
     # Log an error since we need the above-listed environment variables
     echo "Please pass values for the NEO4J_ADDRESS and NEO4J_PORT environment variables if you want graph support"

--- a/docs/EnablePlasoUpload.md
+++ b/docs/EnablePlasoUpload.md
@@ -18,7 +18,7 @@ https://github.com/log2timeline/plaso/wiki/Ubuntu-Packaged-Release
 
     $ sudo apt-get install redis-server
 
-**Configure Timesketch** (/etc/timesketch.conf)
+**Configure Timesketch** (/etc/timesketch/timesketch.conf)
 
     UPLOAD_ENABLED = True
     UPLOAD_FOLDER = u'/path/to/where/timesketch/can/write/files'

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -67,12 +67,13 @@ Then install Timesketch itself:
 
 **Configure Timesketch**
 
-Copy the configuration file to `/etc` and configure it. The file is well commented and it should be pretty straight forward.
+Copy the configuration file to `/etc/timesketch/` and configure it. The file is well commented and it should be pretty straight forward.
 
-    $ sudo cp /usr/local/share/timesketch/timesketch.conf /etc/
-    $ sudo chmod 600 /etc/timesketch.conf
+    $ mkdir /etc/timesketch
+    $ sudo cp /usr/local/share/timesketch/timesketch.conf /etc/timesketch/
+    $ sudo chmod 600 /etc/timesketch/timesketch.conf
 
-Generate a secret key and configure `SECRET_KEY` in `/etc/timesketch.conf`
+Generate a secret key and configure `SECRET_KEY` in `/etc/timesketch/timesketch.conf`
 
     $ openssl rand -base64 32
 

--- a/docs/Users-Guide.md
+++ b/docs/Users-Guide.md
@@ -45,7 +45,7 @@ Parameters:
 
 Example
 ```
-tsctl runserver -c /etc/timesketch.conf
+tsctl runserver -c /etc/timesketch/timesketch.conf
 ```
 
 

--- a/timesketch/__init__.py
+++ b/timesketch/__init__.py
@@ -67,7 +67,14 @@ def create_app(config=None):
     )
 
     if not config:
-        config = '/etc/timesketch.conf'
+        # Where to find the config file
+        default_path = '/etc/timesketch/timesketch.conf'
+        # Fall back to legacy location of the config file
+        legacy_path = '/etc/timesketch.conf'
+        if os.path.isfile(default_path):
+            config = default_path
+        else:
+            config = legacy_path
 
     if isinstance(config, six.text_type):
         os.environ['TIMESKETCH_SETTINGS'] = config

--- a/timesketch/tsctl.py
+++ b/timesketch/tsctl.py
@@ -469,7 +469,7 @@ def main():
         '-c',
         '--config',
         dest='config',
-        default='/etc/timesketch.conf',
+        default='/etc/timesketch/timesketch.conf',
         required=False)
     shell_manager.run()
 


### PR DESCRIPTION
At the moment we have both /etc/timesketch.conf and the dir /etc/timesketch/
This PR moves the config file to the dir, but keeps backward compatibility with old deployments.