### PR TITLE
Fix Docker Readme link (fixes #1247)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Timesketch is an open source tool for collaborative forensic timeline analysis. 
 
 #### Installation
 * [Install Timesketch manually](docs/Installation.md)
-* [Use Docker](docker/README.md)
+* [Use Docker](docker/)
 * [Upgrade from existing installation](docs/Upgrading.md)
 
 #### Adding timelines


### PR DESCRIPTION
During https://github.com/google/timesketch/pull/1207/files the Docker readme was moved to docker/e2e/
And while we do not have a general docker readme, it is better to link to the docker dir than 404.

This was brought up in https://github.com/google/timesketch/issues/1247

Should be a quick review