### PR TITLE
Fix a bug in the API client

### DIFF
--- a/api_client/python/timesketch_api_client/client.py
+++ b/api_client/python/timesketch_api_client/client.py
@@ -297,7 +297,9 @@ class TimesketchApi(object):
         if auth_mode == 'http-basic':
             session.auth = (username, password)
 
-        session.verify = verify  # Depending if SSL cert is verifiable
+        # SSL Cert verification is turned on by default.
+        if not verify:
+            session.verify = False
 
         # Get and set CSRF token and authenticate the session if appropriate.
         self._set_csrf_token(session)

--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -130,20 +130,24 @@ class Sketch(resource.BaseResource):
     @property
     def attributes(self):
         """Property that returns the sketch attributes."""
-        data = self.lazyload_data()
+        data = self.lazyload_data(refresh_cache=True)
         meta = data.get('meta', {})
-        return meta.get('attributes', [])
+        return_dict = {}
+        for items in meta.get('attributes', []):
+            name, values, ontology = items
+            return_dict[name] = (values, ontology)
 
+        return return_dict
 
     @property
     def attributes_table(self):
         """Property that returns the sketch attributes as a data frame."""
-        data = self.lazyload_data()
+        data = self.lazyload_data(refresh_cache=True)
         meta = data.get('meta', {})
         attributes = meta.get('attributes', [])
 
         data_frame = pandas.DataFrame(attributes)
-        data_frame.columns = ['name', 'attributes', 'ontology']
+        data_frame.columns = ['attribute', 'values', 'ontology']
 
         return data_frame
 

--- a/api_client/python/timesketch_api_client/version.py
+++ b/api_client/python/timesketch_api_client/version.py
@@ -14,7 +14,7 @@
 """Version information for Timesketch API Client."""
 
 
-__version__ = '20201023'
+__version__ = '20201027'
 
 
 def get_version():


### PR DESCRIPTION
Fixing a bug in the API Client.

If `verify=True` is set in the code (which is turned on by default) this is called:
```
session.verify = True
```

However that is not how the API works, SSL certificate verification is turned on by default, and according to the [tools documentation](https://requests.readthedocs.io/en/master/user/advanced/#ssl-cert-verification) it should be:

```
s.verify = '/path/to/certfile'
```

For a specific Certificate file verification. Since this is set to `True` in the code the following errors occurs when using `timesketch` as the authentication mechanism:

```
OSError: Could not find a suitable TLS CA certificate bundle, invalid path: True
```

Also changing how attributes are returned, to make it easier to search for them.