### PR TITLE
Stripping pagination from saved views.

### DIFF
--- a/api_client/python/timesketch_api_client/story.py
+++ b/api_client/python/timesketch_api_client/story.py
@@ -491,6 +491,7 @@ class Story(resource.BaseResource):
                     group_obj.from_store(block.group_id)
                     block.feed(group_obj)
                 self._blocks.append(block)
+                index += 1
         return self._blocks
 
     @property

--- a/api_client/python/timesketch_api_client/version.py
+++ b/api_client/python/timesketch_api_client/version.py
@@ -14,7 +14,7 @@
 """Version information for Timesketch API Client."""
 
 
-__version__ = '20201027'
+__version__ = '20201029'
 
 
 def get_version():

--- a/timesketch/api/v1/resources/view.py
+++ b/timesketch/api/v1/resources/view.py
@@ -52,7 +52,12 @@ class ViewListResource(resources.ResourceMixin, Resource):
         # Default to user supplied data
         view_name = form.name.data
         query_string = form.query.data
-        query_filter = json.dumps(form.filter.data, ensure_ascii=False)
+
+        query_filter_dict = form.filter.data
+        # Stripping potential pagination from views before saving it.
+        if 'from' in query_filter_dict:
+            del query_filter_dict['from']
+        query_filter = json.dumps(query_filter_dict, ensure_ascii=False)
         query_dsl = json.dumps(form.dsl.data, ensure_ascii=False)
 
         if isinstance(query_filter, tuple):
@@ -269,7 +274,13 @@ class ViewResource(resources.ResourceMixin, Resource):
                   'User does not have write access controls on sketch.')
         view = View.query.get(view_id)
         view.query_string = form.query.data
-        view.query_filter = json.dumps(form.filter.data, ensure_ascii=False)
+
+        query_filter = form.filter.data
+        # Stripping potential pagination from views before saving it.
+        if 'from' in query_filter:
+            del query_filter['from']
+        view.query_filter = json.dumps(query_filter, ensure_ascii=False)
+
         view.query_dsl = json.dumps(form.dsl.data, ensure_ascii=False)
         view.user = current_user
         view.sketch = sketch


### PR DESCRIPTION
If you create a view, or a saved search from the UI while not viewing the first page of a result the pagination information is not removed.

This causes the views to fail in the API client (`from` is not known in the query_filter) as well as in stories.

This PR strips the pagination from the `query_filter` before a view is updated or created.

There is also a small fix for updating the index in the story.blocks for the API client.