### PR TITLE
Fix an issue with unicode chars in sigma rules

### DIFF
--- a/timesketch/lib/analyzers/sigma_tagger.py
+++ b/timesketch/lib/analyzers/sigma_tagger.py
@@ -4,8 +4,8 @@ from __future__ import unicode_literals
 import logging
 import os
 import time
-import elasticsearch
 import codecs
+import elasticsearch
 
 
 from sigma.backends import elasticsearch as sigma_elasticsearch

--- a/timesketch/lib/analyzers/sigma_tagger.py
+++ b/timesketch/lib/analyzers/sigma_tagger.py
@@ -5,6 +5,7 @@ import logging
 import os
 import time
 import elasticsearch
+import codecs
 
 
 from sigma.backends import elasticsearch as sigma_elasticsearch
@@ -100,7 +101,8 @@ class SigmaPlugin(interface.BaseSketchAnalyzer):
                     rule_file_path = os.path.abspath(rule_file_path)
                     logging.info('[sigma] Reading rules from {0!s}'.format(
                         rule_file_path))
-                    with open(rule_file_path, 'r') as rule_file:
+                    with codecs.open(rule_file_path, 'r', encoding='utf-8',
+                                     errors='replace') as rule_file:
                         try:
                             rule_file_content = rule_file.read()
                             parser = sigma_collection.SigmaCollectionParser(


### PR DESCRIPTION
Should fix:
```[2020-07-15 14:03:03,763: INFO/ForkPoolWorker-15] [sigma] Reading rules from /usr/local/src/timesketch/data/sigma/rules/windows/powershell/powershell_dnscat_execution.yml
[2020-07-15 14:03:03,777: INFO/ForkPoolWorker-15] [sigma] result: Traceback (most recent call last):
  File "/usr/local/src/timesketch/timesketch/lib/analyzers/interface.py", line 804, in run_wrapper
    result = self.run()
  File "/usr/local/src/timesketch/timesketch/lib/analyzers/sigma_tagger.py", line 105, in run
    rule_file_content = rule_file.read()
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 486: ordinal not in range(128)
```

As reported from @rocket-ops 