### PR TITLE
Improve error handling in the get_client function of the config API client module

### DIFF
--- a/api_client/python/timesketch_api_client/config.py
+++ b/api_client/python/timesketch_api_client/config.py
@@ -56,6 +56,12 @@ def get_client(config_dict=None, config_path='', token_password=''):
     try:
         configure_missing_parameters(assistant, token_password)
         return assistant.get_client(token_password=token_password)
+    except (RuntimeError, requests.ConnectionError) as e:
+        logger.error(
+            'Unable to connect to the Timesketch server, are you '
+            'connected to the network? Is the timesketch server '
+            'running and accessible from your host? The error '
+            'message is %s', e)
     except IOError as e:
         logger.error('Unable to get a client, with error: %s', e)
         logger.error(
@@ -64,12 +70,6 @@ def get_client(config_dict=None, config_path='', token_password=''):
             'credential section in ~/.timesketchrc or to remove '
             'both files. Or you could have supplied a wrong '
             'password to undecrypt the token file.')
-    except RuntimeError, requests.ConnectionError as e:
-        logger.error(
-            'Unable to connect to the Timesketch server, are you '
-            'connected to the network? Is the timesketch server '
-            'running and accessible from your host? The error '
-            'message is %s', e)
 
 
 def configure_missing_parameters(config_assistant, token_password=''):

--- a/api_client/python/timesketch_api_client/config.py
+++ b/api_client/python/timesketch_api_client/config.py
@@ -17,6 +17,7 @@ from __future__ import unicode_literals
 import configparser
 import logging
 import os
+import requests
 
 from google.auth.transport import requests as auth_requests
 
@@ -39,14 +40,36 @@ def get_client(config_dict=None, config_path='', token_password=''):
             not supplied a default path will be used.
         token_password (str): an optional password to decrypt
             the credential token file.
+
+    Returns:
+        A timesketch client (TimesketchApi) or None if not possible.
     """
     assistant = ConfigAssistant()
-    assistant.load_config_file(config_path)
-    if config_dict:
-        assistant.load_config_dict(config_dict)
+    try:
+        assistant.load_config_file(config_path)
+        if config_dict:
+            assistant.load_config_dict(config_dict)
+    except IOError as e:
+        logger.error('Unable to load the config file, is it valid?')
+        logger.error('Error: %s', e)
 
-    configure_missing_parameters(assistant, token_password)
-    return assistant.get_client(token_password=token_password)
+    try:
+        configure_missing_parameters(assistant, token_password)
+        return assistant.get_client(token_password=token_password)
+    except IOError as e:
+        logger.error('Unable to get a client, with error: %s', e)
+        logger.error(
+            'If the issue is in the credentials then one solution '
+            'is to remove the ~/.timesketch.token file and the '
+            'credential section in ~/.timesketchrc or to remove '
+            'both files. Or you could have supplied a wrong '
+            'password to undecrypt the token file.')
+    except RuntimeError, requests.ConnectionError as e:
+        logger.error(
+            'Unable to connect to the Timesketch server, are you '
+            'connected to the network? Is the timesketch server '
+            'running and accessible from your host? The error '
+            'message is %s', e)
 
 
 def configure_missing_parameters(config_assistant, token_password=''):

--- a/api_client/python/timesketch_api_client/version.py
+++ b/api_client/python/timesketch_api_client/version.py
@@ -14,7 +14,7 @@
 """Version information for Timesketch API Client."""
 
 
-__version__ = '20201029'
+__version__ = '20201030'
 
 
 def get_version():


### PR DESCRIPTION
Improving the error handing of the `get_client` method in the config module.

The idea is to provide a bit more guidance in case the function fails to produce a client.