### PR TITLE
Added pylint support to tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3
+envlist = py3{6,7,8},coverage,pylint
 
 [testenv]
 pip_pre = True
@@ -9,10 +9,17 @@ deps =
     Cython
     -rrequirements.txt
     -rtest_requirements.txt
+    # TODO: remove nose from test_requirements.txt
+    # nose
+    # TODO: remove coverage from test_requirements.txt
+    # coverage: coverage
 commands =
-    ./run_tests.py
+    py3{6,7,8}: nosetests -x api_client/python importer_client/python timesketch
+    coverage: coverage erase
+    coverage: nosetests --with-coverage --cover-package=timesketch_api_client,timesketch_import_client,timesketch api_client/python importer_client/python timesketch
 
-[testenv:py38]
+[testenv:pylint]
+skipsdist=True
 pip_pre = True
 setenv =
     PYTHONPATH = {toxinidir}
@@ -20,6 +27,7 @@ deps =
     Cython
     -rrequirements.txt
     -rtest_requirements.txt
+    # TODO: remove pylint from test_requirements.txt and run_tests.py
+    # pylint >= 2.4.0, < 2.5.0
 commands =
-    coverage erase
-    coverage run --source=timesketch --omit="*_test*,*__init__*,*test_lib*" run_tests.py
+    pylint --rcfile=.pylintrc api_client/python/timesketch_api_client importer_client/python/timesketch_import_client timesketch tests


### PR DESCRIPTION
@berggren FYI the [tox pylint configuration](https://github.com/google/timesketch/pull/1258/commits/8d10f89262e4bb1173bafa53774131195203d47f) I was mentioning. `tox -epylint` will run a full pylint check in a virtualenv. Next tests would be to remove the pylint check from `run_tests.py` and move pylint from `test_requirements.txt` into `tox.ini`.

Depends on:

* https://github.com/google/timesketch/pull/1252

However the pylint tests currently fail with the following errors.
```
/usr/lib64/python3.8/distutils/tests:1:0: F0010: error while code parsing: Unable to load file /usr/lib64/python3.8/distutils/tests:
[Errno 21] Is a directory: '/usr/lib64/python3.8/distutils/tests' (parse-error)
/usr/lib64/python3.8/distutils/tests:1:0: R0401: Cyclic import (timesketch.api.v1.resources -> timesketch.app -> timesketch.api.v1.routes) (cyclic-import)
/usr/lib64/python3.8/distutils/tests:1:0: R0401: Cyclic import (timesketch.api.v1.archive -> timesketch.api.v1.resources -> timesketch.app -> timesketch.api.v1.routes) (cyclic-import)
/usr/lib64/python3.8/distutils/tests:1:0: R0401: Cyclic import (timesketch.api.v1.resources -> timesketch.lib.tasks -> timesketch.app -> timesketch.api.v1.routes) (cyclic-import)
```