### PR TITLE
Minor changes to the search API object.

### DIFF
--- a/api_client/python/timesketch_api_client/search.py
+++ b/api_client/python/timesketch_api_client/search.py
@@ -584,6 +584,9 @@ class Search(resource.SketchResource):
         self._name = 'From Explore'
         self._description = 'From Explore'
 
+        if query_filter:
+          self.query_filter = query_filter
+
         self._query_string = query_string
         self._query_dsl = query_dsl
         self._return_fields = return_fields
@@ -627,7 +630,9 @@ class Search(resource.SketchResource):
         self._description = data.get('description', '')
         self._name = data.get('name', '')
         self._query_dsl = data.get('query_dsl', '')
-        self._query_filter = data.get('query_filter', {})
+        query_filter = data.get('query_filter', {}
+        if query_filter:
+            self.query_filter = query_filter
         self._query_string = data.get('query_string', '')
         self._resource_id = search_id
         self._searchtemplate = data.get('searchtemplate', 0)
@@ -701,6 +706,7 @@ class Search(resource.SketchResource):
     def query_filter(self, query_filter):
         """Make changes to the query filter."""
         self._query_filter = query_filter
+        self._extract_chips(query_filter)
         self.commit()
 
     @property

--- a/api_client/python/timesketch_api_client/search.py
+++ b/api_client/python/timesketch_api_client/search.py
@@ -371,6 +371,7 @@ class Search(resource.SketchResource):
               date, before, after = value.split()
               unit = before[-1]
               chip.unit = unit
+              chip.date = date
               chip.before = int(before[1:-1])
               chip.after = int(after[1:-1])
 
@@ -630,9 +631,9 @@ class Search(resource.SketchResource):
         self._description = data.get('description', '')
         self._name = data.get('name', '')
         self._query_dsl = data.get('query_dsl', '')
-        query_filter = data.get('query_filter', {}
+        query_filter = data.get('query_filter', '')
         if query_filter:
-            self.query_filter = query_filter
+            self.query_filter = json.loads(query_filter)
         self._query_string = data.get('query_string', '')
         self._resource_id = search_id
         self._searchtemplate = data.get('searchtemplate', 0)
@@ -705,6 +706,11 @@ class Search(resource.SketchResource):
     @query_filter.setter
     def query_filter(self, query_filter):
         """Make changes to the query filter."""
+        if isinstance(query_filter, str):
+            query_filter = json.loads(query_filter)
+
+        if not isinstance(query_filter, dict):
+            raise ValueError('Query filter needs to be a dict.')
         self._query_filter = query_filter
         self._extract_chips(query_filter)
         self.commit()

--- a/api_client/python/timesketch_api_client/search.py
+++ b/api_client/python/timesketch_api_client/search.py
@@ -367,37 +367,37 @@ class Search(resource.SketchResource):
                 continue
 
             if chip_type == 'datetime_interval':
-              chip = DateIntervalChip()
-              date, before, after = value.split()
-              unit = before[-1]
-              chip.unit = unit
-              chip.date = date
-              chip.before = int(before[1:-1])
-              chip.after = int(after[1:-1])
+                chip = DateIntervalChip()
+                date, before, after = value.split()
+                unit = before[-1]
+                chip.unit = unit
+                chip.date = date
+                chip.before = int(before[1:-1])
+                chip.after = int(after[1:-1])
 
             elif chip_type == 'datetime_range':
-              chip = DateRangeChip()
-              start, end = value.split(',')
-              chip.start_time = start
-              chip.end_time = end
+                chip = DateRangeChip()
+                start, end = value.split(',')
+                chip.start_time = start
+                chip.end_time = end
 
             elif chip_type == 'label':
-              chip = LabelChip()
-              chip.label = value
+                chip = LabelChip()
+                chip.label = value
 
             elif chip_type == 'term':
-              chip = TermChip()
-              chip.field = chip_dict.get('field')
-              chip.query = value
+                chip = TermChip()
+                chip.field = chip_dict.get('field')
+                chip.query = value
 
             active = chip_dict.get('active', True)
             chip.active = active
 
             operator = chip_dict.get('operator', 'must')
             if operator == 'must':
-              chip.set_include()
+                chip.set_include()
             elif operator == 'must_not':
-              chip.set_exclude()
+                chip.set_exclude()
 
             self.add_chip(chip)
 
@@ -586,7 +586,7 @@ class Search(resource.SketchResource):
         self._description = 'From Explore'
 
         if query_filter:
-          self.query_filter = query_filter
+            self.query_filter = query_filter
 
         self._query_string = query_string
         self._query_dsl = query_dsl


### PR DESCRIPTION
This PR adds few things in the API client:

1. Fixes the `from_explore` function that should have been renamed last time
2. Chips weren't preserved when reading from saved searches, nor where they when the query filter was manually set. This is now fixed.
3. It is now possible to change the name and description of a timeline object in the API client.