### PR TITLE
Changed how message string is constructed

### DIFF
--- a/api_client/python/setup.py
+++ b/api_client/python/setup.py
@@ -24,7 +24,7 @@ from setuptools import setup
 
 setup(
     name='timesketch-api-client',
-    version='20200306',
+    version='20200310',
     description='Timesketch API client',
     license='Apache License, Version 2.0',
     url='http://www.timesketch.org/',

--- a/api_client/python/timesketch_api_client/importer.py
+++ b/api_client/python/timesketch_api_client/importer.py
@@ -21,13 +21,13 @@ import json
 import logging
 import math
 import os
-import six
 import string
 import time
 import uuid
 
-import pandas
 import dateutil.parser
+import pandas
+import six
 
 from . import timeline
 from . import definitions


### PR DESCRIPTION
Changed how the message string is constructed, moving away from an `apply` method which is slow to a more optimal string concatenation method.

Quick timeit test on old. vs. new code

+ old:      **144.56 sec**
+ new:        **8.68 sec**

(tests running on a chromebook, using a dataframe with 634.605 lines and a format message string that is built using content of three columns as well as extra text)