### PR TITLE
Update installation and plaso documentation

### DIFF
--- a/docs/EnablePlasoUpload.md
+++ b/docs/EnablePlasoUpload.md
@@ -7,12 +7,12 @@ To enable uploading and processing of Plaso storage files, there are a couple of
 NOTE: Due to changes in the format of the Plaso storage file you need to run the latest version of Plaso (>=1.5.0).
 
 Following the official Plaso documentation:
-https://github.com/log2timeline/plaso/wiki/Ubuntu-Packaged-Release
+https://plaso.readthedocs.io/en/latest/sources/user/Ubuntu-Packaged-Release.html
 
     $ sudo add-apt-repository universe
     $ sudo add-apt-repository ppa:gift/stable
     $ sudo apt-get update
-    $ sudo apt-get install python-plaso
+    $ sudo apt-get install plaso-tools
 
 **Install Redis**
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -16,10 +16,10 @@ Install Java
     $ sudo apt-get install openjdk-8-jre-headless
     $ sudo apt-get install apt-transport-https
 
-Install the latest Elasticsearch 6.x release:
+Install the latest Elasticsearch 7.x release:
 
     $ sudo wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
-    $ sudo echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-6.x.list
+    $ sudo echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-7.x.list
     $ sudo apt-get update
     $ sudo apt-get install elasticsearch
 
@@ -33,7 +33,7 @@ Make sure that Elasticsearch is started on boot:
     /bin/systemctl daemon-reload
     /bin/systemctl enable elasticsearch.service
     /bin/systemctl start elasticsearch.service
-    
+
 Make sure that Elasticsearch is running:
 
     /bin/systemctl status elasticsearch.service


### PR DESCRIPTION
Update Elasticsearch version to 7.x in installation documentation since version 6.x didn't worked.
Update the installation of plaso to install `plaso-tools` instead of `python-plaso` and the link to plaso documentation.
`libffi3-dev` was not changed to `libffi-dev` because PR #1168 already change it.