### PR TITLE
bump requests version to 2.22.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ PyJWT==1.7.1
 python_dateutil==2.8.1
 PyYAML==5.3
 redis==3.3.11
-requests==2.21.0
+requests==2.22.0
 sigmatools==0.14 ; python_version > '3.4'
 six==1.12.0
 SQLAlchemy==1.3.12


### PR DESCRIPTION
As per discussion, bump of requirements requests to 2.22 to make pymisp happy.