### PR TITLE
Docker install: run from /tmp directory

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -62,6 +62,7 @@ if [ "$1" = 'timesketch' ]; then
   tsctl add_user --username "$TIMESKETCH_USER" --password "$TIMESKETCH_PASSWORD"
 
   # Run the Timesketch server (without SSL)
+  cd /tmp
   exec `bash -c "/usr/local/bin/celery -A timesketch.lib.tasks worker --uid nobody --loglevel info &\
   gunicorn -b 0.0.0.0:80 --access-logfile - --error-logfile - --log-level info --timeout 120 timesketch.wsgi:application"`
 fi


### PR DESCRIPTION
In the Docker installation, make sure the celery worker is running from the `/tmp` directory. This makes sure that `psort` will be able to create its log files.

Fixes https://github.com/google/timesketch/issues/1060 & https://github.com/google/timesketch/issues/870