### PR TITLE
Fix start of Elasticsearch

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -29,6 +29,7 @@ services:
 
     environment:
       - TAKE_FILE_OWNERSHIP=1
+      - discovery.type=single-node
     # uncomment the following lines to control JVM memory utilization
     # in smaller deployments with minimal resources
     #  - ES_JAVA_OPTS= -Xms1g -Xmx1g # 1G min/1G max


### PR DESCRIPTION
Run Elasticsearch as a single node. Documented at https://hub.docker.com/_/elasticsearch .

Without this fix, Elasticsearch does not find other nodes and restarts itself forever.