### PR TITLE
Fix a bug if there are no stories in a sketch and add properties to View

### DIFF
--- a/api_client/python/setup.py
+++ b/api_client/python/setup.py
@@ -24,7 +24,7 @@ from setuptools import setup
 
 setup(
     name='timesketch-api-client',
-    version='20200319',
+    version='20200320',
     description='Timesketch API client',
     license='Apache License, Version 2.0',
     url='http://www.timesketch.org/',

--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -344,13 +344,13 @@ class Sketch(resource.BaseResource):
             self.api.api_root, self.id)
         response = self.api.session.get(resource_url)
         response_json = response.json()
-        objects = response_json.get('objects')
-        if not objects:
+        story_objects = response_json.get('objects')
+        if not story_objects:
             return story_list
 
-        if not len(objects) == 1:
+        if not len(story_objects) == 1:
             return story_list
-        stories = objects[0]
+        stories = story_objects[0]
         for story_dict in stories:
             story_list.append(story.Story(
                 story_id=story_dict.get('id', -1),

--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -344,7 +344,13 @@ class Sketch(resource.BaseResource):
             self.api.api_root, self.id)
         response = self.api.session.get(resource_url)
         response_json = response.json()
-        stories = response_json.get('objects', [[]])[0]
+        objects = response_json.get('objects')
+        if not objects:
+            return story_list
+
+        if not len(objects) == 1:
+            return story_list
+        stories = objects[0]
         for story_dict in stories:
             story_list.append(story.Story(
                 story_id=story_dict.get('id', -1),

--- a/api_client/python/timesketch_api_client/view.py
+++ b/api_client/python/timesketch_api_client/view.py
@@ -52,13 +52,13 @@ class View(resource.BaseResource):
             The dict value of the key "name".
         """
         view = self.lazyload_data(refresh_cache=refresh)
-        objects = view.get('objects')
-        if not objects:
+        view_objects = view.get('objects')
+        if not view_objects:
             return ''
-        if not len(objects) == 1:
+        if not len(view_objects) == 1:
             return ''
 
-        first_object = objects[0]
+        first_object = view_objects[0]
         return first_object.get(name, default_value)
 
     @property

--- a/api_client/python/timesketch_api_client/view.py
+++ b/api_client/python/timesketch_api_client/view.py
@@ -39,6 +39,37 @@ class View(resource.BaseResource):
         resource_uri = 'sketches/{0:d}/views/{1:d}/'.format(sketch_id, self.id)
         super(View, self).__init__(api, resource_uri)
 
+    def _get_top_level_attribute(self, name, default_value=None, refresh=False):
+        """Returns a top level attribute from a view object.
+
+        Args:
+            name: String with the attribute name.
+            default_value: The default value if the attribute does not exit,
+                defaults to None.
+            refresh: If set to True then the data will be refreshed.
+
+        Returns:
+            The dict value of the key "name".
+        """
+        view = self.lazyload_data(refresh_cache=refresh)
+        objects = view.get('objects')
+        if not objects:
+            return ''
+        if not len(objects) == 1:
+            return ''
+
+        first_object = objects[0]
+        return first_object.get(name, default_value)
+
+    @property
+    def description(self):
+        """Property that returns the description value of a view.
+
+        Returns:
+            Description of the view as a string.
+        """
+        return self._get_top_level_attribute('description', default_value='')
+
     @property
     def query_string(self):
         """Property that returns the views query string.
@@ -46,8 +77,7 @@ class View(resource.BaseResource):
         Returns:
             Elasticsearch query as string.
         """
-        view = self.lazyload_data()
-        return view['objects'][0]['query_string']
+        return self._get_top_level_attribute('query_string', default_value='')
 
     @property
     def query_filter(self):
@@ -56,8 +86,7 @@ class View(resource.BaseResource):
         Returns:
             Elasticsearch filter as JSON string.
         """
-        view = self.lazyload_data()
-        return view['objects'][0]['query_filter']
+        return self._get_top_level_attribute('query_filter', default_value='')
 
     @property
     def query_dsl(self):
@@ -66,5 +95,4 @@ class View(resource.BaseResource):
         Returns:
             Elasticsearch DSL as JSON string.
         """
-        view = self.lazyload_data()
-        return view['objects'][0]['query_dsl']
+        return self._get_top_level_attribute('query_dsl', default_value='')

--- a/api_client/python/timesketch_api_client/view.py
+++ b/api_client/python/timesketch_api_client/view.py
@@ -71,6 +71,19 @@ class View(resource.BaseResource):
         return self._get_top_level_attribute('description', default_value='')
 
     @property
+    def user(self):
+        """Property that returns the username of the view creator.
+
+        Returns:
+            A string with the username of the user generating the view.
+        """
+        user_dict = self._get_top_level_attribute('user', default_value={})
+        username = user_dict.get('username')
+        if not username:
+            return 'System'
+        return username
+
+    @property
     def query_string(self):
         """Property that returns the views query string.
 


### PR DESCRIPTION
Fixes a bug when trying to call `list_stories` on a sketch with no stories in it.

Also adding few more properties of a view object.