### PR TITLE
Elasticsearch 7.x support

### DIFF
--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - ../../:/usr/local/src/timesketch/
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.4.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.6.0
     restart: always
     environment:
       - discovery.type=single-node

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     # uncomment the following lines to control JVM memory utilization
     # in smaller deployments with minimal resources
     #  - ES_JAVA_OPTS= -Xms1g -Xmx1g # 1G min/1G max
-    image: elasticsearch:6.4.2
+    image: elasticsearch:7.6.0
     ports:
       - "9200:9200"
       - "9300:9300"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ altair==3.3.0  # Note: Last version to support py2
 celery==4.4.0
 cryptography==2.3
 datasketch==1.5.0
-elasticsearch==6.3.1
+elasticsearch==7.5.1
 Flask==1.1.1
 flask_bcrypt==0.7.1
 flask_login==0.4.1

--- a/timesketch/api/v1/resources.py
+++ b/timesketch/api/v1/resources.py
@@ -419,7 +419,7 @@ class SketchResource(ResourceMixin, Resource):
 
         mappings = []
 
-        for index_name, value in mappings_settings.items():
+        for _, value in mappings_settings.items():
             # The structure is different in ES version 6.x and lower. This check
             # makes sure we support both old and new versions.
             properties = value['mappings'].get('properties')
@@ -1606,6 +1606,7 @@ class UploadFileResource(ResourceMixin, Resource):
         enable_stream = form.enable_stream.data
         # Start Celery pipeline for indexing and analysis.
         # Import here to avoid circular imports.
+        # pylint: disable=import-outside-toplevel
         from timesketch.lib import tasks
         pipeline = tasks.build_index_pipeline(
             file_path, timeline_name, index_name, file_extension, sketch_id,
@@ -1625,6 +1626,7 @@ class UploadFileResource(ResourceMixin, Resource):
 class TaskResource(ResourceMixin, Resource):
     """Resource to get information on celery task."""
 
+    # pylint: disable=import-outside-toplevel
     def __init__(self):
         super(TaskResource, self).__init__()
         from timesketch import create_celery_app
@@ -2017,6 +2019,7 @@ class AnalyzerRunResource(ResourceMixin, Resource):
                     'Kwargs needs to be a dictionary of parameters.')
 
         # Import here to avoid circular imports.
+        # pylint: disable=import-outside-toplevel
         from timesketch.lib import tasks
         try:
             analyzer_group, session_id = tasks.build_sketch_analysis_pipeline(
@@ -2100,6 +2103,7 @@ class TimelineListResource(ResourceMixin, Resource):
 
         # Run sketch analyzers when timeline is added. Import here to avoid
         # circular imports.
+        # pylint: disable=import-outside-toplevel
         if current_app.config.get('AUTO_SKETCH_ANALYZERS'):
             from timesketch.lib import tasks
             sketch_analyzer_group, _ = tasks.build_sketch_analysis_pipeline(

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -331,8 +331,8 @@ class ElasticsearchDataStore(object):
                 search_type=search_type,
                 scroll=scroll_timeout)
 
+        # pylint: disable=unexpected-keyword-arg
         if self.version.startswith('6'):
-            # pylint: disable=unexpected-keyword-arg
             _search_result = self.client.search(
                 body=query_dsl,
                 index=list(indices),
@@ -340,7 +340,6 @@ class ElasticsearchDataStore(object):
                 _source_include=return_fields,
                 scroll=scroll_timeout)
         else:
-            # pylint: disable=unexpected-keyword-arg
             _search_result = self.client.search(
                 body=query_dsl,
                 index=list(indices),

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -331,6 +331,8 @@ class ElasticsearchDataStore(object):
                 search_type=search_type,
                 scroll=scroll_timeout)
 
+        # The argument " _source_include" changed to "_source_includes" in
+        # ES version 7. This check add support for both version 6 and 7 clients.
         # pylint: disable=unexpected-keyword-arg
         if self.version.startswith('6'):
             _search_result = self.client.search(

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -332,6 +332,7 @@ class ElasticsearchDataStore(object):
                 scroll=scroll_timeout)
 
         if self.version.startswith('6'):
+            # pylint: disable=unexpected-keyword-arg
             _search_result = self.client.search(
                 body=query_dsl,
                 index=list(indices),
@@ -339,6 +340,7 @@ class ElasticsearchDataStore(object):
                 _source_include=return_fields,
                 scroll=scroll_timeout)
         else:
+            # pylint: disable=unexpected-keyword-arg
             _search_result = self.client.search(
                 body=query_dsl,
                 index=list(indices),
@@ -346,9 +348,6 @@ class ElasticsearchDataStore(object):
                 _source_includes=return_fields,
                 scroll=scroll_timeout)
 
-        # Suppress the lint error because elasticsearch-py adds parameters
-        # to the function with a decorator and this makes pylint sad.
-        # pylint: disable=unexpected-keyword-arg
         return _search_result
 
     def search_stream(self, sketch_id=None, query_string=None,

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -331,15 +331,25 @@ class ElasticsearchDataStore(object):
                 search_type=search_type,
                 scroll=scroll_timeout)
 
+        if self.version.startswith('6'):
+            _search_result = self.client.search(
+                body=query_dsl,
+                index=list(indices),
+                search_type=search_type,
+                _source_include=return_fields,
+                scroll=scroll_timeout)
+        else:
+            _search_result = self.client.search(
+                body=query_dsl,
+                index=list(indices),
+                search_type=search_type,
+                _source_includes=return_fields,
+                scroll=scroll_timeout)
+
         # Suppress the lint error because elasticsearch-py adds parameters
         # to the function with a decorator and this makes pylint sad.
         # pylint: disable=unexpected-keyword-arg
-        return self.client.search(
-            body=query_dsl,
-            index=list(indices),
-            search_type=search_type,
-            _source_include=return_fields,
-            scroll=scroll_timeout)
+        return _search_result
 
     def search_stream(self, sketch_id=None, query_string=None,
                       query_filter=None, query_dsl=None, indices=None,
@@ -378,6 +388,11 @@ class ElasticsearchDataStore(object):
         scroll_id = result['_scroll_id']
         scroll_size = result['hits']['total']
 
+        # Elasticsearch version 7.x returns total hits as a dictionary.
+        # TODO: Refactor when version 6.x has been deprecated.
+        if isinstance(scroll_size, dict):
+            scroll_size = scroll_size.get('value', 0)
+
         for event in result['hits']['hits']:
             yield event
 
@@ -403,11 +418,21 @@ class ElasticsearchDataStore(object):
             # Suppress the lint error because elasticsearch-py adds parameters
             # to the function with a decorator and this makes pylint sad.
             # pylint: disable=unexpected-keyword-arg
-            return self.client.get(
-                index=searchindex_id,
-                id=event_id,
-                doc_type='_all',
-                _source_exclude=['timesketch_label'])
+            if self.version.startswith('6'):
+                event = self.client.get(
+                    index=searchindex_id,
+                    id=event_id,
+                    doc_type='_all',
+                    _source_exclude=['timesketch_label'])
+            else:
+                event = self.client.get(
+                    index=searchindex_id,
+                    id=event_id,
+                    doc_type='_all',
+                    _source_excludes=['timesketch_label'])
+
+            return event
+
         except NotFoundError:
             abort(HTTP_STATUS_CODE_NOT_FOUND)
 
@@ -500,14 +525,18 @@ class ElasticsearchDataStore(object):
             Document type in string format.
         """
         _document_mapping = {
-            doc_type: {
-                'properties': {
-                    'timesketch_label': {
-                        'type': 'nested'
-                    }
+            'properties': {
+                'timesketch_label': {
+                    'type': 'nested'
+                },
+                'datetime': {
+                    'type': 'date'
                 }
             }
         }
+
+        if self.version.startswith('6'):
+            _document_mapping = {doc_type: _document_mapping}
 
         if not self.client.indices.exists(index_name):
             try:
@@ -565,16 +594,19 @@ class ElasticsearchDataStore(object):
             header = {
                 'index': {
                     '_index': index_name,
-                    '_type': event_type
                 }
             }
             update_header = {
                 'update': {
                     '_index': index_name,
-                    '_type': event_type,
                     '_id': event_id
                 }
             }
+
+            # TODO: Remove when we deprecate Elasticsearch version 6.x
+            if self.version.startswith('6'):
+                header['index']['_type'] = event_type
+                update_header['update']['_type'] = event_type
 
             if event_id:
                 # Event has "lang" defined if there is a script used for import.

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -535,6 +535,7 @@ class ElasticsearchDataStore(object):
             }
         }
 
+        # TODO: Remove when we deprecate Elasticsearch version 6.x
         if self.version.startswith('6'):
             _document_mapping = {doc_type: _document_mapping}
 

--- a/timesketch/lib/tasks.py
+++ b/timesketch/lib/tasks.py
@@ -26,6 +26,7 @@ from celery import chain
 from celery import signals
 from flask import current_app
 from sqlalchemy import create_engine
+from elasticsearch.exceptions import RequestError
 
 from timesketch import create_celery_app
 from timesketch.lib.analyzers import manager
@@ -477,7 +478,8 @@ def run_csv_jsonl(source_file_path, timeline_name, index_name, source_type):
         # Import the remaining events
         es.flush_queued_events()
 
-    except (RuntimeError, ImportError, NameError, UnboundLocalError) as e:
+    except (RuntimeError, ImportError, NameError, UnboundLocalError,
+            RequestError) as e:
         _set_timeline_status(index_name, status='fail', error_msg=str(e))
         raise
 


### PR DESCRIPTION
Due to some breaking changes in Elasticsearch 7.x we need to add logic to support both 6 and 7.
https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html