### PR TITLE
debian package manager tweaks

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,9 @@ FROM ubuntu:18.04
 RUN apt-get update && apt-get -y upgrade && apt-get -y dist-upgrade
 
 # Setup install environment and Timesketch dependencies
-RUN apt-get -y install apt-transport-https \
+RUN apt-get --no-install-recommends -y install apt-transport-https \
+                       apt-utils \
+                       ca-certificates \
                        git \
                        libffi-dev \
                        lsb-release \
@@ -14,9 +16,9 @@ RUN apt-get -y install apt-transport-https \
                        python3-psycopg2
 
 # Install Plaso, nodejs and yarn.
-RUN apt-get -y install software-properties-common
+RUN apt-get --no-install-recommends -y install software-properties-common
 RUN add-apt-repository ppa:gift/stable && apt-get update
-RUN apt-get update && apt-get -y install plaso-tools
+RUN apt-get update && apt-get --no-install-recommends -y install plaso-tools
 
 # Use Python 3 pip (pip3) to install Timesketch
 RUN pip3 install timesketch

--- a/docker/factory/development/Dockerfile
+++ b/docker/factory/development/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     software-properties-common \
     apt-transport-https \
     apt-utils \
+    ca-certificates \
     curl \
     git \
     gpg-agent \


### PR DESCRIPTION
Major Changes No 1 : debian package manager tweaks

By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages . 

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Major Changes No 2 : added packages apt-utils ca-certificates

Because build is 

1.  Slow and in log it is showing because "apt-utils" not installed 

2. to avoid build to exits with error without having certificate in wget,curl or git.