### PR TITLE
API client: Adding a check for scroll ID in the explore function

### DIFF
--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -947,6 +947,10 @@ class Sketch(resource.BaseResource):
             if stop_size and total_count >= stop_size:
                 break
 
+            if not scroll_id:
+                logger.debug('No scroll ID, will stop.')
+                break
+
             more_response = self.api.session.post(resource_url, json=form_data)
             if not error.check_return_status(more_response, logger):
                 error.error_message(

--- a/api_client/python/timesketch_api_client/version.py
+++ b/api_client/python/timesketch_api_client/version.py
@@ -14,7 +14,7 @@
 """Version information for Timesketch API Client."""
 
 
-__version__ = '20201013'
+__version__ = '20201015'
 
 
 def get_version():


### PR DESCRIPTION
Small fix when there are few records returned and the query_filter is set there is a chance of an endless loop in the explore function.