### PR TITLE
Adding support for working with stories from the API client, as well as adding aggregation support in the backend

### DIFF
--- a/api_client/python/setup.py
+++ b/api_client/python/setup.py
@@ -24,7 +24,7 @@ from setuptools import setup
 
 setup(
     name='timesketch-api-client',
-    version='20200311',
+    version='20200312',
     description='Timesketch API client',
     license='Apache License, Version 2.0',
     url='http://www.timesketch.org/',

--- a/api_client/python/timesketch_api_client/aggregation.py
+++ b/api_client/python/timesketch_api_client/aggregation.py
@@ -35,8 +35,7 @@ class Aggregation(resource.BaseResource):
         view: a view ID if the aggregation is tied to a specific view.
     """
 
-    def __init__(
-            self, sketch, api):
+    def __init__(self, sketch, api):
         self._sketch = sketch
         self._aggregator_data = {}
         self._parameters = {}

--- a/api_client/python/timesketch_api_client/client.py
+++ b/api_client/python/timesketch_api_client/client.py
@@ -15,6 +15,8 @@
 from __future__ import unicode_literals
 
 import os
+import json
+import logging
 import uuid
 
 # pylint: disable=wrong-import-order
@@ -33,6 +35,9 @@ from . import definitions
 from . import error
 from . import index
 from . import sketch
+
+
+logger = logging.getLogger('client_api')
 
 
 class TimesketchApi(object):
@@ -270,10 +275,16 @@ class TimesketchApi(object):
         Returns:
             Dictionary with the response data.
         """
-        # TODO: Catch HTTP errors and add descriptive message string.
         resource_url = '{0:s}/{1:s}'.format(self.api_root, resource_uri)
         response = self.session.get(resource_url)
-        return response.json()
+        try:
+            return response.json()
+        except json.JSONDecodeError as e:
+            logger.error(
+                'Error fetching resources: [{0:d}] {1!s} {2!s}, error: '
+                '{3!s}'.format(
+                    response.status_code, response.reason, response.text, e))
+        return {}
 
     def create_sketch(self, name, description=None):
         """Create a new sketch.
@@ -362,7 +373,7 @@ class TimesketchApi(object):
         return pandas.DataFrame(lines)
 
     def list_sketches(self):
-        """Get list of all open sketches that the user has access to.
+        """Get a list of all open sketches that the user has access to.
 
         Returns:
             List of Sketch objects instances.

--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -166,7 +166,7 @@ class Sketch(resource.BaseResource):
         story_dict = response_json.get('objects', [{}])[0]
         return story.Story(
             story_id=story_dict.get('id', -1),
-            sketch_id=self.id,
+            sketch=self,
             api=self.api)
 
     def list_aggregations(self):
@@ -250,7 +250,7 @@ class Sketch(resource.BaseResource):
         for story_dict in stories:
             story_list.append(story.Story(
                 story_id=story_dict.get('id', -1),
-                sketch_id=self.id,
+                sketch=self,
                 api=self.api))
         return story_list
 

--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -211,14 +211,38 @@ class Sketch(resource.BaseResource):
                 return aggregation_obj
         return None
 
+    def get_story(self, story_id=None, story_title=None):
+        """Returns a story object that is stored in the sketch.
+
+        Args:
+            story_id: an integer indicating the ID of the story to
+                be fetched. Defaults to None.
+            story_title: a string with the title of the story. Optional
+                and defaults to None.
+
+        Returns:
+            A story object (instance of Story) if one is found. Returns
+            a None if neiter story_id or story_title is defined or if
+            the view does not exist.
+        """
+        if story_id is None and story_title is None:
+            return None
+
+        for story in self.list_stories():
+            if story_id and story_id == story.id:
+                return story
+            if story_title and story_title.lower() == story.title.lower():
+                return story
+        return None
+
     def get_view(self, view_id=None, view_name=None):
         """Returns a view object that is stored in the sketch.
 
         Args:
-            view_name: a string with the name of the view. Optional
-                and defaults to None.
             view_id: an integer indicating the ID of the view to
                 be fetched. Defaults to None.
+            view_name: a string with the name of the view. Optional
+                and defaults to None.
 
         Returns:
             A view object (instance of View) if one is found. Returns

--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -165,7 +165,7 @@ class Sketch(resource.BaseResource):
         response_json = response.json()
         story_dict = response_json.get('objects', [{}])[0]
         return story.Story(
-            story_id=story_dict.get('id', -1),
+            story_id=story_dict.get('id', 0),
             sketch=self,
             api=self.api)
 
@@ -223,7 +223,9 @@ class Sketch(resource.BaseResource):
         Returns:
             A story object (instance of Story) if one is found. Returns
             a None if neiter story_id or story_title is defined or if
-            the view does not exist.
+            the view does not exist. If a story title is defined and
+            not a story id, the first story that is found with the same
+            title will be returned.
         """
         if story_id is None and story_title is None:
             return None

--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -24,6 +24,7 @@ from . import aggregation
 from . import definitions
 from . import error
 from . import resource
+from . import story
 from . import timeline
 from . import view as view_lib
 
@@ -143,6 +144,31 @@ class Sketch(resource.BaseResource):
 
         return data_frame
 
+    def create_story(self, title):
+        """Create a story object.
+
+        Args:
+            title: the title of the story.
+
+        Returns:
+            A story object (instance of Story) for the newly
+            created story.
+        """
+        resource_url = '{0:s}/sketches/{1:d}/stories/'.format(
+            self.api.api_root, self.id)
+        data = {
+            'title': title,
+            'content': ''
+        }
+
+        response = self.api.session.post(resource_url, json=data)
+        response_json = response.json()
+        story_dict = response_json.get('objects', [{}])[0]
+        return story.Story(
+            story_id=story_dict.get('id', -1),
+            sketch_id=self.id,
+            api=self.api)
+
     def list_aggregations(self):
         """List all saved aggregations for this sketch.
 
@@ -208,6 +234,25 @@ class Sketch(resource.BaseResource):
             if view_name and view_name.lower() == view.name.lower():
                 return view
         return None
+
+    def list_stories(self):
+        """Get a list of all stories that are attached to the sketch.
+
+        Returns:
+            List of stories (instances of Story objects)
+        """
+        story_list = []
+        resource_url = '{0:s}/sketches/{1:d}/stories/'.format(
+            self.api.api_root, self.id)
+        response = self.api.session.get(resource_url)
+        response_json = response.json()
+        stories = response_json.get('objects', [[]])[0]
+        for story_dict in stories:
+            story_list.append(story.Story(
+                story_id=story_dict.get('id', -1),
+                sketch_id=self.id,
+                api=self.api))
+        return story_list
 
     def list_views(self):
         """List all saved views for this sketch.

--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -228,11 +228,11 @@ class Sketch(resource.BaseResource):
         if story_id is None and story_title is None:
             return None
 
-        for story in self.list_stories():
-            if story_id and story_id == story.id:
-                return story
-            if story_title and story_title.lower() == story.title.lower():
-                return story
+        for story_obj in self.list_stories():
+            if story_id and story_id == story_obj.id:
+                return story_obj
+            if story_title and story_title.lower() == story_obj.title.lower():
+                return story_obj
         return None
 
     def get_view(self, view_id=None, view_name=None):

--- a/api_client/python/timesketch_api_client/story.py
+++ b/api_client/python/timesketch_api_client/story.py
@@ -18,6 +18,189 @@ import json
 
 from . import definitions
 from . import resource
+from . import view
+
+
+class BaseBlock(object):
+    """Base block object."""
+
+    # A string representation of the type of block.
+    TYPE = ''
+
+    def __init__(self, story, index):
+        """Initialize the base block."""
+        self.index = index
+        self._story = story
+
+        self._data = None
+
+    @property
+    def data(self):
+        """Returns the building block."""
+        return self.to_dict()
+
+    @data.setter
+    def data(self, data):
+        """Feeds data to the block."""
+        self._data = data
+
+    @property
+    def json(self):
+        """Returns the building block."""
+        return self.to_dict()
+
+    def _get_base(self):
+        """Returns a base building block."""
+        return {
+            'componentName': '',
+            'componentProps': {},
+            'content': '',
+            'edit': False,
+            'showPanel': False,
+            'isActive': False
+        }
+
+    def delete(self):
+        """Remove block from index."""
+        self._story.remove_block(self.index)
+
+    def feed(self, data):
+        """Feed data into the block."""
+        self._data = data
+
+    def from_dict(self, data_dict):
+        """Feed a block from a block dict."""
+        raise NotImplementedError
+
+    def move_down(self):
+        """Moves a block down one location in the index."""
+        self._story.move_to(self, self.index+1)
+
+    def move_up(self):
+        """Moves a block up one location in the index."""
+        self._story.move_to(self, self.index-1)
+
+    def to_dict(self):
+        """Returns a dict with the block data.
+
+        Raises:
+            ValueError: if the block has not been fed with data.
+            TypeError: if the data that was fed is of the wrong type.
+
+        Returns:
+            A dict with the block data.
+        """
+        raise NotImplementedError
+
+    def reset(self):
+        """Resets the data in the block."""
+        self._data = None
+
+
+class ViewBlock(BaseBlock):
+    """Block object for views."""
+
+    TYPE = 'view'
+
+    def __init__(self, story, index):
+        super(ViewBlock, self).__init__(story, index)
+        self._view_id = 0
+        self._view_name = ''
+
+    @property
+    def view(self):
+        """Returns the view."""
+        return self._data
+
+    @property
+    def view_id(self):
+        """Returns the view ID."""
+        if self._data and hasattr(self._data, 'id'):
+            return self._data.id
+        return self._view_id
+
+    @property
+    def view_name(self):
+        """Returns the view name."""
+        if self._data and hasattr(self._data, 'name'):
+            return self._data.name
+        return self._view_name
+
+    def from_dict(self, data_dict):
+        """Feed a block from a block dict."""
+        props = data_dict.get('componentProps', {})
+        view_dict = props.get('view')
+        if not view_dict:
+            raise TypeError('View not defined')
+
+        self._view_id = view_dict.get('id', 0)
+        self._view_name = view_dict.get('name', '')
+
+    def to_dict(self):
+        """Returns a dict with the block data.
+
+        Raises:
+            ValueError: if the block has not been fed with data.
+            TypeError: if the data that was fed is of the wrong type.
+
+        Returns:
+            A dict with the block data.
+        """
+        if not self._data:
+            raise ValueError('No data has been fed to the block.')
+
+        view_obj = self._data
+        if not hasattr(view_obj, 'id'):
+            raise TypeError('View object is not correctly formed.')
+
+        if not hasattr(view_obj, 'name'):
+            raise TypeError('View object is not correctly formed.')
+
+        view_block = self._get_base()
+        view_block['componentName'] = 'TsViewEventList'
+        view_block['componentProps']['view'] = {
+            'id': view_obj.id, 'name': view_obj.name}
+
+        return view_block
+
+
+class TextBlock(BaseBlock):
+    """Block object for text."""
+
+    TYPE = 'text'
+
+    @property
+    def text(self):
+        """Returns the text."""
+        if not self._data:
+            return ''
+        return self._data
+
+    def from_dict(self, data_dict):
+        """Feed a block from a block dict."""
+        text = data_dict.get('content', '')
+        self.feed(text)
+
+    def to_dict(self):
+        """Returns a dict with the block data.
+
+        Raises:
+            ValueError: if the block has not been fed with data.
+            TypeError: if the data that was fed is of the wrong type.
+
+        Returns:
+            A dict with the block data.
+        """
+        if not self._data:
+            raise ValueError('No data has been fed to the block.')
+
+        if not isinstance(self._data, str):
+            raise TypeError('Data to a text block needs to be a string.')
+
+        text_block = self._get_base()
+        text_block['content'] = self._data
+
+        return text_block
 
 
 class Story(resource.BaseResource):
@@ -27,21 +210,48 @@ class Story(resource.BaseResource):
         id: Primary key of the story.
     """
 
-    def __init__(self, story_id, sketch_id, api):
+    def __init__(self, story_id, sketch, api):
         """Initializes the Story object.
 
         Args:
             story_id: The primary key ID of the story.
-            sketch_id: ID of a sketch.
+            sketch: The sketch object (instance of Sketch).
             api: Instance of a TimesketchApi object.
         """
         self.id = story_id
+        self._api = api
         self._title = ''
-        self._content = ''
+        self._blocks = []
+        self._sketch = sketch
 
         resource_uri = 'sketches/{0:d}/stories/{1:d}/'.format(
-            sketch_id, self.id)
+            sketch.id, self.id)
         super(Story, self).__init__(api, resource_uri)
+
+    @property
+    def blocks(self):
+        """Returns all the blocks of the story."""
+        if not self._blocks:
+            story_data = self.lazyload_data()
+            objects = story_data.get('objects')
+            content = ''
+            if objects:
+                content = objects[0].get('content', [])
+            index = 0
+            for content_block in json.loads(content):
+                if content_block.get('content'):
+                    block = TextBlock(self, index)
+                    block.from_dict(content_block)
+                else:
+                    block = ViewBlock(self, index)
+                    block.from_dict(content_block)
+                    view_obj = view.View(
+                        block.view_id, block.view_name, self._sketch.id,
+                        self._api)
+                    block.feed(view_obj)
+                self._blocks.append(block)
+                index += 1
+        return self._blocks
 
     @property
     def title(self):
@@ -64,28 +274,32 @@ class Story(resource.BaseResource):
         Returns:
             Story content as a list of blocks.
         """
-        if not self._content:
-            story = self.lazyload_data()
-            objects = story.get('objects')
-            if objects:
-                self._content = objects[0].get('content', [])
-        return self._content
+        content_list = [x.to_dict() for x in self.blocks]
+        return json.dumps(content_list)
 
-    def _add_block(self, block):
+    @property
+    def size(self):
+        """Retiurns the number of blocks stored in the story."""
+        return len(self._blocks)
+
+    def __len__(self):
+        """Returns the number of blocks stored in the story."""
+        return len(self._blocks)
+
+    def _add_block(self, block, index):
         """Adds a block to the story's content."""
+        self._blocks.insert(index, block)
+        self._commit()
         self.refresh()
-        content = self.content
-        if content:
-            content_list = json.loads(content)
-        else:
-            content_list = []
 
-        content_list.append(block)
-        self._content = json.dumps(content_list)
+    def _commit(self):
+        """Commit the story to the server."""
+        content_list = [x.to_dict() for x in self._blocks]
+        content = json.dumps(content_list)
 
         data = {
             'title': self.title,
-            'content': self._content,
+            'content': content,
         }
         response = self.api.session.post(
             '{0:s}/{1:s}'.format(self.api.api_root, self.resource_uri),
@@ -93,36 +307,33 @@ class Story(resource.BaseResource):
 
         return response.status_code in definitions.HTTP_STATUS_CODE_20X
 
-    def _create_new_block(self):
-        """Returns a new block dict."""
-        return {
-            'componentName': '',
-            'componentProps': {},
-            'content': '',
-            'edit': False,
-            'showPanel': False,
-            'isActive': False
-        }
-
-    def add_text(self, text):
+    def add_text(self, text, index=-1):
         """Adds a text block to the story.
 
         Args:
             text: the string to add to the story.
+            index: an integer, if supplied determines where the new
+                block will be added. If not supplied it will be
+                appended at the end.
 
         Returns:
             Boolean that indicates whether block was successfully added.
         """
-        text_block = self._create_new_block()
-        text_block['content'] = text
+        if index == -1:
+            index = len(self._blocks)
+        text_block = TextBlock(self, index)
+        text_block.feed(text)
 
-        return self._add_block(text_block)
+        return self._add_block(text_block, index)
 
-    def add_view(self, view):
+    def add_view(self, view_obj, index=-1):
         """Add a view to the story.
 
         Args:
-            view: a view object (instance of view.View)
+            view_obj: a view object (instance of view.View)
+            index: an integer, if supplied determines where the new
+                block will be added. If not supplied it will be
+                appended at the end.
 
         Returns:
             Boolean that indicates whether block was successfully added.
@@ -130,18 +341,19 @@ class Story(resource.BaseResource):
         Raises:
             TypeError: if the view object is not of the correct type.
         """
-        if not hasattr(view, 'id'):
+        if not hasattr(view_obj, 'id'):
             raise TypeError('View object is not correctly formed.')
 
-        if not hasattr(view, 'name'):
+        if not hasattr(view_obj, 'name'):
             raise TypeError('View object is not correctly formed.')
 
-        view_block = self._create_new_block()
-        view_block['componentName'] = 'TsViewEventList'
-        view_block['componentProps']['view'] = {
-            'id': view.id, 'name': view.name}
+        if index == -1:
+            index = len(self._blocks)
 
-        return self._add_block(view_block)
+        view_block = ViewBlock(self, index)
+        view_block.feed(view_obj)
+
+        return self._add_block(view_block, index)
 
     def delete(self):
         """Delete the story from the sketch.
@@ -154,8 +366,39 @@ class Story(resource.BaseResource):
 
         return response.status_code in definitions.HTTP_STATUS_CODE_20X
 
+    def move_to(self, block, new_index):
+        """Moves a block from one index to another."""
+        if new_index < 0:
+            return
+        old_index = block.index
+        old_block = self._blocks.pop(old_index)
+        if old_block.data != block.data:
+            raise ValueError('Block is not correctly set.')
+        self._blocks.insert(new_index, block)
+        self._commit()
+
+    def remove_block(self, index):
+        """Removes a block from the story."""
+        _ = self._blocks.pop(index)
+        self._commit()
+        self.refresh()
+
     def refresh(self):
         """Refresh story content."""
         self._title = ''
-        self._content = ''
+        self._blocks = []
         _ = self.lazyload_data(refresh_cache=True)
+        _ = self.blocks
+
+    def to_string(self):
+        """Returns a string with the content of all the story."""
+        self.refresh()
+        string_list = []
+        for block in self.blocks:
+            if block.TYPE == 'text':
+                string_list.append(block.text)
+            elif block.TYPE == 'view':
+                data_frame = self._sketch.explore(
+                    view=block.view, as_pandas=True)
+                string_list.append(data_frame.to_string(index=False))
+        return '\n'.join(string_list)

--- a/api_client/python/timesketch_api_client/story.py
+++ b/api_client/python/timesketch_api_client/story.py
@@ -406,4 +406,4 @@ class Story(resource.BaseResource):
                 data_frame = self._sketch.explore(
                     view=block.view, as_pandas=True)
                 string_list.append(data_frame.to_string(index=False))
-        return '\n'.join(string_list)
+        return '\n\n'.join(string_list)

--- a/api_client/python/timesketch_api_client/story.py
+++ b/api_client/python/timesketch_api_client/story.py
@@ -74,11 +74,15 @@ class BaseBlock(object):
 
     def move_down(self):
         """Moves a block down one location in the index."""
-        self._story.move_to(self, self.index+1)
+        new_index = self.index + 1
+        self._story.move_to(self, new_index)
+        self.index = new_index
 
     def move_up(self):
         """Moves a block up one location in the index."""
-        self._story.move_to(self, self.index-1)
+        new_index = self.index - 1
+        self._story.move_to(self, new_index)
+        self.index = new_index
 
     def to_dict(self):
         """Returns a dict with the block data.

--- a/api_client/python/timesketch_api_client/story.py
+++ b/api_client/python/timesketch_api_client/story.py
@@ -230,7 +230,7 @@ class AggregationBlock(BaseBlock):
         super(AggregationBlock, self).__init__(story, index)
         self._agg_id = 0
         self._agg_name = ''
-        self._agg_type = 'chart'
+        self._agg_type = 'table'
 
     @property
     def aggregation(self):
@@ -291,7 +291,7 @@ class AggregationBlock(BaseBlock):
 
         self._agg_id = agg_dict.get('id', 0)
         self._agg_name = agg_dict.get('name', '')
-        self._agg_type = agg_dict.get('type', 'chart')
+        self._agg_type = agg_dict.get('type', 'table')
 
     def to_dict(self):
         """Returns a dict with the block data.
@@ -377,6 +377,10 @@ class Story(resource.BaseResource):
                     agg_obj = aggregation.Aggregation(self._sketch, self._api)
                     agg_obj.from_store(block.agg_id)
                     block.feed(agg_obj)
+
+                    # Defaults to a table view.
+                    if not block.agg_type:
+                        block.agg_type = 'table'
                 self._blocks.append(block)
         return self._blocks
 

--- a/api_client/python/timesketch_api_client/story.py
+++ b/api_client/python/timesketch_api_client/story.py
@@ -1,0 +1,161 @@
+# Copyright 2020 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Timesketch API client library."""
+from __future__ import unicode_literals
+
+import json
+
+from . import definitions
+from . import resource
+
+
+class Story(resource.BaseResource):
+    """Story object.
+
+    Attributes:
+        id: Primary key of the story.
+    """
+
+    def __init__(self, story_id, sketch_id, api):
+        """Initializes the Story object.
+
+        Args:
+            story_id: The primary key ID of the story.
+            sketch_id: ID of a sketch.
+            api: Instance of a TimesketchApi object.
+        """
+        self.id = story_id
+        self._title = ''
+        self._content = ''
+
+        resource_uri = 'sketches/{0:d}/stories/{1:d}/'.format(
+            sketch_id, self.id)
+        super(Story, self).__init__(api, resource_uri)
+
+    @property
+    def title(self):
+        """Property that returns story title.
+
+        Returns:
+            Story name as a string.
+        """
+        if not self._title:
+            story = self.lazyload_data()
+            objects = story.get('objects')
+            if objects:
+                self._title = objects[0].get('title', 'No Title')
+        return self._title
+
+    @property
+    def content(self):
+        """Property that returns the content of a story.
+
+        Returns:
+            Story content as a list of blocks.
+        """
+        if not self._content:
+            story = self.lazyload_data()
+            objects = story.get('objects')
+            if objects:
+                self._content = objects[0].get('content', [])
+        return self._content
+
+    def _add_block(self, block):
+        """Adds a block to the story's content."""
+        self.refresh()
+        content = self.content
+        if content:
+            content_list = json.loads(content)
+        else:
+            content_list = []
+
+        content_list.append(block)
+        self._content = json.dumps(content_list)
+
+        data = {
+            'title': self.title,
+            'content': self._content,
+        }
+        response = self.api.session.post(
+            '{0:s}/{1:s}'.format(self.api.api_root, self.resource_uri),
+            json=data)
+
+        return response.status_code in definitions.HTTP_STATUS_CODE_20X
+
+    def _create_new_block(self):
+        """Returns a new block dict."""
+        return {
+            'componentName': '',
+            'componentProps': {},
+            'content': '',
+            'edit': False,
+            'showPanel': False,
+            'isActive': False
+        }
+
+    def add_text(self, text):
+        """Adds a text block to the story.
+
+        Args:
+            text: the string to add to the story.
+
+        Returns:
+            Boolean that indicates whether block was successfully added.
+        """
+        text_block = self._create_new_block()
+        text_block['content'] = text
+
+        return self._add_block(text_block)
+
+    def add_view(self, view):
+        """Add a view to the story.
+
+        Args:
+            view: a view object (instance of view.View)
+
+        Returns:
+            Boolean that indicates whether block was successfully added.
+
+        Raises:
+            TypeError: if the view object is not of the correct type.
+        """
+        if not hasattr(view, 'id'):
+            raise TypeError('View object is not correctly formed.')
+
+        if not hasattr(view, 'name'):
+            raise TypeError('View object is not correctly formed.')
+
+        view_block = self._create_new_block()
+        view_block['componentName'] = 'TsViewEventList'
+        view_block['componentProps']['view'] = {
+            'id': view.id, 'name': view.name}
+
+        return self._add_block(view_block)
+
+    def delete(self):
+        """Delete the story from the sketch.
+
+        Returns:
+            Boolean that indicates whether the deletion was successful.
+        """
+        response = self.api.session.delete(
+            '{0:s}/{1:s}'.format(self.api.api_root, self.resource_uri))
+
+        return response.status_code in definitions.HTTP_STATUS_CODE_20X
+
+    def refresh(self):
+        """Refresh story content."""
+        self._title = ''
+        self._content = ''
+        _ = self.lazyload_data(refresh_cache=True)

--- a/api_client/python/timesketch_api_client/story.py
+++ b/api_client/python/timesketch_api_client/story.py
@@ -261,8 +261,8 @@ class Story(resource.BaseResource):
             Story name as a string.
         """
         if not self._title:
-            story = self.lazyload_data()
-            objects = story.get('objects')
+            story_data = self.lazyload_data()
+            objects = story_data.get('objects')
             if objects:
                 self._title = objects[0].get('title', 'No Title')
         return self._title
@@ -284,6 +284,7 @@ class Story(resource.BaseResource):
 
     def __len__(self):
         """Returns the number of blocks stored in the story."""
+        _ = self.blocks
         return len(self._blocks)
 
     def _add_block(self, block, index):

--- a/api_client/python/timesketch_api_client/story.py
+++ b/api_client/python/timesketch_api_client/story.py
@@ -230,13 +230,14 @@ class AggregationBlock(BaseBlock):
         super(AggregationBlock, self).__init__(story, index)
         self._agg_id = 0
         self._agg_name = ''
-        self._agg_type = ''
+        self._agg_type = 'chart'
 
     @property
     def aggregation(self):
         """Returns the aggregation object."""
         if self._data:
             return self._data
+        return None
 
     @aggregation.setter
     def aggregation(self, agg_obj):
@@ -423,7 +424,7 @@ class Story(resource.BaseResource):
         """Adds an aggregation object to the story.
 
         Args:
-            agg_obj: an aggregation object (instance of aggregation.Aggregation).
+            agg_obj: an aggregation object (instance of aggregation.Aggregation)
             index: an integer, if supplied determines where the new
                 block will be added. If not supplied it will be
                 appended at the end.

--- a/api_client/python/timesketch_api_client/story.py
+++ b/api_client/python/timesketch_api_client/story.py
@@ -424,11 +424,14 @@ class Story(resource.BaseResource):
         self.commit()
         self.reset()
 
-    def add_aggregation(self, agg_obj, index=-1):
+    def add_aggregation(self, agg_obj, agg_type='table', index=-1):
         """Adds an aggregation object to the story.
 
         Args:
             agg_obj: an aggregation object (instance of aggregation.Aggregation)
+            agg_type (str): string indicating the type of aggregation, can be:
+                "table" or the name of the chart to be used, eg "barcharct",
+                "hbarchart". Defaults to "table".
             index: an integer, if supplied determines where the new
                 block will be added. If not supplied it will be
                 appended at the end.
@@ -450,6 +453,7 @@ class Story(resource.BaseResource):
 
         agg_block = AggregationBlock(self, index)
         agg_block.feed(agg_obj)
+        agg_block.agg_type = agg_type
 
         return self._add_block(agg_block, index)
 

--- a/api_client/python/timesketch_api_client/story_test.py
+++ b/api_client/python/timesketch_api_client/story_test.py
@@ -1,0 +1,41 @@
+# Copyright 2020 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the Timesketch API client"""
+from __future__ import unicode_literals
+
+import unittest
+import mock
+
+from . import client
+from . import test_lib
+from . import story as story_lib
+
+
+class StoryTest(unittest.TestCase):
+    """Test Story object."""
+
+    @mock.patch('requests.Session', test_lib.mock_session)
+    def setUp(self):
+        """Setup test case."""
+        self.api_client = client.TimesketchApi(
+            'http://127.0.0.1', 'test', 'test')
+        self.sketch = self.api_client.get_sketch(1)
+
+    def test_story(self):
+        """Test story object."""
+        story = self.sketch.list_stories()[0]
+        self.assertIsInstance(story, story_lib.Story)
+        self.assertEqual(story.id, 1)
+        self.assertEqual(story.title, 'my first test story')
+        self.assertEqual(len(story), 2)

--- a/api_client/python/timesketch_api_client/story_test.py
+++ b/api_client/python/timesketch_api_client/story_test.py
@@ -37,5 +37,23 @@ class StoryTest(unittest.TestCase):
         story = self.sketch.list_stories()[0]
         self.assertIsInstance(story, story_lib.Story)
         self.assertEqual(story.id, 1)
-        self.assertEqual(story.title, 'my first test story')
-        self.assertEqual(len(story), 2)
+        self.assertEqual(story.title, 'My First Story')
+        self.assertEqual(len(story), 3)
+        blocks = list(story.blocks)
+        text_count = 0
+        view_count = 0
+        for block in blocks:
+            if block.TYPE == 'text':
+                text_count += 1
+            elif block.TYPE == 'view':
+                view_count += 1
+
+        self.assertEqual(text_count, 2)
+        self.assertEqual(view_count, 1)
+
+        self.assertEqual(blocks[0].text, '# My Heading\nWith Some Text.')
+
+        blocks[0].move_down()
+        blocks = list(story.blocks)
+        self.assertEqual(len(blocks), 3)
+        self.assertEqual(blocks[1].text, '# My Heading\nWith Some Text.')

--- a/api_client/python/timesketch_api_client/test_lib.py
+++ b/api_client/python/timesketch_api_client/test_lib.py
@@ -14,6 +14,8 @@
 """Tests for the Timesketch API client"""
 from __future__ import unicode_literals
 
+import json
+
 
 def mock_session():
     """Mock HTTP requests session."""
@@ -124,6 +126,49 @@ def mock_response(*args, **kwargs):
         'objects': []
     }
 
+    story_list_data = {
+        'meta': {'es_time': 23},
+        'objects': [[{'id': 1}]]
+    }
+
+    story_data = {
+        'meta': {
+            'es_time': 1,
+        },
+        'objects': [{
+            'title': 'My First Story',
+            'content': json.dumps([
+                {
+                    'componentName': '',
+                    'componentProps': {},
+                    'content': '# My Heading\nWith Some Text.',
+                    'edit': False,
+                    'showPanel': False,
+                    'isActive': False
+                },
+                {
+                    'componentName': 'TsViewEventList',
+                    'componentProps': {
+                        'view': {
+                            'id': 1,
+                            'name': 'Smoking Gun'}},
+                    'content': '',
+                    'edit': False,
+                    'showPanel': False,
+                    'isActive': False
+                },
+                {
+                    'componentName': '',
+                    'componentProps': {},
+                    'content': '... and that was the true crime.',
+                    'edit': False,
+                    'showPanel': False,
+                    'isActive': False
+                }
+            ])
+        }]
+    }
+
     # Register API endpoints to the correct mock response data.
     url_router = {
         'http://127.0.0.1':
@@ -136,8 +181,13 @@ def mock_response(*args, **kwargs):
         MockResponse(json_data=timeline_data),
         'http://127.0.0.1/api/v1/sketches/1/explore/':
         MockResponse(json_data=timeline_data),
+        'http://127.0.0.1/api/v1/sketches/1/stories/':
+        MockResponse(json_data=story_list_data),
+        'http://127.0.0.1/api/v1/sketches/1/stories/1/':
+        MockResponse(json_data=story_data),
     }
 
     if kwargs.get('empty', False):
         return MockResponse(text_data=empty_data)
+
     return url_router.get(args[0], MockResponse(None, 404))

--- a/run_tests.py
+++ b/run_tests.py
@@ -13,11 +13,12 @@ def run_python_tests(coverage=False):
             subprocess.check_call(
                 'nosetests --with-coverage'
                 + ' --cover-package=timesketch_api_client,timesketch'
-                + ' api_client/python/timesketch_api_client/ timesketch/',
+                + ' api_client/python/ timesketch/',
                 shell=True,
             )
         else:
-            subprocess.check_call(['nosetests'])
+            subprocess.check_call(
+                ['nosetests', '-x', 'timesketch/', 'api_client/python/'])
     finally:
         subprocess.check_call(['rm', '-f', '.coverage'])
 

--- a/timesketch/api/v1/resources.py
+++ b/timesketch/api/v1/resources.py
@@ -1905,6 +1905,14 @@ class StoryResource(ResourceMixin, Resource):
         sketch = Sketch.query.get_with_acl(sketch_id)
         story = Story.query.get(story_id)
 
+        if not story:
+            msg = 'No Story found with this ID.'
+            abort(HTTP_STATUS_CODE_NOT_FOUND, msg)
+
+        if not sketch:
+            msg = 'No sketch found with this ID.'
+            abort(HTTP_STATUS_CODE_NOT_FOUND, msg)
+
         # Check that this story belongs to the sketch
         if story.sketch_id != sketch.id:
             abort(

--- a/timesketch/lib/analyzers/interface.py
+++ b/timesketch/lib/analyzers/interface.py
@@ -434,6 +434,22 @@ class Story(object):
         block['content'] = text
         self._commit(block)
 
+    def add_aggregation(self, aggregation, agg_type):
+        """Add a saved aggregation to the Story.
+
+        Args:
+            aggregation (Aggregation): Saved aggregation to add to the story.
+            agg_type (str): string indicating the type of aggregation, can be:
+                "table" or the name of the chart to be used, eg "barcharct",
+                "hbarchart".
+        """
+        block = self._create_new_block()
+        block['componentName'] = 'TsAggregationEventList'
+        block['componentProps']['aggregation'] = {
+            'id': aggregation.id, 'name': aggregation.name,
+            'type': agg_type}
+        self._commit(block)
+
     def add_view(self, view):
         """Add a saved view to the Story.
 

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -341,7 +341,7 @@ class ElasticsearchDataStore(object):
                 body=query_dsl,
                 index=list(indices),
                 search_type=search_type,
-                _source_include=return_fields,
+                _source_includes=return_fields,
                 scroll=scroll_timeout)
         else:
             _search_result = self.client.search(
@@ -425,7 +425,7 @@ class ElasticsearchDataStore(object):
                     index=searchindex_id,
                     id=event_id,
                     doc_type='_all',
-                    _source_exclude=['timesketch_label'])
+                    _source_excludes=['timesketch_label'])
             else:
                 event = self.client.get(
                     index=searchindex_id,

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -341,7 +341,7 @@ class ElasticsearchDataStore(object):
                 body=query_dsl,
                 index=list(indices),
                 search_type=search_type,
-                _source_includes=return_fields,
+                _source_include=return_fields,
                 scroll=scroll_timeout)
         else:
             _search_result = self.client.search(
@@ -425,7 +425,7 @@ class ElasticsearchDataStore(object):
                     index=searchindex_id,
                     id=event_id,
                     doc_type='_all',
-                    _source_excludes=['timesketch_label'])
+                    _source_exclude=['timesketch_label'])
             else:
                 event = self.client.get(
                     index=searchindex_id,


### PR DESCRIPTION
This PR does quite a few things:

1. Increments client API version number
2. Adds a Story class that can add views and text to a story
3. Adds the ability to delete a story from a sketch in the API
4. Adds some logging into the API client for failed resource fetches
5. Adds the ability to create and list stories in the sketch object for the API client
6. Adds ability to manipulate and work with stories and individual blocks in the API client
7. Adds the ability for analyzers to add aggregation to stories.
8. Fixes an issue where API client tests weren't run and fixes broken tests