### PR TITLE
Adding a logger to sketch.explore as well as a cleanup of "filter" in sketch API

### DIFF
--- a/api_client/python/setup.py
+++ b/api_client/python/setup.py
@@ -24,7 +24,7 @@ from setuptools import setup
 
 setup(
     name='timesketch-api-client',
-    version='20200305',
+    version='20200306',
     description='Timesketch API client',
     license='Apache License, Version 2.0',
     url='http://www.timesketch.org/',

--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -404,9 +404,9 @@ class Sketch(resource.BaseResource):
         total_elastic_count = response_json.get(
             'meta', {}).get('es_total_count', 0)
         if total_elastic_count != total_count:
-          logger.info(
-              '{0:d} results were returned, but {1:d} records matched the '
-              'search query'.format(total_count, total_elastic_count))
+            logger.info(
+                '{0:d} results were returned, but {1:d} records matched the '
+                'search query'.format(total_count, total_elastic_count))
 
         if as_pandas:
             return self._build_pandas_dataframe(response_json, return_fields)

--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -14,6 +14,7 @@
 """Timesketch API client library."""
 from __future__ import unicode_literals
 
+import os
 import json
 import logging
 
@@ -400,11 +401,12 @@ class Sketch(resource.BaseResource):
             added_time = more_meta.get('es_time', 0)
             response_json['meta']['es_time'] += added_time
 
-        total_elastic_count = response_json.get('es_total_count', 0)
+        total_elastic_count = response_json.get(
+            'meta', {}).get('es_total_count', 0)
         if total_elastic_count != total_count:
-            logger.info('{0:>30s}: {1:d}\n{2:>30s}: {3:d}'.format(
-                'Total results from search', total_elastic_count,
-                'Total results returned', total_count))
+          logger.info(
+              '{0:d} results were returned, but {1:d} records matched the '
+              'search query'.format(total_count, total_elastic_count))
 
         if as_pandas:
             return self._build_pandas_dataframe(response_json, return_fields)

--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -15,6 +15,7 @@
 from __future__ import unicode_literals
 
 import json
+import logging
 
 import pandas
 
@@ -24,6 +25,11 @@ from . import error
 from . import resource
 from . import timeline
 from . import view as view_lib
+
+
+logging.basicConfig(level=os.environ.get('LOGLEVEL', 'INFO'))
+logger = logging.getLogger('sketch_api')
+
 
 class Sketch(resource.BaseResource):
     """Timesketch sketch object.
@@ -393,6 +399,12 @@ class Sketch(resource.BaseResource):
             more_meta = more_response_json.get('meta', {})
             added_time = more_meta.get('es_time', 0)
             response_json['meta']['es_time'] += added_time
+
+        total_elastic_count = response_json.get('es_total_count', 0)
+        if total_elastic_count != total_count:
+            logger.info('{0:>30s}: {1:d}\n{2:>30s}: {3:d}'.format(
+                'Total results from search', total_elastic_count,
+                'Total results returned', total_count))
 
         if as_pandas:
             return self._build_pandas_dataframe(response_json, return_fields)

--- a/timesketch/api/v1/resources.py
+++ b/timesketch/api/v1/resources.py
@@ -781,7 +781,7 @@ class ExploreResource(ResourceMixin, Resource):
         enable_scroll = form.enable_scroll.data
         scroll_id = form.scroll_id.data
 
-        query_filter = request.json.get('filter', [])
+        query_filter = request.json.get('filter', {})
 
         return_field_string = form.fields.data
         if return_field_string:


### PR DESCRIPTION
This PR adds few things:
+ Increments API client version
+ Adds a logger to the sketch API, and logs a mismatch between events returned vs. events that matched the search query (makes it possible to adjust your search query to get more results)
+ Makes `query_filter` default to a dict, as the correct behavior is.