### PR TITLE
Added Ubuntu 20.04 Python 3.8 Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,21 @@
-matrix:
+version: ~> 1.0
+language: generic
+os: linux
+dist: bionic
+jobs:
   include:
-  - name: "Ubuntu Bionic (18.04) (Docker) with Python 3.6"
-    env: [MODE="pypi", UBUNTU_VERSION="18.04"]
-    os: linux
-    dist: xenial
-    sudo: required
+  - name: "Ubuntu Bionic (18.04) (Docker) with Python 3.6 using PyPI"
+    env: [TARGET="pypi", UBUNTU_VERSION="18.04"]
     group: edge
     language: python
     python: 3.6
+    services:
+    - docker
+  - name: "Ubuntu Focal (20.04) (Docker) with Python 3.8 using PyPI"
+    env: [TARGET="pypi", UBUNTU_VERSION="20.04"]
+    group: edge
+    language: python
+    python: 3.8
     services:
     - docker
 cache:

--- a/config/travis/run_python3.sh
+++ b/config/travis/run_python3.sh
@@ -5,7 +5,7 @@
 # Exit on error.
 set -e;
 
-nosetests3
+python3 ./run_tests.py
 
 python3 ./setup.py build
 python3 ./setup.py sdist

--- a/config/travis/runtests.sh
+++ b/config/travis/runtests.sh
@@ -5,7 +5,8 @@
 # Exit on error.
 set -e;
 
-if test ${MODE} = "dpkg"; then
+if test -n "${UBUNTU_VERSION}";
+then
 	CONTAINER_NAME="ubuntu${UBUNTU_VERSION}";
 	CONTAINER_OPTIONS="-e LANG=en_US.UTF-8";
 
@@ -18,10 +19,8 @@ if test ${MODE} = "dpkg"; then
 	# Note that exec options need to be defined before the container name.
 	docker exec ${CONTAINER_OPTIONS} ${CONTAINER_NAME} sh -c "cd timesketch && ${TEST_COMMAND}";
 
-elif test ${MODE} = "pypi"; then
-	python3 ./run_tests.py
-
-elif test "${TRAVIS_OS_NAME}" = "linux"; then
+elif test "${TRAVIS_OS_NAME}" = "linux";
+then
 	python3 ./run_tests.py
 
 	python3 ./setup.py bdist


### PR DESCRIPTION
* Added Ubuntu 20.04 Python 3.8 Travis CI tests
* Changed the Travis-CI test scripts to use Docker containers so newer versions of Ubuntu can be tested without having to wait for Travis CI to provide new images