### PR TITLE
Fixing an issue with the export functionality.

### DIFF
--- a/timesketch/api/v1/export.py
+++ b/timesketch/api/v1/export.py
@@ -138,6 +138,9 @@ def query_to_filehandle(
     query_filter['terminate_after'] = 10000
     query_filter['size'] = 10000
 
+    if 'from' in query_filter:
+        del query_filter['from']
+
     result = datastore.search(
         sketch_id=sketch.id,
         query_string=query_string,


### PR DESCRIPTION
If the keyword `from` was added to the query_filter (for pagination) the query export function  fails.

See: https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html#_scroll

```
Scroll
The from parameter can no longer be used in the search request body when initiating a scroll. The parameter was already ignored in these situations, now in addition an error is thrown.
```

Since we want all the events to be exported we are enabling scroll.