### PR TITLE
Bug fix: Trailing slash in API urls

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ except ImportError:  # for pip <= 9.0.3
     from pip.req import parse_requirements
 
 
-timesketch_version = '20191220'
+timesketch_version = '20191220-1'
 
 timesketch_description = (
     'Timesketch is a web based tool for collaborative forensic timeline '

--- a/timesketch/frontend/src/utils/RestApiClient.js
+++ b/timesketch/frontend/src/utils/RestApiClient.js
@@ -30,7 +30,7 @@ const RestApiClient = axios.create({
 RestApiClient.interceptors.response.use(function (response) {
   return response;
 }, function (error) {
-  if (error.response.data.message === 'The CSRF token has expired.') {
+  if (error.response.data.message === 'The CSRF token has expired') {
     Snackbar.open({
       message: error.response.data.message,
       type: 'is-white',
@@ -122,7 +122,7 @@ export default {
     return RestApiClient.get('sketches/' + sketchId + '/stories/')
   },
   getStory (sketchId, storyId) {
-    return RestApiClient.get('/sketches/' + sketchId + '/stories/' + storyId)
+    return RestApiClient.get('/sketches/' + sketchId + '/stories/' + storyId + '/')
   },
   createStory (title, content, sketchId) {
     let formData = {
@@ -140,7 +140,7 @@ export default {
   },
   // Saved views
   getView (sketchId, viewId) {
-    return RestApiClient.get('/sketches/' + sketchId + '/views/' + viewId)
+    return RestApiClient.get('/sketches/' + sketchId + '/views/' + viewId + '/')
   },
   createView (sketchId, viewName, queryString, queryFilter) {
     let formData = {
@@ -169,7 +169,7 @@ export default {
     return RestApiClient.post('/upload/', formData, config)
   },
   getSessions (sketchId, timelineIndex) {
-    return RestApiClient.get('/sketches/' + sketchId + '/explore/sessions/' + timelineIndex)
+    return RestApiClient.get('/sketches/' + sketchId + '/explore/sessions/' + timelineIndex + '/')
   },
   getUsers () {
     return RestApiClient.get('/users/')


### PR DESCRIPTION
When run behind a proxy the trailing slash is important so to not redirect to HTTP.