### PR TITLE
Minor changes to the way date is parsed when a custom event is added

### DIFF
--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -1268,7 +1268,8 @@ class Sketch(resource.BaseResource):
 
         Args:
             message: A string that will be used as the message string.
-            date: A string with the timestamp of the message.
+            date: A string with the timestamp of the message. This should be
+                in a human readable format, eg: "2020-09-03T22:52:21".
             timestamp_desc : Description of the timestamp.
             attributes: A dict of extra attributes to add to the event.
             tags: A list of strings to include as tags.

--- a/timesketch/api/v1/resources/event.py
+++ b/timesketch/api/v1/resources/event.py
@@ -127,7 +127,15 @@ class EventCreateResource(resources.ResourceMixin, Resource):
             date = datetime.datetime.utcnow().isoformat()
         else:
             # derive datetime from timestamp:
-            date = dateutil.parser.parse(date_string)
+            try:
+                date = dateutil.parser.parse(date_string)
+            except OverflowError as e:
+                logger.error('Unable to convert date string', exc_info=True)
+                abort(
+                    HTTP_STATUS_CODE_BAD_REQUEST,
+                    'Unable to add event, not able to convert the date '
+                    'string. Was it properly formed? Error: {0!s}'.format(
+                        e))
 
         timestamp = int(
             time.mktime(date.utctimetuple())) * 1000000

--- a/timesketch/api/v1/resources/event.py
+++ b/timesketch/api/v1/resources/event.py
@@ -134,8 +134,8 @@ class EventCreateResource(resources.ResourceMixin, Resource):
                 abort(
                     HTTP_STATUS_CODE_BAD_REQUEST,
                     'Unable to add event, not able to convert the date '
-                    'string. Was it properly formed? Error: {0!s}'.format(
-                        e))
+                    'string. Was it properly formatted? Error: '
+                    '{0!s}'.format(e))
 
         timestamp = int(
             time.mktime(date.utctimetuple())) * 1000000

--- a/timesketch/api/v1/resources/event.py
+++ b/timesketch/api/v1/resources/event.py
@@ -129,7 +129,7 @@ class EventCreateResource(resources.ResourceMixin, Resource):
             # derive datetime from timestamp:
             try:
                 date = dateutil.parser.parse(date_string)
-            except OverflowError as e:
+            except (dateutil.parser.ParserError, OverflowError) as e:
                 logger.error('Unable to convert date string', exc_info=True)
                 abort(
                     HTTP_STATUS_CODE_BAD_REQUEST,


### PR DESCRIPTION
Adding an error handling to the custom `add_event`, to catch badly formed datestrings.