### PR TITLE
Fix bug: error on import plaso file on docker because tasks.py run psort …

### DIFF
--- a/timesketch/lib/tasks.py
+++ b/timesketch/lib/tasks.py
@@ -410,7 +410,7 @@ def run_plaso(source_file_path, timeline_name, index_name, source_type):
     # Log information to Celery
     message = 'Index timeline [{0:s}] to index [{1:s}] (source: {2:s})'
     logging.info(message.format(timeline_name, index_name, source_type))
-
+    path_tmp = current_app.config.get('UPLOAD_FOLDER')
     try:
         psort_path = current_app.config['PSORT_PATH']
     except KeyError:
@@ -425,9 +425,9 @@ def run_plaso(source_file_path, timeline_name, index_name, source_type):
     try:
         if six.PY3:
             subprocess.check_output(
-                cmd, stderr=subprocess.STDOUT, encoding='utf-8')
+                cmd, cwd=path_tmp, stderr=subprocess.STDOUT, encoding='utf-8')
         else:
-            subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+            subprocess.check_output(cmd, cwd=path_tmp, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
         # Mark the searchindex and timelines as failed and exit the task
         _set_timeline_status(index_name, status='fail', error_msg=e.output)


### PR DESCRIPTION
Fix bug: error on import plaso file on docker because tasks.py run psort from path not writable (cwd)
I used config file informations for cwd (UPLOAD_FOLDER).
Sincerely,
Lionel
log error:
----------
```

Jan 29 10:22:22 172.16.0.4 docker_docker_timesketch2_docker_timesketch_1[42470]: [2020-01-29 09:22:22,769: INFO/ForkPoolWorker-31] Task timesketch.lib.tasks.run_plaso[fe8134f69c054b7e9becf8180cabf26a] succeeded in 4.399268261855468s: '2020-01-29 09:22:21,678 [INFO] (MainProcess) PID:209 <data_location> Determined data location: /usr/share/plaso
Jan 29 10:22:22 172.16.0.4 docker_docker_timesketch2_docker_timesketch_1[42470]: 2020-01-29 09:22:21,820 [INFO] (MainProcess) PID:209 <timesketch_out> Timeline name: testword2
Jan 29 10:22:22 172.16.0.4 docker_docker_timesketch2_docker_timesketch_1[42470]: 2020-01-29 09:22:21,820 [INFO] (MainProcess) PID:209 <timesketch_out> Owner of the timeline: None
Jan 29 10:22:22 172.16.0.4 docker_docker_timesketch2_docker_timesketch_1[42470]: Traceback (most recent call last):
Jan 29 10:22:22 172.16.0.4 docker_docker_timesketch2_docker_timesketch_1[42470]:   File "/usr/bin/psort.py", line 85, in <module>
Jan 29 10:22:22 172.16.0.4 docker_docker_timesketch2_docker_timesketch_1[42470]:     if not Main():
Jan 29 10:22:22 172.16.0.4 docker_docker_timesketch2_docker_timesketch_1[42470]:   File "/usr/bin/psort.py", line 67, in Main
Jan 29 10:22:22 172.16.0.4 docker_docker_timesketch2_docker_timesketch_1[42470]:     tool.ProcessStorage()
Jan 29 10:22:22 172.16.0.4 docker_docker_timesketch2_docker_timesketch_1[42470]:   File "/usr/lib/python3/dist-packages/plaso/cli/psort_tool.py", line 501, in ProcessStorage
Jan 29 10:22:22 172.16.0.4 docker_docker_timesketch2_docker_timesketch_1[42470]:     self._CheckStorageFile(self._storage_file_path)
Jan 29 10:22:22 172.16.0.4 docker_docker_timesketch2_docker_timesketch_1[42470]:   File "/usr/lib/python3/dist-packages/plaso/cli/psort_tool.py", line 115, in _CheckStorageFile
Jan 29 10:22:22 172.16.0.4 docker_docker_timesketch2_docker_timesketch_1[42470]:     logger.warning('Appending to an already existing storage file.')
Jan 29 10:22:22 172.16.0.4 docker_docker_timesketch2_docker_timesketch_1[42470]:   File "/usr/lib/python3.6/logging/__init__.py", line 1320, in warning
Jan 29 10:22:22 172.16.0.4 docker_docker_timesketch2_docker_timesketch_1[42470]:     self._log(WARNING, msg, args, **kwargs)
Jan 29 10:22:22 172.16.0.4 docker_docker_timesketch2_docker_timeskUPLOAD_FOLDERetch_1[42470]:   File "/usr/lib/python3.6/logging/__init__.py", line 1444, in _log
Jan 29 10:22:22 172.16.0.4 docker_docker_timesketch2_docker_timesketch_1[42470]:     self.handle(record)
Jan 29 10:22:22 172.16.0.4 docker_docker_timesketch2_docker_timesketch_1[42470]:   File...'

```
----------