### PR TITLE
Fix method docstring (copy paste error)

### DIFF
--- a/timesketch/api/v1/resources/information.py
+++ b/timesketch/api/v1/resources/information.py
@@ -30,7 +30,7 @@ class VersionResource(resources.ResourceMixin, Resource):
         """Handles GET request to the resource.
 
         Returns:
-            List of usernames
+            JSON object including version info
         """
         schema = {
             'meta': {


### PR DESCRIPTION
Guess there was a copy paste error in this PR: https://github.com/google/timesketch/commit/64157452b7b8285ea928e4949434d46592791d47

As the method does not return user info.