### PR TITLE
Changing the behavior of the API calls for event tagging

### DIFF
--- a/api_client/python/timesketch_api_client/error.py
+++ b/api_client/python/timesketch_api_client/error.py
@@ -70,7 +70,8 @@ def get_response_json(response, logger):
         return response.json()
     except json.JSONDecodeError as e:
         logger.error('Unable to decode response: {0!s}'.format(e))
-        return {}
+
+    return {}
 
 
 def error_message(response, message=None, error=RuntimeError):

--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -1109,12 +1109,14 @@ class Sketch(resource.BaseResource):
         response = self.api.session.post(resource_url, json=form_data)
         return error.get_response_json(response, logger)
 
-    def tag_events(self, events, tags):
+    def tag_events(self, events, tags, verbose=False):
         """Tags one or more events with a list of tags.
 
         Args:
             events: Array of JSON objects representing events.
             tags: List of tags (str) to add to the events.
+            verbose: Bool that determines whether extra information
+                is added to the meta dict that gets returned.
 
         Raises:
             ValueError: if tags is not a list of strings.
@@ -1135,7 +1137,8 @@ class Sketch(resource.BaseResource):
 
         form_data = {
             'tag_string': json.dumps(tags),
-            'events': events
+            'events': events,
+            'verbose': verbose,
         }
         resource_url = '{0:s}/sketches/{1:d}/event/tagging/'.format(
             self.api.api_root, self.id)
@@ -1150,7 +1153,7 @@ class Sketch(resource.BaseResource):
 
         response_json = error.get_response_json(response, logger)
         meta = response_json.get('meta', {})
-        meta['number_of_events_sent'] = len(events)
+        meta['total_number_of_events_sent_by_client'] = len(events)
         return meta
 
     def search_by_label(self, label_name, as_pandas=False):

--- a/api_client/python/timesketch_api_client/version.py
+++ b/api_client/python/timesketch_api_client/version.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Version information for Timesketch API Client."""
 
-__version__ = '20200609'
+__version__ = '20200612'
 
 
 def get_version():

--- a/timesketch/api/v1/resources/__init__.py
+++ b/timesketch/api/v1/resources/__init__.py
@@ -17,6 +17,8 @@ The timesketch API is a RESTful API that exposes the following resources:
 """
 from __future__ import unicode_literals
 
+import logging
+
 from flask import current_app
 from flask import jsonify
 from flask_restful import fields
@@ -24,6 +26,12 @@ from flask_restful import marshal
 
 from timesketch.lib.definitions import HTTP_STATUS_CODE_OK
 from timesketch.lib.datastores.elastic import ElasticsearchDataStore
+
+
+logging.basicConfig(
+    format='%(asctime)s %(levelname)-8s %(message)s',
+    level=logging.INFO,
+    datefmt='%Y-%m-%d %H:%M:%S')
 
 
 class ResourceMixin(object):

--- a/timesketch/api/v1/resources/event.py
+++ b/timesketch/api/v1/resources/event.py
@@ -17,10 +17,14 @@ import codecs
 import hashlib
 import json
 import logging
+import math
 import time
 import six
 
 import dateutil
+from elasticsearch.exceptions import RequestError
+import numpy as np
+import pandas as pd
 
 from flask import jsonify
 from flask import request
@@ -45,6 +49,45 @@ from timesketch.models.sketch import Timeline
 
 
 logger = logging.getLogger('api_resources')
+
+
+def _tag_event(row, tag_dict, tags_to_add, datastore, flush_interval):
+    """Tag each event from a dataframe with tags.
+
+    Args:
+        row (np.Series): a single row of data with existing tags and
+            information about the event in order to be able to add
+            tags to it.
+        tag_dict (dict): a dict that contains information to be returned
+            by the API call to the user.
+        tags_to_add (list[str]): a list of strings of tags to add to each
+            event.
+        datastore (elastic.ElasticsearchDataStore): the datastore object.
+        flush_interval (int): the number of events to import before a bulk
+            update is done with the datastore.
+    """
+    tag_dict['events_processed_by_api'] += 1
+    existing_tags = set()
+
+    if 'tag' in row:
+        tag = row['tag']
+        if isinstance(tag, (list, tuple)):
+            existing_tags = set(tag)
+
+        new_tags = list(set().union(existing_tags, set(tags_to_add)))
+    else:
+        new_tags = tags_to_add
+
+    if set(existing_tags) == set(new_tags):
+        return
+
+    datastore.import_event(
+        index_name=row['_index'], event_type=row['_type'],
+        event_id=row['_id'], event={'tag': new_tags},
+        flush_interval=flush_interval)
+
+    tag_dict['tags_applied'] += len(new_tags)
+    tag_dict['number_of_events_with_added_tags'] += 1
 
 
 class EventCreateResource(resources.ResourceMixin, Resource):
@@ -244,6 +287,12 @@ class EventResource(resources.ResourceMixin, Resource):
 class EventTaggingResource(resources.ResourceMixin, Resource):
     """Resource to fetch and set tags to an event."""
 
+    # The number of events to bulk together for each query.
+    EVENT_CHUNK_SIZE = 1000
+
+    # The maximum number of events to tag in a single request.
+    MAX_EVENTS_TO_TAG = 100000
+
     @login_required
     def post(self, sketch_id):
         """Handles POST request to the resource.
@@ -270,8 +319,9 @@ class EventTaggingResource(resources.ResourceMixin, Resource):
             form = request.data
 
         tag_dict = {
-            'event_count': 0,
-            'tag_count': 0,
+            'events_processed_by_api': 0,
+            'number_of_events_with_added_tags': 0,
+            'tags_applied': 0,
         }
         datastore = self.datastore
 
@@ -281,6 +331,7 @@ class EventTaggingResource(resources.ResourceMixin, Resource):
             abort(
                 HTTP_STATUS_CODE_BAD_REQUEST,
                 'Unable to read the tags, with error: {0!s}'.format(e))
+
         if not isinstance(tags_to_add, list):
             abort(
                 HTTP_STATUS_CODE_BAD_REQUEST, 'Tags need to be a list')
@@ -291,43 +342,98 @@ class EventTaggingResource(resources.ResourceMixin, Resource):
                 'Tags need to be a list of strings')
 
         events = form.get('events', [])
-        for _event in events:
-            query = {
-                'query': {
-                    'bool': {
-                        'filter': {
-                            'term': {
-                                '_id': _event['_id'],
-                            }
+        event_df = pd.DataFrame(events)
+        tag_df = pd.DataFrame()
+
+        event_size = event_df.shape[0]
+        if event_size > self.MAX_EVENTS_TO_TAG:
+            abort(
+                HTTP_STATUS_CODE_BAD_REQUEST,
+                'Cannot tag more than {0:d} events in a single '
+                'request'.format(self.MAX_EVENTS_TO_TAG))
+
+        tag_dict['number_of_events_passed_to_api'] = event_size
+
+        verbose = form.get('verbose', False)
+        if verbose:
+            tag_dict['number_of_indices'] = len(event_df['_index'].unique())
+            time_tag_gathering_start = time.time()
+
+        for _index in event_df['_index'].unique():
+            query_filter = {
+                'time_start': None,
+                'time_end': None,
+                'indices': [_index],
+            }
+
+            index_slice = event_df[event_df['_index'] == _index]
+            index_size = index_slice.shape[0]
+            if verbose:
+                tag_dict.setdefault('index_count', {})
+                tag_dict['index_count'][_index] = index_size
+
+            if index_size <= self.EVENT_CHUNK_SIZE:
+                chunks = 1
+            else:
+                chunks = math.ceil(index_size / self.EVENT_CHUNK_SIZE)
+
+            tags = []
+            for index_chunk in np.array_split(
+                    index_slice['_id'].unique(), chunks):
+                should_list = [{'match': {'_id': x}} for x in index_chunk]
+                query = {
+                    'query': {
+                        'bool': {
+                            'should': should_list
                         }
                     }
                 }
-            }
-            results = datastore.client.search(
-                index=[_event['_index']], body=query)
+                try:
+                    for result in datastore.search_stream(
+                            sketch_id=sketch.id, query_dsl=json.dumps(query),
+                            indices=[_index], return_fields=['tag'],
+                            query_filter=query_filter, enable_scroll=False):
+                        tag = result.get('_source', {}).get('tag', [])
+                        if not tag:
+                            continue
+                        tags.append({'_id': result.get('_id'), 'tag': tag})
+                except RequestError as e:
+                    logger.error('Unable to query for events, {0!s}'.format(e))
+                    abort(
+                        HTTP_STATUS_CODE_BAD_REQUEST,
+                        'Unable to query events, {0!s}'.format(e))
 
-            ds_events = results['hits']['hits']
-            if len(ds_events) != 1:
-                logger.error(
-                    'Unable to tag event: {0:s}, couldn\'t find the '
-                    'event.'.format(_event['_id']))
+            if not tags:
                 continue
+            tag_df = pd.concat([tag_df, pd.DataFrame(tags)])
 
-            source = ds_events[0].get('_source', {})
-            existing_tags = source.get('tag', [])
-            new_tags = list(set().union(existing_tags, tags_to_add))
+        event_df = event_df.merge(tag_df, on='_id', how='left')
 
-            if set(existing_tags) == set(new_tags):
-                continue
+        if verbose:
+            tag_dict[
+                'time_to_gather_tags'] = time.time() - time_tag_gathering_start
+            tag_dict['number_of_events'] = len(events)
+            if 'tag' in event_df:
+                current_tag_events = event_df[~event_df['tag'].isna()].shape[0]
+                tag_dict['number_of_events_with_tags'] = current_tag_events
+            else:
+                tag_dict['number_of_events_with_tags'] = 0
 
-            datastore.import_event(
-                index_name=_event['_index'], event_type=_event['_type'],
-                event_id=_event['_id'], event={'tag': new_tags})
+            tag_dict['tags_to_add'] = tags_to_add
+            time_tag_start = time.time()
 
-            tag_dict['event_count'] += 1
-            tag_dict['tag_count'] += len(new_tags)
-
+        if event_size > datastore.DEFAULT_FLUSH_INTERVAL:
+            flush_interval = 10000
+        else:
+            flush_interval = datastore.DEFAULT_FLUSH_INTERVAL
+        _ = event_df.apply(
+            _tag_event, axis=1, tag_dict=tag_dict, tags_to_add=tags_to_add,
+            datastore=datastore, flush_interval=flush_interval)
         datastore.flush_queued_events()
+
+        if verbose:
+            tag_dict['time_to_tag'] = time.time() - time_tag_start
+
         schema = {
             'meta': tag_dict,
             'objects': []}

--- a/timesketch/api/v1/resources/event.py
+++ b/timesketch/api/v1/resources/event.py
@@ -407,7 +407,8 @@ class EventTaggingResource(resources.ResourceMixin, Resource):
                 continue
             tag_df = pd.concat([tag_df, pd.DataFrame(tags)])
 
-        event_df = event_df.merge(tag_df, on='_id', how='left')
+        if tag_df.shape[0]:
+            event_df = event_df.merge(tag_df, on='_id', how='left')
 
         if verbose:
             tag_dict[

--- a/timesketch/api/v1/resources/event.py
+++ b/timesketch/api/v1/resources/event.py
@@ -405,6 +405,7 @@ class EventTaggingResource(resources.ResourceMixin, Resource):
                     }
                 }
 
+                # Adding a small buffer to make sure all results are captured.
                 size = len(should_list) + 100
                 query_body['size'] = size
                 query_body['terminate_after'] = size

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Elasticsearch datastore."""
-
 from __future__ import unicode_literals
 
 from collections import Counter
@@ -356,7 +355,7 @@ class ElasticsearchDataStore(object):
 
     def search_stream(self, sketch_id=None, query_string=None,
                       query_filter=None, query_dsl=None, indices=None,
-                      return_fields=None):
+                      return_fields=None, enable_scroll=True):
         """Search ElasticSearch. This will take a query string from the UI
         together with a filter definition. Based on this it will execute the
         search request on ElasticSearch and get result back.
@@ -368,6 +367,7 @@ class ElasticsearchDataStore(object):
             query_dsl: Dictionary containing Elasticsearch DSL query
             indices: List of indices to query
             return_fields: List of fields to return
+            enable_scroll: Boolean determing whether scrolling is enabled.
 
         Returns:
             Generator of event documents in JSON format
@@ -386,10 +386,14 @@ class ElasticsearchDataStore(object):
             query_filter=query_filter,
             indices=indices,
             return_fields=return_fields,
-            enable_scroll=True)
+            enable_scroll=enable_scroll)
 
-        scroll_id = result['_scroll_id']
-        scroll_size = result['hits']['total']
+        if enable_scroll:
+            scroll_id = result['_scroll_id']
+            scroll_size = result['hits']['total']
+        else:
+            scroll_id = None
+            scroll_size = 0
 
         # Elasticsearch version 7.x returns total hits as a dictionary.
         # TODO: Refactor when version 6.x has been deprecated.


### PR DESCRIPTION
This PR changes the approach to event tagging to doing some bulk lookups to better test against large tagging requests.

There was an issue with the previous tagging approach which resulted in both too many requests to the backend, since there was a single ES search per event that needed to be tagged. Now searches are done in bulk, just as the actual changes to the document is. 

Also made some changes in increasing the size of the bulk requests (increased the threshold value)