### PR TITLE
Adding the ability to add labels to sketches.

### DIFF
--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -58,7 +58,6 @@ class Sketch(resource.BaseResource):
         self.id = sketch_id
         self.api = api
         self._archived = None
-        self._labels = []
         self._sketch_name = sketch_name
         self._resource_uri = 'sketches/{0:d}'.format(self.id)
         super(Sketch, self).__init__(api=api, resource_uri=self._resource_uri)
@@ -79,22 +78,17 @@ class Sketch(resource.BaseResource):
     @property
     def labels(self):
         """Property that returns the sketch labels."""
-        if self._labels:
-            return self._labels
-
-        data = self.lazyload_data()
+        data = self.lazyload_data(refresh_cache=True)
         objects = data.get('objects', [])
         if not objects:
-            return self._labels
+            return []
 
         sketch_data = objects[0]
         label_string = sketch_data.get('label_string', '')
         if label_string:
-            self._labels = json.loads(label_string)
-        else:
-            self._labels = []
+            return json.loads(label_string)
 
-        return self._labels
+        return []
 
     @property
     def name(self):
@@ -179,6 +173,67 @@ class Sketch(resource.BaseResource):
                 pass
 
         return data_frame
+
+    def add_sketch_label(self, label):
+        """Add a label to the sketch.
+
+        Args:
+            label (str): A string with the label to add to the sketch.
+
+        Returns:
+            bool: A boolean to indicate whether the label was successfully
+                  added to the sketch.
+        """
+        if label in self.labels:
+            logger.error(
+                'Label [{0:s}] already applied to sketch.'.format(label))
+            return False
+
+        resource_url = '{0:s}/sketches/{1:d}/'.format(
+            self.api.api_root, self.id)
+
+        data = {
+            'labels': [label],
+            'label_action': 'add',
+        }
+        response = self.api.session.post(resource_url, json=data)
+
+        status = error.check_return_status(response, logger)
+        if not status:
+            logger.error('Unable to add the label to the sketch.')
+
+        return status
+
+    def remove_sketch_label(self, label):
+        """Remove a label from the sketch.
+
+        Args:
+            label (str): A string with the label to remove from the sketch.
+
+        Returns:
+            bool: A boolean to indicate whether the label was successfully
+                  removed from the sketch.
+        """
+        if label not in self.labels:
+            logger.error(
+                'Unable to remove label [{0:s}], not a label '
+                'attached to this sketch.'.format(label))
+            return False
+
+        resource_url = '{0:s}/sketches/{1:d}/'.format(
+            self.api.api_root, self.id)
+
+        data = {
+            'labels': [label],
+            'label_action': 'remove',
+        }
+        response = self.api.session.post(resource_url, json=data)
+
+        status = error.check_return_status(response, logger)
+        if not status:
+            logger.error('Unable to remove the label from the sketch.')
+
+        return status
 
     def create_view(
             self, name, query_string='', query_dsl='', query_filter=None):

--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -102,6 +102,26 @@ class Sketch(resource.BaseResource):
             self._sketch_name = sketch['objects'][0]['name']
         return self._sketch_name
 
+    @name.setter
+    def name(self, name_value):
+        """Change the name of the sketch to a new value."""
+        if not isinstance(name_value, str):
+            logger.error('Unable to change the name to a non string value')
+            return
+
+        resource_url = '{0:s}/sketches/{1:d}/'.format(
+            self.api.api_root, self.id)
+
+        data = {
+            'name': name_value,
+        }
+        response = self.api.session.post(resource_url, json=data)
+        _ = error.check_return_status(response, logger)
+
+        # Force the new name to be re-loaded.
+        self._sketch_name = ''
+        _ = self.lazyload_data(refresh_cache=True)
+
     @property
     def description(self):
         """Property that returns sketch description.
@@ -111,6 +131,25 @@ class Sketch(resource.BaseResource):
         """
         sketch = self.lazyload_data()
         return sketch['objects'][0]['description']
+
+    @description.setter
+    def description(self, description_value):
+        """Change the sketch description to a new value."""
+        if not isinstance(description_value, str):
+            logger.error('Unable to change the name to a non string value')
+            return
+
+        resource_url = '{0:s}/sketches/{1:d}/'.format(
+            self.api.api_root, self.id)
+
+        data = {
+            'description': description_value,
+        }
+        response = self.api.session.post(resource_url, json=data)
+        _ = error.check_return_status(response, logger)
+
+        # Force the new description to be re-loaded.
+        _ = self.lazyload_data(refresh_cache=True)
 
     @property
     def status(self):

--- a/api_client/python/timesketch_api_client/version.py
+++ b/api_client/python/timesketch_api_client/version.py
@@ -14,7 +14,7 @@
 """Version information for Timesketch API Client."""
 
 
-__version__ = '20200910'
+__version__ = '20201001'
 
 
 def get_version():

--- a/timesketch/api/v1/resources/sketch.py
+++ b/timesketch/api/v1/resources/sketch.py
@@ -115,6 +115,26 @@ class SketchListResource(resources.ResourceMixin, Resource):
 class SketchResource(resources.ResourceMixin, Resource):
     """Resource to get a sketch."""
 
+    def _add_label(self, sketch, label):
+        """Add a label to the sketch."""
+        if sketch.has_label(label):
+            logger.warning(
+                'Unable to apply the label [{0:s}] to sketch {1:d}, '
+                'already exists.'.format(label, sketch.id))
+            return False
+        sketch.add_label(label, user=current_user)
+        return True
+
+    def _remove_label(self, sketch, label):
+        """Removes a label to the sketch."""
+        if not sketch.has_label(label):
+            logger.warning(
+                'Unable to remove the label [{0:s}] to sketch {1:d}, '
+                'label does not exist.'.format(label, sketch.id))
+            return False
+        sketch.remove_label(label)
+        return True
+
     def _get_sketch_for_admin(self, sketch):
         """Returns a limited sketch view for adminstrators.
 
@@ -352,24 +372,50 @@ class SketchResource(resources.ResourceMixin, Resource):
         Returns:
             A sketch in JSON (instance of flask.wrappers.Response)
         """
-        form = forms.NameDescriptionForm.build(request)
         sketch = Sketch.query.get_with_acl(sketch_id)
         if not sketch:
             abort(
                 HTTP_STATUS_CODE_NOT_FOUND, 'No sketch found with this ID.')
 
-        if not form.validate_on_submit():
-            abort(
-                HTTP_STATUS_CODE_BAD_REQUEST, (
-                    'Unable to rename sketch, '
-                    'unable to validate form data'))
-
         if not sketch.has_permission(current_user, 'write'):
             abort(HTTP_STATUS_CODE_FORBIDDEN,
                   'User does not have write access controls on sketch.')
 
-        sketch.name = form.name.data
-        sketch.description = form.description.data
-        db_session.add(sketch)
-        db_session.commit()
+        form = request.json
+        if not form:
+            form = request.data
+
+        update_object = False
+        name = form.get('name', '')
+        if name:
+            sketch.name = name
+            update_object = True
+
+        description = form.get('description', '')
+        if description:
+            sketch.description = description
+            update_object = True
+
+        labels = form.get('labels', [])
+        label_action = form.get('label_action', 'add')
+        if label_action not in ('add', 'remove'):
+            abort(
+                HTTP_STATUS_CODE_BAD_REQUEST,
+                'Label actions needs to be either "add" or "remove", '
+                'not [{0:s}]'.format(label_action))
+
+        if labels and isinstance(labels, (tuple, list)):
+            for label in labels:
+                if label_action == 'add':
+                    changed = self._add_label(sketch=sketch, label=label)
+                elif label_action == 'remove':
+                    changed = self._remove_label(sketch=sketch, label=label)
+
+                if changed:
+                    update_object = True
+
+        if update_object:
+            db_session.add(sketch)
+            db_session.commit()
+
         return self.to_json(sketch, status_code=HTTP_STATUS_CODE_CREATED)


### PR DESCRIPTION
The config file already has the parameter `LABELS_TO_PREVENT_DELETION`, and the archival functionality has the functionality to check that configuration and prevent a sketch from being archived if it has a label in that definition.

However, neither the API nor the API Client (or UI) has the ability to add/remove/edit labels of a sketch.

This PR adds two things:

1. The ability to add/remove labels from a sketch in the API and API client
2. The ability in the API client to modify name/description of the sketch.