### PR TITLE
Fix for a flaky test with the win crash analyzer.

### DIFF
--- a/timesketch/lib/analyzers/win_crash_test.py
+++ b/timesketch/lib/analyzers/win_crash_test.py
@@ -39,11 +39,16 @@ class TestWinCrashPlugin(BaseTest):
             ' OR (data_type:"fs:stat" AND filename:"/Microsoft/Windows/WER/")'
             ' OR (data_type:"windows:registry:key_value" AND '
             'key_path:"\\\\Control\\\\CrashControl")'
-            )
+        ).replace('(', '').replace(')', '')
 
-        self.assertEqual(
-            self.analyzer.formulate_query(template),
-            expected_query)
+        # To prevent flakiness we break up the query into a set.
+        expected_set = set(expected_query.split())
+
+        formulated_query = self.analyzer.formulate_query(template)
+        formulated_set = set(
+            formulated_query.replace('(', '').replace(')', '').split())
+
+        self.assertSetEqual(expected_set, formulated_set)
 
     def test_extract_filename(self):
         """Test generator of filename extraction regex"""


### PR DESCRIPTION
Fixing a flaky test with the win_crash analyzer.

An example error:
```
AssertionError: '(data_type:"fs:stat" AND filename:"/Microsoft/Windows[147 chars]ol")' != '(data_type:"windows:evtx:record" AND event_level:"2")[147 chars]ol")'
- (data_type:"fs:stat" AND filename:"/Microsoft/Windows/WER/") OR (data_type:"windows:evtx:record" AND event_level:"2") OR (data_type:"windows:registry:key_value" AND key_path:"\\Control\\CrashControl")
+ (data_type:"windows:evtx:record" AND event_level:"2") OR (data_type:"fs:stat" AND filename:"/Microsoft/Windows/WER/") OR (data_type:"windows:registry:key_value" AND key_path:"\\Control\\CrashControl")
```

