### PR TITLE
Fixes to the API and API client

### DIFF
--- a/api_client/python/timesketch_api_client/timeline.py
+++ b/api_client/python/timesketch_api_client/timeline.py
@@ -45,6 +45,7 @@ class Timeline(resource.BaseResource):
         """
         self.id = timeline_id
         self._labels = []
+        self._color = ''
         self._name = name
         self._searchindex = searchindex
         resource_uri = 'sketches/{0:d}/timelines/{1:d}/'.format(
@@ -70,6 +71,28 @@ class Timeline(resource.BaseResource):
             self._labels = []
 
         return self._labels
+
+    @property
+    def color(self):
+        """Property that returns timeline color.
+
+        Returns:
+            Color name as string.
+        """
+        if not self._color:
+            timeline = self.lazyload_data()
+            self._color = timeline['objects'][0]['color']
+        return self._color
+
+    @property
+    def description(self):
+        """Property that returns timeline description.
+
+        Returns:
+            Description as string.
+        """
+        timeline = self.lazyload_data()
+        return timeline['objects'][0]['description']
 
     @property
     def name(self):
@@ -151,6 +174,9 @@ class Timeline(resource.BaseResource):
             self.api.api_root, self.resource_uri)
 
         data = {
+            'name': self.name,
+            'description': self.description,
+            'color': self.color,
             'labels': [label],
             'label_action': 'add',
         }
@@ -182,6 +208,9 @@ class Timeline(resource.BaseResource):
             self.api.api_root, self.resource_uri)
 
         data = {
+            'name': self.name,
+            'description': self.description,
+            'color': self.color,
             'labels': [label],
             'label_action': 'remove',
         }

--- a/api_client/python/timesketch_api_client/timeline.py
+++ b/api_client/python/timesketch_api_client/timeline.py
@@ -177,7 +177,7 @@ class Timeline(resource.BaseResource):
             'name': self.name,
             'description': self.description,
             'color': self.color,
-            'labels': [label],
+            'labels': json.dumps([label]),
             'label_action': 'add',
         }
         response = self.api.session.post(resource_url, json=data)
@@ -211,7 +211,7 @@ class Timeline(resource.BaseResource):
             'name': self.name,
             'description': self.description,
             'color': self.color,
-            'labels': [label],
+            'labels': json.dumps([label]),
             'label_action': 'remove',
         }
         response = self.api.session.post(resource_url, json=data)

--- a/api_client/python/timesketch_api_client/timeline.py
+++ b/api_client/python/timesketch_api_client/timeline.py
@@ -44,7 +44,6 @@ class Timeline(resource.BaseResource):
             searchindex: The Elasticsearch index name (optional)
         """
         self.id = timeline_id
-        self._labels = []
         self._color = ''
         self._name = name
         self._searchindex = searchindex
@@ -55,22 +54,17 @@ class Timeline(resource.BaseResource):
     @property
     def labels(self):
         """Property that returns the timeline labels."""
-        if self._labels:
-            return self._labels
-
-        data = self.lazyload_data()
+        data = self.lazyload_data(refresh_cache=True)
         objects = data.get('objects', [])
         if not objects:
-            return self._labels
+            return []
 
         timeline_data = objects[0]
         label_string = timeline_data.get('label_string', '')
         if label_string:
-            self._labels = json.loads(label_string)
-        else:
-            self._labels = []
+            return json.loads(label_string)
 
-        return self._labels
+        return []
 
     @property
     def color(self):

--- a/api_client/python/timesketch_api_client/timeline.py
+++ b/api_client/python/timesketch_api_client/timeline.py
@@ -132,6 +132,67 @@ class Timeline(resource.BaseResource):
         status = status_list[0]
         return status.get('status')
 
+    def add_timeline_label(self, label):
+        """Add a label to the timelinne.
+
+        Args:
+            label (str): A string with the label to add to the timeline.
+
+        Returns:
+            bool: A boolean to indicate whether the label was successfully
+                  added to the timeline.
+        """
+        if label in self.labels:
+            logger.error(
+                'Label [{0:s}] already applied to timeline.'.format(label))
+            return False
+
+        resource_url = '{0:s}/{1:s}'.format(
+            self.api.api_root, self.resource_uri)
+
+        data = {
+            'labels': [label],
+            'label_action': 'add',
+        }
+        response = self.api.session.post(resource_url, json=data)
+
+        status = error.check_return_status(response, logger)
+        if not status:
+            logger.error('Unable to add the label to the timeline.')
+
+        return status
+
+    def remove_timeline_label(self, label):
+        """Remove a label from the timeline.
+
+        Args:
+            label (str): A string with the label to remove from the timeline.
+
+        Returns:
+            bool: A boolean to indicate whether the label was successfully
+                  removed from the timeline.
+        """
+        if label not in self.labels:
+            logger.error(
+                'Unable to remove label [{0:s}], not a label '
+                'attached to this timeline.'.format(label))
+            return False
+
+        resource_url = '{0:s}/{1:s}'.format(
+            self.api.api_root, self.resource_uri)
+
+        data = {
+            'labels': [label],
+            'label_action': 'remove',
+        }
+        response = self.api.session.post(resource_url, json=data)
+
+        status = error.check_return_status(response, logger)
+        if not status:
+            logger.error('Unable to remove the label from the sketch.')
+
+        return status
+
     def delete(self):
         """Deletes the timeline."""
         resource_url = '{0:s}/{1:s}'.format(

--- a/api_client/python/timesketch_api_client/version.py
+++ b/api_client/python/timesketch_api_client/version.py
@@ -14,7 +14,7 @@
 """Version information for Timesketch API Client."""
 
 
-__version__ = '20201015'
+__version__ = '20201022'
 
 
 def get_version():

--- a/timesketch/api/v1/resources/analysis.py
+++ b/timesketch/api/v1/resources/analysis.py
@@ -125,10 +125,11 @@ class AnalyzerRunResource(resources.ResourceMixin, Resource):
         if not sketch:
             abort(
                 HTTP_STATUS_CODE_NOT_FOUND, 'No sketch found with this ID.')
-        if not sketch.has_permission(current_user, 'read'):
+
+        if not sketch.has_permission(current_user, 'write'):
             return abort(
                 HTTP_STATUS_CODE_FORBIDDEN,
-                'User does not have read permission on the sketch.')
+                'User does not have write permission on the sketch.')
 
         form = request.json
         if not form:

--- a/timesketch/api/v1/resources/timeline.py
+++ b/timesketch/api/v1/resources/timeline.py
@@ -242,12 +242,12 @@ class TimelineResource(resources.ResourceMixin, Resource):
                 abort(
                     HTTP_STATUS_CODE_BAD_REQUEST, (
                         'Label needs to be a JSON string that '
-                        'converts a list of strings [{}] {}'.format(type(labels), labels)))
+                        'converts to a list of strings.'))
             if not all([isinstance(x, str) for x in labels]):
                 abort(
                     HTTP_STATUS_CODE_BAD_REQUEST, (
                         'Label needs to be a JSON string that '
-                        'converts a list of strings (not all strings)'))
+                        'converts to a list of strings (not all strings)'))
 
             label_action = form.label_action.data
             if label_action not in ('add', 'remove'):

--- a/timesketch/api/v1/resources/timeline.py
+++ b/timesketch/api/v1/resources/timeline.py
@@ -226,11 +226,10 @@ class TimelineResource(resources.ResourceMixin, Resource):
                 HTTP_STATUS_CODE_FORBIDDEN,
                 'The user does not have write permission on the sketch.')
 
+        form = forms.TimelineForm.build(request)
         if not form.validate_on_submit():
             abort(
                 HTTP_STATUS_CODE_BAD_REQUEST, 'Unable to validate form data.')
-
-        form = forms.TimelineForm.build(request)
 
         if form.labels.data:
             label_string = form.labels.data

--- a/timesketch/api/v1/resources/timeline.py
+++ b/timesketch/api/v1/resources/timeline.py
@@ -15,6 +15,7 @@
 
 import codecs
 import json
+import logging
 import uuid
 import six
 
@@ -36,6 +37,9 @@ from timesketch.models import db_session
 from timesketch.models.sketch import SearchIndex
 from timesketch.models.sketch import Sketch
 from timesketch.models.sketch import Timeline
+
+
+logger = logging.getLogger('timesketch.timeline_api')
 
 
 class TimelineListResource(resources.ResourceMixin, Resource):
@@ -265,9 +269,14 @@ class TimelineResource(resources.ResourceMixin, Resource):
                         self._remove_label(timeline=timeline, label=label))
                 changed = any(changes)
 
-            if changed:
-                db_session.add(timeline)
-                db_session.commit()
+            if not changed:
+                abort(
+                    HTTP_STATUS_CODE_BAD_REQUEST,
+                    'Label [{0:s}] not {1:s}'.format(
+                        ', '.join(labels), label_action))
+
+            db_session.add(timeline)
+            db_session.commit()
             return HTTP_STATUS_CODE_OK
 
         timeline.name = form.name.data

--- a/timesketch/api/v1/resources/timeline.py
+++ b/timesketch/api/v1/resources/timeline.py
@@ -263,6 +263,12 @@ class TimelineResource(resources.ResourceMixin, Resource):
                         self._add_label(timeline=timeline, label=label))
                 changed = any(changes)
             elif label_action == 'remove':
+                if not sketch.has_permission(
+                        user=current_user, permission='delete'):
+                    abort(
+                        HTTP_STATUS_CODE_FORBIDDEN,
+                        'The user does not have delete permission on sketch.')
+
                 changes = []
                 for label in labels:
                     changes.append(

--- a/timesketch/api/v1/resources/upload.py
+++ b/timesketch/api/v1/resources/upload.py
@@ -64,7 +64,6 @@ class UploadFileResource(resources.ResourceMixin, Resource):
         # Check if search index already exists.
         searchindex = SearchIndex.query.filter_by(
             name=timeline_name,
-            description=timeline_name,
             user=current_user,
             index_name=index_name).first()
 

--- a/timesketch/lib/forms.py
+++ b/timesketch/lib/forms.py
@@ -126,7 +126,7 @@ class CreateTimelineForm(BaseForm):
 
 class TimelineForm(NameDescriptionForm):
     """Form to edit a timeline."""
-    labels = StringField('Label', validators=[Optional()])
+    labels = StringField('Labels', validators=[Optional()])
     label_action = StringField('LabelAction', validators=[Optional()])
     color = StringField(
         'Color',

--- a/timesketch/lib/forms.py
+++ b/timesketch/lib/forms.py
@@ -126,6 +126,8 @@ class CreateTimelineForm(BaseForm):
 
 class TimelineForm(NameDescriptionForm):
     """Form to edit a timeline."""
+    labels = StringField('Label', validators=[Optional()])
+    label_action = StringField('LabelAction', validators=[Optional()])
     color = StringField(
         'Color',
         validators=[DataRequired(),


### PR DESCRIPTION
This PR includes few fixes to the API and API client:

+ Fix a bug in uploads where multiple timelines could be generated, #1422
+ Adding an API to add/remove labels from timelines, #1423
+ Making it a requirement to have write access to a sketch to be able to run an analyzer (since it modifies the data)