### PR TITLE
Bugfix: Set status on added timelines

### DIFF
--- a/timesketch/api/v1/resources/timeline.py
+++ b/timesketch/api/v1/resources/timeline.py
@@ -112,6 +112,10 @@ class TimelineListResource(resources.ResourceMixin, Resource):
                     continue
                 timeline.add_label(label)
                 searchindex.add_label(label)
+
+            # Set status to ready so the timeline can be queried.
+            timeline.set_status('ready')
+
             db_session.add(timeline)
             db_session.commit()
         else:


### PR DESCRIPTION
Existing timelines that was added via the UI didn't get the status set to ready. This had the effect that the timeline wasn't ready for query, and resulted in 0 search hits.

This PR fixes that.