### PR TITLE
Fixing a minor issue if context is empty and some linter fixes

### DIFF
--- a/test_tools/timesketch/lib/analyzers/interface.py
+++ b/test_tools/timesketch/lib/analyzers/interface.py
@@ -103,7 +103,7 @@ class AnalyzerContext(object):
         Args:
               event: instance of Event.
         """
-        if not event.event_id in self.event_cache:
+        if event.event_id not in self.event_cache:
             self.event_cache[event.event_id] = event
 
     def add_query(
@@ -130,7 +130,7 @@ class AnalyzerContext(object):
         Args:
               event: instance of Event.
         """
-        if not event.event_id in self.event_cache:
+        if event.event_id not in self.event_cache:
             raise ValueError('Event {0:s} not in cache.'.format(event.event_id))
         del self.event_cache[event.event_id]
 
@@ -140,7 +140,7 @@ class AnalyzerContext(object):
         Args:
               event: instance of Event.
         """
-        if not event.event_id in self.event_cache:
+        if event.event_id not in self.event_cache:
             self.add_event(event)
             return
         self.event_cache[event.event_id] = event

--- a/test_tools/timesketch/lib/analyzers/interface.py
+++ b/test_tools/timesketch/lib/analyzers/interface.py
@@ -428,6 +428,7 @@ class BaseIndexAnalyzer(object):
 
     Attributes:
         name: Analyzer name.
+        index_name: Mocked index name.
         sketch: Instance of Sketch object.
     """
 
@@ -449,6 +450,7 @@ class BaseIndexAnalyzer(object):
             file_name: the file path to the test event file.
         """
         self.datastore = None
+        self.index_name = 'mocked_index'
         self.name = self.NAME
         if not os.path.isfile(file_name):
             raise IOError(

--- a/test_tools/timesketch/lib/analyzers/utils.py
+++ b/test_tools/timesketch/lib/analyzers/utils.py
@@ -229,12 +229,13 @@ def get_events_from_data_frame(frame, datastore):
     """
     context = datastore if isinstance(
         datastore, interface.AnalyzerContext) else None
+    sketch = context.sketch if context else None
 
     for row in frame.iterrows():
         _, entry = row
         # pylint: disable-msg=unexpected-keyword-arg
         event = interface.Event(
-            entry, sketch=context.sketch, context=context, datastore=None)
+            entry, sketch=sketch, context=context, datastore=None)
         if context:
             context.add_event(event)
         yield event


### PR DESCRIPTION
Minor issue if the context is empty in the mocked utils.py library. Then there is no `context.sketch`. 

There are also some minor linter issues in few other places