### PR TITLE
Possibility to specify index when uploading data for the timesketch_api_client

### DIFF
--- a/api_client/python/timesketch_api_client/importer.py
+++ b/api_client/python/timesketch_api_client/importer.py
@@ -284,7 +284,7 @@ class ImportStreamer(object):
                     filepath, delimiter=delimiter, chunksize=self._threshold):
                 self.add_data_frame(chunk_frame, part_of_iter=True)
         elif file_ending == 'plaso':
-            self._sketch.upload(self._timeline_name, filepath)
+            self._sketch.upload(self._timeline_name, filepath, self._index)
         elif file_ending == 'jsonl':
             data_frame = None
             with open(filepath, 'r') as fh:
@@ -401,6 +401,10 @@ class ImportStreamer(object):
     def set_timeline_name(self, name):
         """Set the timeline name."""
         self._timeline_name = name
+
+    def set_index_name(self, index):
+        """Set the index name."""
+        self._index = index
 
     def set_timestamp_description(self, description):
         """Set the timestamp description field."""

--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -243,13 +243,15 @@ class Sketch(resource.BaseResource):
         Args:
             timeline_name: Name of the resulting timeline.
             file_path: Path to the file to be uploaded.
+            index: Index name for the ES database
 
         Returns:
             Timeline object instance.
         """
         resource_url = '{0:s}/upload/'.format(self.api.api_root)
         files = {'file': open(file_path, 'rb')}
-        data = {'name': timeline_name, 'sketch_id': self.id, 'index_name': index}
+        data = {'name': timeline_name, 'sketch_id': self.id,
+                'index_name': index}
         response = self.api.session.post(resource_url, files=files, data=data)
         response_dict = response.json()
         timeline_dict = response_dict['objects'][0]

--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -237,7 +237,7 @@ class Sketch(resource.BaseResource):
             timelines.append(timeline_obj)
         return timelines
 
-    def upload(self, timeline_name, file_path):
+    def upload(self, timeline_name, file_path, index=None):
         """Upload a CSV, JSONL, or Plaso file to the server for indexing.
 
         Args:
@@ -249,7 +249,7 @@ class Sketch(resource.BaseResource):
         """
         resource_url = '{0:s}/upload/'.format(self.api.api_root)
         files = {'file': open(file_path, 'rb')}
-        data = {'name': timeline_name, 'sketch_id': self.id}
+        data = {'name': timeline_name, 'sketch_id': self.id, 'index_name': index}
         response = self.api.session.post(resource_url, files=files, data=data)
         response_dict = response.json()
         timeline_dict = response_dict['objects'][0]


### PR DESCRIPTION
Hi,
I have slighty modified the code of the timesketch api client in order to be able to specify an arbitrary index instead of the default uuid.
I kept the default behavior :)

if you find it useful.