### PR TITLE
Added support for optional keyword rdomain

### DIFF
--- a/timesketch/lib/analyzers/ssh_sessionizer.py
+++ b/timesketch/lib/analyzers/ssh_sessionizer.py
@@ -12,15 +12,16 @@ from timesketch.lib.analyzers import sessionizer
 SSH_PATTERN = re.compile(r'^\[sshd\] \[(?P<process_id>\d+)\]:')
 
 # pylint: disable=line-too-long
-# Pattern for message of SSH events for successful connection to port:
-# '[sshd] [{process_id}]: Connection from {client_ip} port {client_port} on {host_ip} port {host_port}'
+# Pattern for message of SSH events for successful connection to port (rdomain is optional):
+# '[sshd] [{process_id}]: Connection from {client_ip} port {client_port} on {host_ip} port {host_port} rdomain {rdomain}'
 #
 # The SSH_CONNECTION_PATTERN is compatible with IPv4
 # TODO Change the pattern to be compatible also with IPv6
 SSH_CONNECTION_PATTERN = \
     re.compile(r'^\[sshd\] \[(?P<process_id>\d+)\]: Connection from ' + \
     r'(?P<client_ip>(\d{1,3}\.){3}\d{1,3}) port (?P<client_port>\d+) on ' + \
-    r'(?P<host_ip>(\d{1,3}\.){3}\d{1,3}) port (?P<host_port>\d+)$')
+    r'(?P<host_ip>(\d{1,3}\.){3}\d{1,3}) port (?P<host_port>\d+)' + \
+    r'( rdomain (?P<rdomain>.*))?$')
 
 
 class SSHSessionizerSketchPlugin(sessionizer.SessionizerSketchPlugin):


### PR DESCRIPTION
rdomain is sometimes logged in SSH logs. Previously any log line that contained rdomain would be skipped.