### PR TITLE
Support non-text fields in aggregations

### DIFF
--- a/timesketch/lib/aggregators/bucket.py
+++ b/timesketch/lib/aggregators/bucket.py
@@ -84,6 +84,8 @@ class TermsAggregation(interface.BaseAggregator):
             Instance of interface.AggregationResult with aggregation result.
         """
         self.field = field
+        formatted_field_name = self.format_field_by_type(field)
+
         # Encoding information for Vega-Lite.
         encoding = {
             'x': {
@@ -102,7 +104,7 @@ class TermsAggregation(interface.BaseAggregator):
             'aggs': {
                 'aggregation': {
                     'terms': {
-                        'field': '{0:s}.keyword'.format(field),
+                        'field': formatted_field_name,
                         'size': limit
                     }
                 }

--- a/timesketch/lib/aggregators/term.py
+++ b/timesketch/lib/aggregators/term.py
@@ -64,7 +64,7 @@ def get_spec(field, query='', query_dsl=''):
                 'aggregations': {
                     'term_count': {
                         'terms': {
-                            'field': '{0:s}.keyword'.format(field)
+                            'field': field
                         }
                     }
                 }
@@ -155,8 +155,10 @@ class FilteredTermsAggregation(interface.BaseAggregator):
             raise ValueError('Both query_string and query_dsl are missing')
 
         self.field = field
+        formatted_field_name = self.format_field_by_type(field)
+
         aggregation_spec = get_spec(
-            field=field, query=query_string, query_dsl=query_dsl)
+            field=formatted_field_name, query=query_string, query_dsl=query_dsl)
 
         # Encoding information for Vega-Lite.
         encoding = {


### PR DESCRIPTION
Currently we are using .keyword fields for every field type. This doesn't work for non-text fields.
This PR get the mapping for the field and decides using .keyword based on the type.
