### PR TITLE
Fixing typo Installation re. libffi

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -59,7 +59,7 @@ Then you need to restart PostgreSQL:
 
 Now it is time to install Timesketch. First we need to install some dependencies:
 
-    $ sudo apt-get install python3-pip python3-dev libffi3-dev
+    $ sudo apt-get install python3-pip python3-dev libffi-dev
 
 Then install Timesketch itself:
 


### PR DESCRIPTION
Not sure, but I think `libffi-dev` should have been left intact maybe? `libffi3-dev` doesn't seem to exist on my Ubuntu.