### PR TITLE
Fix count in linux sigma rule

### DIFF
--- a/data/linux/recon_commands.yaml
+++ b/data/linux/recon_commands.yaml
@@ -20,5 +20,5 @@ detection:
     - 'hostname -f'
     - 'netstat -nltupw'
     - 'cat /proc/net/*'
+  condition: keywords | count() > 3
 timeframe: 30m
-conditions: count > 3


### PR DESCRIPTION
The current count does not work, it raises a SigmaParserError.

That has two reasons as far as I understood, the condition is in the wrong place, and also the way count was proposed in the yaml file is not covered in Sigma, while testing the original one, I got the following exception:
````
  File "/usr/local/lib/python3.6/dist-packages/sigma/parser/rule.py", line 41, in parse_sigma
    conditions = self.parsedyaml["detection"]["condition"]
KeyError: 'condition'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/src/timesketch/timesketch/lib/analyzers/interface.py", line 803, in run_wrapper
    result = self.run()
  File "/usr/local/src/timesketch/timesketch/lib/analyzers/sigma_tagger.py", line 84, in run
    rule_file_content, self.sigma_config, None)
  File "/usr/local/lib/python3.6/dist-packages/sigma/parser/collection.py", line 61, in __init__
    self.parsers.append(SigmaParser(yamldoc, config))
  File "/usr/local/lib/python3.6/dist-packages/sigma/parser/rule.py", line 29, in __init__
    self.parse_sigma()
  File "/usr/local/lib/python3.6/dist-packages/sigma/parser/rule.py", line 49, in parse_sigma
    raise SigmaParseError("No condition found")
sigma.parser.exceptions.SigmaParseError: No condition found
````

My fix should solve that problem.