### PR TITLE
Fix docker compose errors by installing missing dependencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,8 @@ RUN apt-get --no-install-recommends -y install apt-transport-https \
                        lsb-release \
                        python3-dev \
                        python3-pip \
+                       python3-setuptools \
+                       python3-wheel \
                        python3-psycopg2
 
 # Install Plaso, nodejs and yarn.


### PR DESCRIPTION
This fixes two problems encountered when running docker-compose.

More discussion in [issue](https://github.com/google/timesketch/issues/1174) and [another issue](https://github.com/google/timesketch/issues/1191).

Problem 1: no setuptools

```
Removing intermediate container 8b2e8d5eb9bd
 ---> d924bdabb275
Step 7/17 : RUN pip3 install timesketch
 ---> Running in f149b97f443d
Collecting timesketch
  Downloading https://files.pythonhosted.org/packages/ed/00/4fd5de4724b90719cf7777e19f5144bd6fa040333b382ced2d8ef4785d24/timesketch-20200507.tar.gz (8.9MB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
    ModuleNotFoundError: No module named 'setuptools'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-qpnk56ax/timesketch/
ERROR: Service 'timesketch' failed to build: The command '/bin/sh -c pip3 install timesketch' returned a non-zero code: 1
```

Problem 2: no wheels package

```
Building wheels for collected packages: timesketch, PyYAML, SQLAlchemy, alembic, flask-bcrypt, flask-login, flask-script, neo4jrestclient, tabulate, toolz, pyrsistent, wrapt
  Running setup.py bdist_wheel for timesketch: started
  Running setup.py bdist_wheel for timesketch: finished with status 'error'
  Complete output from command /usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-oih4cb4i/timesketch/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmpaj7kblimpip-wheel- --python-tag cp36:
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help
  
  error: invalid command 'bdist_wheel'
  
  ----------------------------------------
  Failed building wheel for timesketch
  Running setup.py clean for timesketch
  Running setup.py bdist_wheel for PyYAML: started
  Running setup.py bdist_wheel for PyYAML: finished with status 'error'
```

