### PR TITLE
Splitting credentials out of crypto storage module in API client.

### DIFF
--- a/api_client/python/timesketch_api_client/client.py
+++ b/api_client/python/timesketch_api_client/client.py
@@ -31,7 +31,7 @@ from google_auth_oauthlib import flow as googleauth_flow
 import google.auth.transport.requests
 import pandas
 
-from . import crypto
+from . import credentials
 from . import definitions
 from . import error
 from . import index
@@ -227,7 +227,7 @@ class TimesketchApi(object):
 
         session = flow.authorized_session()
         self._flow = flow
-        self.credentials = crypto.TimesketchOAuthCredentials()
+        self.credentials = credentials.TimesketchOAuthCredentials()
         self.credentials.credential = flow.credentials
         return self.authenticate_oauth_session(session)
 

--- a/api_client/python/timesketch_api_client/config.py
+++ b/api_client/python/timesketch_api_client/config.py
@@ -22,6 +22,7 @@ from google.auth.transport import requests as auth_requests
 
 from . import client
 from . import cli_input
+from . import credentials as ts_credentials
 from . import crypto
 
 
@@ -92,7 +93,7 @@ def configure_missing_parameters(config_assistant, token_password=''):
     password = cli_input.ask_question(
         'Password for user {0:s}'.format(username), input_type=str,
         hide_input=True)
-    credentials = crypto.TimesketchPwdCredentials()
+    credentials = ts_credentials.TimesketchPwdCredentials()
     credentials.credential = {
         'username': username,
         'password': password

--- a/api_client/python/timesketch_api_client/credentials.py
+++ b/api_client/python/timesketch_api_client/credentials.py
@@ -11,7 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Timesketch API crypto storage library for OAUTH client."""
+"""Timesketch API credential library.
+
+This library contains classes that define how to serialize the different
+credential objects Timesketch supports.
+"""
 from __future__ import unicode_literals
 
 import base64

--- a/api_client/python/timesketch_api_client/credentials.py
+++ b/api_client/python/timesketch_api_client/credentials.py
@@ -1,0 +1,170 @@
+# Copyright 2020 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Timesketch API crypto storage library for OAUTH client."""
+from __future__ import unicode_literals
+
+import base64
+import os
+import getpass
+import json
+import logging
+import stat
+
+from google.oauth2 import credentials
+
+
+logger = logging.getLogger('crypto_client_api')
+
+
+class TimesketchCredentials:
+    """Class to store and retrieve credentials for Timesketch."""
+
+    # The type of credential object.
+    TYPE = ''
+
+    def __init__(self):
+        """Initialize the credential object."""
+        self._credential = None
+
+    @property
+    def credential(self):
+        """Returns the credentials back."""
+        return self._credential
+
+    @credential.setter
+    def credential(self, credential_obj):
+        """Sets the credential object."""
+        self._credential = credential_obj
+
+    def serialize(self):
+        """Return serialized bytes object."""
+        data = self.to_bytes()
+        type_string = bytes(self.TYPE, 'utf-8').rjust(10)[:10]
+
+        return type_string + data
+
+    def deserialize(self, data):
+        """Deserialize a credential object from bytes.
+
+        Args:
+            data (bytes): serialized credential object.
+        """
+        type_data = data[:10]
+        type_string = type_data.decode('utf-8').strip()
+        if not self.TYPE.startswith(type_string):
+            raise TypeError('Not the correct serializer.')
+
+        self.from_bytes(data[10:])
+
+    def to_bytes(self):
+        """Convert the credential object into bytes for storage."""
+        raise NotImplementedError
+
+    def from_bytes(self, data):
+        """Deserialize a credential object from bytes.
+
+        Args:
+            data (bytes): serialized credential object.
+        """
+        raise NotImplementedError
+
+
+class TimesketchPwdCredentials(TimesketchCredentials):
+    """Username and password credentials for Timesketch authentication."""
+
+    TYPE = 'timesketch'
+
+    def from_bytes(self, data):
+        """Deserialize a credential object from bytes.
+
+        Args:
+            data (bytes): serialized credential object.
+
+        Raises:
+            TypeError: if the data is not in bytes.
+        """
+        if not isinstance(data, bytes):
+            raise TypeError('Data needs to be bytes.')
+
+        try:
+            data_dict = json.loads(data.decode('utf-8'))
+        except ValueError:
+            raise TypeError('Unable to parse the byte string.')
+
+        if not 'username' in data_dict:
+            raise TypeError('Username is not set.')
+        if not 'password' in data_dict:
+            raise TypeError('Password is not set.')
+        self._credential = data_dict
+
+    def to_bytes(self):
+        """Convert the credential object into bytes for storage."""
+        if not self._credential:
+            return b''
+
+        data_string = json.dumps(self._credential)
+        return bytes(data_string, 'utf-8')
+
+
+class TimesketchOAuthCredentials(TimesketchCredentials):
+    """OAUTH credentials for Timesketch authentication."""
+
+    TYPE = 'oauth'
+
+    def from_bytes(self, data):
+        """Deserialize a credential object from bytes.
+
+        Args:
+            data (bytes): serialized credential object.
+
+        Raises:
+            TypeError: if the data is not in bytes.
+        """
+        if not isinstance(data, bytes):
+            raise TypeError('Data needs to be bytes.')
+
+        try:
+            token_dict = json.loads(data.decode('utf-8'))
+        except ValueError:
+            raise TypeError('Unable to parse the byte string.')
+
+        self._credential = credentials.Credentials(
+            token=token_dict.get('token'),
+            refresh_token=token_dict.get('_refresh_token'),
+            id_token=token_dict.get('_id_token'),
+            token_uri=token_dict.get('_token_uri'),
+            client_id=token_dict.get('_client_id'),
+            client_secret=token_dict.get('_client_secret')
+        )
+
+    def to_bytes(self):
+        """Convert the credential object into bytes for storage."""
+        if not self._credential:
+            return b''
+
+        cred_obj = self._credential
+        data = {
+            'token': cred_obj.token,
+            '_scopes': getattr(cred_obj, '_scopes', []),
+            '_refresh_token': getattr(cred_obj, '_refresh_token', ''),
+            '_id_token': getattr(cred_obj, '_id_token', ''),
+            '_token_uri': getattr(cred_obj, '_token_uri', ''),
+            '_client_id': getattr(cred_obj, '_client_id', ''),
+            '_client_secret': getattr(cred_obj, '_client_secret', ''),
+        }
+        if cred_obj.expiry:
+            data['expiry'] = cred_obj.expiry.isoformat()
+        data_string = json.dumps(data)
+
+        return bytes(data_string, 'utf-8')

--- a/api_client/python/timesketch_api_client/credentials.py
+++ b/api_client/python/timesketch_api_client/credentials.py
@@ -18,17 +18,9 @@ credential objects Timesketch supports.
 """
 from __future__ import unicode_literals
 
-import base64
-import os
-import getpass
 import json
-import logging
-import stat
 
 from google.oauth2 import credentials
-
-
-logger = logging.getLogger('crypto_client_api')
 
 
 class TimesketchCredentials:

--- a/api_client/python/timesketch_api_client/crypto.py
+++ b/api_client/python/timesketch_api_client/crypto.py
@@ -17,161 +17,18 @@ from __future__ import unicode_literals
 import base64
 import os
 import getpass
-import json
 import logging
 import stat
 
 from cryptography import fernet
-from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat import backends
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
-from google.oauth2 import credentials
+
+from . import credentials
 
 
 logger = logging.getLogger('crypto_client_api')
-
-
-class TimesketchCredentials:
-    """Class to store and retrieve credentials for Timesketch."""
-
-    # The type of credential object.
-    TYPE = ''
-
-    def __init__(self):
-        """Initialize the credential object."""
-        self._credential = None
-
-    @property
-    def credential(self):
-        """Returns the credentials back."""
-        return self._credential
-
-    @credential.setter
-    def credential(self, credential_obj):
-        """Sets the credential object."""
-        self._credential = credential_obj
-
-    def serialize(self):
-        """Return serialized bytes object."""
-        data = self.to_bytes()
-        type_string = bytes(self.TYPE, 'utf-8').rjust(10)[:10]
-
-        return type_string + data
-
-    def deserialize(self, data):
-        """Deserialize a credential object from bytes.
-
-        Args:
-            data (bytes): serialized credential object.
-        """
-        type_data = data[:10]
-        type_string = type_data.decode('utf-8').strip()
-        if not self.TYPE.startswith(type_string):
-            raise TypeError('Not the correct serializer.')
-
-        self.from_bytes(data[10:])
-
-    def to_bytes(self):
-        """Convert the credential object into bytes for storage."""
-        raise NotImplementedError
-
-    def from_bytes(self, data):
-        """Deserialize a credential object from bytes.
-
-        Args:
-            data (bytes): serialized credential object.
-        """
-        raise NotImplementedError
-
-
-class TimesketchPwdCredentials(TimesketchCredentials):
-    """Username and password credentials for Timesketch authentication."""
-
-    TYPE = 'timesketch'
-
-    def from_bytes(self, data):
-        """Deserialize a credential object from bytes.
-
-        Args:
-            data (bytes): serialized credential object.
-
-        Raises:
-            TypeError: if the data is not in bytes.
-        """
-        if not isinstance(data, bytes):
-            raise TypeError('Data needs to be bytes.')
-
-        try:
-            data_dict = json.loads(data.decode('utf-8'))
-        except ValueError:
-            raise TypeError('Unable to parse the byte string.')
-
-        if not 'username' in data_dict:
-            raise TypeError('Username is not set.')
-        if not 'password' in data_dict:
-            raise TypeError('Password is not set.')
-        self._credential = data_dict
-
-    def to_bytes(self):
-        """Convert the credential object into bytes for storage."""
-        if not self._credential:
-            return b''
-
-        data_string = json.dumps(self._credential)
-        return bytes(data_string, 'utf-8')
-
-
-class TimesketchOAuthCredentials(TimesketchCredentials):
-    """OAUTH credentials for Timesketch authentication."""
-
-    TYPE = 'oauth'
-
-    def from_bytes(self, data):
-        """Deserialize a credential object from bytes.
-
-        Args:
-            data (bytes): serialized credential object.
-
-        Raises:
-            TypeError: if the data is not in bytes.
-        """
-        if not isinstance(data, bytes):
-            raise TypeError('Data needs to be bytes.')
-
-        try:
-            token_dict = json.loads(data.decode('utf-8'))
-        except ValueError:
-            raise TypeError('Unable to parse the byte string.')
-
-        self._credential = credentials.Credentials(
-            token=token_dict.get('token'),
-            refresh_token=token_dict.get('_refresh_token'),
-            id_token=token_dict.get('_id_token'),
-            token_uri=token_dict.get('_token_uri'),
-            client_id=token_dict.get('_client_id'),
-            client_secret=token_dict.get('_client_secret')
-        )
-
-    def to_bytes(self):
-        """Convert the credential object into bytes for storage."""
-        if not self._credential:
-            return b''
-
-        cred_obj = self._credential
-        data = {
-            'token': cred_obj.token,
-            '_scopes': getattr(cred_obj, '_scopes', []),
-            '_refresh_token': getattr(cred_obj, '_refresh_token', ''),
-            '_id_token': getattr(cred_obj, '_id_token', ''),
-            '_token_uri': getattr(cred_obj, '_token_uri', ''),
-            '_client_id': getattr(cred_obj, '_client_id', ''),
-            '_client_secret': getattr(cred_obj, '_client_secret', ''),
-        }
-        if cred_obj.expiry:
-            data['expiry'] = cred_obj.expiry.isoformat()
-        data_string = json.dumps(data)
-
-        return bytes(data_string, 'utf-8')
 
 
 class CredentialStorage:
@@ -206,7 +63,7 @@ class CredentialStorage:
             length=32,
             salt=salt,
             iterations=100000,
-            backend=default_backend()
+            backend=backends.default_backend()
         )
         return base64.urlsafe_b64encode(
             kdf.derive(password))
@@ -225,7 +82,7 @@ class CredentialStorage:
         that contains a stored copy of the credential object.
 
         Args:
-            cred_obj (TimesketchCredentials): the credential
+            cred_obj (credentials.TimesketchCredentials): the credential
                 object that is to be stored on disk.
             file_path (str): full path to the file storing the saved
                 credentials.
@@ -323,7 +180,7 @@ class CredentialStorage:
                     '{0!s})'.format(e))
 
             # TODO: Implement a manager.
-            cred_obj = TimesketchPwdCredentials()
+            cred_obj = credentials.TimesketchPwdCredentials()
             try:
                 cred_obj.deserialize(data_string)
 
@@ -331,6 +188,6 @@ class CredentialStorage:
             except TypeError:
                 logger.debug('Credential object is not "timesketch" auth.')
 
-            cred_obj = TimesketchOAuthCredentials()
+            cred_obj = credentials.TimesketchOAuthCredentials()
             cred_obj.deserialize(data_string)
             return cred_obj

--- a/importer_client/python/tools/timesketch_importer.py
+++ b/importer_client/python/tools/timesketch_importer.py
@@ -23,6 +23,7 @@ import sys
 from typing import Dict
 
 from timesketch_api_client import cli_input
+from timesketch_api_client import credentials as ts_credentials
 from timesketch_api_client import crypto
 from timesketch_api_client import config
 from timesketch_api_client import sketch
@@ -234,7 +235,7 @@ if __name__ == '__main__':
             assistant.set_config('auth_mode', 'timesketch')
 
     if conf_password:
-        credentials = crypto.TimesketchPwdCredentials()
+        credentials = ts_credentials.TimesketchPwdCredentials()
         credentials.credential = {
             'username': assistant.get_config('username'),
             'password': conf_password


### PR DESCRIPTION
Splitting up the crypto library into two files.

The crypto storage stays in the crypto library but the credential classes move to a separate file.