### PR TITLE
Always use HTTPS for OIDC redirects

### DIFF
--- a/timesketch/__init__.py
+++ b/timesketch/__init__.py
@@ -99,10 +99,9 @@ def create_app(config=None):
     if app.config['UPLOAD_ENABLED']:
         try:
             from plaso import __version__ as plaso_version
+            app.config['PLASO_VERSION'] = plaso_version
         except ImportError:
             sys.stderr.write('Upload is enabled, but Plaso is not installed.')
-            sys.exit()
-        app.config['PLASO_VERSION'] = plaso_version
 
     # Setup the database.
     configure_engine(app.config['SQLALCHEMY_DATABASE_URI'])

--- a/timesketch/lib/google_auth.py
+++ b/timesketch/lib/google_auth.py
@@ -122,7 +122,11 @@ def get_oauth2_authorize_url(hosted_domain=None):
     """
     csrf_token = _generate_random_token()
     nonce = _generate_random_token()
-    redirect_uri = url_for('user_views.google_openid_connect', _external=True)
+    redirect_uri = url_for(
+        'user_views.google_openid_connect',
+        _scheme='https',
+        _external=True
+    )
     scopes = ('openid', 'email', 'profile')
 
     # Add the generated CSRF token to the client session for later validation.
@@ -160,7 +164,11 @@ def get_encoded_jwt_over_https(code):
     """
 
     discovery_document = get_oauth2_discovery_document()
-    redirect_uri = url_for('user_views.google_openid_connect', _external=True)
+    redirect_uri = url_for(
+        'user_views.google_openid_connect',
+        _scheme='https',
+        _external=True
+    )
     post_data = {
         'code': code,
         'client_id': current_app.config.get('GOOGLE_OIDC_CLIENT_ID'),


### PR DESCRIPTION
This PR makes deployments behind reverse proxies work by enforcing HTTPS with OIDC. It also removes the Plaso requirement for the webserver if Uploads are enabled. This wasy we can have separate web and celery workers.