### PR TITLE
fix https://github.com/google/timesketch/issues/1450

### DIFF
--- a/timesketch/lib/analyzers/interface.py
+++ b/timesketch/lib/analyzers/interface.py
@@ -159,7 +159,7 @@ class Event(object):
 
         if not event_to_commit:
             return
-            
+
         self.datastore.import_event(
             self.index_name, self.event_type, event_id=self.event_id,
             event=event_to_commit, flush_interval=1)

--- a/timesketch/lib/analyzers/interface.py
+++ b/timesketch/lib/analyzers/interface.py
@@ -159,6 +159,7 @@ class Event(object):
 
         if not event_to_commit:
             return
+            
         self.datastore.import_event(
             self.index_name, self.event_type, event_id=self.event_id,
             event=event_to_commit, flush_interval=1)

--- a/timesketch/lib/analyzers/interface.py
+++ b/timesketch/lib/analyzers/interface.py
@@ -159,10 +159,9 @@ class Event(object):
 
         if not event_to_commit:
             return
-
         self.datastore.import_event(
             self.index_name, self.event_type, event_id=self.event_id,
-            event=event_to_commit)
+            event=event_to_commit, flush_interval=1)
         self.updated_event = {}
 
     def add_attributes(self, attributes):


### PR DESCRIPTION
Can be tested with:

```
# Try to understand https://github.com/google/timesketch/issues/1450

# connect to TS
from timesketch_api_client import config

ts_client = config.get_client()

ts_client.create_sketch("Demo sketch")

ts_client = config.get_client()
[(x.id, x.name) for x in ts_client.list_sketches()]

sketch = ts_client.get_sketch(1)

from timesketch_import_client import importer


with importer.ImportStreamer() as streamer:
  streamer.set_sketch(sketch)
  streamer.set_timeline_name('test data')
  streamer.set_timestamp_description('some_description')

  streamer.add_file('../test_tools/test_events/sigma_events.jsonl')
from timesketch_import_client import importer


with importer.ImportStreamer() as streamer:
  streamer.set_sketch(sketch)
  streamer.set_timeline_name('test data')
  streamer.set_timestamp_description('some_description')

  streamer.add_file('../test_tools/test_events/sigma_events.jsonl')

#get the correct timeline

[(x.id, x.name) for x in sketch.list_timelines()]

# copy the rule to get it tested
!cp ../data/sigma/rules/lnx_susp_zenmap.yml ../data/sigma/rules/lnx_susp_zenmap2.yml

result = sketch.run_analyzer("Sigma", timeline_id=1)

result2 = sketch.get_analyzer_status() # will give all the ran analyzers, so need to filter
for job in result2:
    if (job['analyzer'] == "Sigma"):
            if (job['timeline_id'] == int(1)):
                                import pprint
                                pp = pprint.PrettyPrinter(indent=4)
                                pp.pprint(job)

# remove the rule at the end again
!rm ../data/sigma/rules/lnx_susp_zenmap2.yml
```

This addresses: https://github.com/google/timesketch/issues/1450
I have not seen any side effects caused by the change.