### PR TITLE
Minor change to the EVTX Gap analyzer

### DIFF
--- a/timesketch/lib/analyzers/win_evtxgap.py
+++ b/timesketch/lib/analyzers/win_evtxgap.py
@@ -244,6 +244,8 @@ class EvtxGapPlugin(interface.BaseSketchAnalyzer):
             df_append = pd.DataFrame(rows_to_append)
             event_count = event_count.append(df_append, sort=False)
             event_count.sort_values(by='day', inplace=True)
+            if 'timestamp' in event_count:
+                del event_count['timestamp']
 
             if event_count.shape[0]:
                 params = {


### PR DESCRIPTION
Removing timestamp from the EVTX chart, which was causing some issues with the vega lite specification (not visible in the UI)