### PR TITLE
Various updates to the API Client

### DIFF
--- a/api_client/python/timesketch_api_client/aggregation.py
+++ b/api_client/python/timesketch_api_client/aggregation.py
@@ -249,8 +249,8 @@ class Aggregation(resource.SketchResource):
         return self._parameters
 
     @property
-    def part_of_a_group(self):
-        """Property that returns bool indicating if the agg is part of a group."""
+    def is_part_of_group(self):
+        """Property that returns whether an agg is part of a group or not."""
         if self._group_id is None:
             return False
 

--- a/api_client/python/timesketch_api_client/aggregation.py
+++ b/api_client/python/timesketch_api_client/aggregation.py
@@ -45,6 +45,7 @@ class Aggregation(resource.SketchResource):
         self._created_at = ''
         self._parameters = {}
         self._updated_at = ''
+        self._group_id = None
         self.aggregator_name = ''
         self.chart_color = ''
         self.chart_type = ''
@@ -151,6 +152,7 @@ class Aggregation(resource.SketchResource):
 
         self._created_at = data.get('created_at', '')
         self._updated_at = data.get('updated_at', '')
+        self._group_id = data.get('aggregationgroup_id')
 
         label_string = data.get('label_string', '')
         if label_string:
@@ -245,6 +247,14 @@ class Aggregation(resource.SketchResource):
     def parameters(self):
         """Property that returns the parameters of the aggregation."""
         return self._parameters
+
+    @property
+    def part_of_a_group(self):
+        """Property that returns bool indicating if the agg is part of a group."""
+        if self._group_id is None:
+            return False
+
+        return bool(self._group_id)
 
     @property
     def title(self):
@@ -425,6 +435,11 @@ class AggregationGroup(resource.SketchResource):
             self._resource_id, self._name, self._description)
 
     @property
+    def aggregations(self):
+        """Property that returns a list of aggregations in the group."""
+        return self._aggregations
+
+    @property
     def created_at(self):
         """Returns a timestamp when the aggregation group was created."""
         return self._created_at
@@ -572,7 +587,6 @@ class AggregationGroup(resource.SketchResource):
 
         group_dict = objects[0]
         group_dict['id'] = group_id
-        print(group_dict)
         self.from_dict(group_dict)
 
     def generate_chart(self):

--- a/api_client/python/timesketch_api_client/search.py
+++ b/api_client/python/timesketch_api_client/search.py
@@ -719,7 +719,7 @@ class Search(resource.SketchResource):
     @query_dsl.setter
     def query_dsl(self, query_dsl):
         """Make changes to the query DSL of the search."""
-        if isinstance(query_dsl, str):
+        if query_dsl and isinstance(query_dsl, str):
             query_dsl = json.loads(query_dsl)
 
         # Special condition of an empty DSL.

--- a/api_client/python/timesketch_api_client/search.py
+++ b/api_client/python/timesketch_api_client/search.py
@@ -655,7 +655,7 @@ class Search(resource.SketchResource):
         self._created_at = data.get('created_at', '')
         self._description = data.get('description', '')
         self._name = data.get('name', '')
-        self._query_dsl = data.get('query_dsl', '')
+        self.query_dsl = data.get('query_dsl', '')
         query_filter = data.get('query_filter', '')
         if query_filter:
             filter_dict = json.loads(query_filter)
@@ -719,6 +719,13 @@ class Search(resource.SketchResource):
     @query_dsl.setter
     def query_dsl(self, query_dsl):
         """Make changes to the query DSL of the search."""
+        if isinstance(query_dsl, str):
+            query_dsl = json.loads(query_dsl)
+
+        # Special condition of an empty DSL.
+        if query_dsl == '""':
+            query_dsl = ''
+
         self._query_dsl = query_dsl
         self.commit()
 

--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -589,7 +589,7 @@ class Sketch(resource.BaseResource):
             if not group_dict.get('id'):
                 continue
             group = aggregation.AggregationGroup(sketch=self)
-            group.from_dict(group_dict)
+            group.from_saved(group_dict.get('id'))
             groups.append(group)
         return groups
 

--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -585,8 +585,6 @@ class Sketch(resource.BaseResource):
             f'sketches/{self.id}/aggregation/group/')
 
         for group_dict in data.get('objects', []):
-            print(group_dict)
-            print(type(group_dict))
             if not group_dict.get('id'):
                 continue
             group = aggregation.AggregationGroup(sketch=self)

--- a/api_client/python/timesketch_api_client/timeline.py
+++ b/api_client/python/timesketch_api_client/timeline.py
@@ -212,8 +212,9 @@ class Timeline(resource.BaseResource):
                 result_analyzer = result.get('analyzer_name', 'N/A')
                 if fnmatch.fnmatch(result_analyzer, analyzer_name):
                     logger.error(
-                        f'Analyzer {result_analyzer} has already been run on '
-                        f'the timeline, use "ignore_previous=True" to overwrite')
+                        'Analyzer {0:s} has already been run on the timeline, '
+                        'use "ignore_previous=True" to overwrite'.format(
+                            result_analyzer))
                     stop_running = True
 
             if stop_running:

--- a/api_client/python/timesketch_api_client/version.py
+++ b/api_client/python/timesketch_api_client/version.py
@@ -14,7 +14,7 @@
 """Version information for Timesketch API Client."""
 
 
-__version__ = '20201219'
+__version__ = '20210106'
 
 
 def get_version():

--- a/timesketch/api/v1/resources/__init__.py
+++ b/timesketch/api/v1/resources/__init__.py
@@ -55,8 +55,8 @@ class ResourceMixin(object):
         'chart_type': fields.String,
         'label_string': fields.String,
         'user': fields.Nested(user_fields),
-        'created_at': fields.DateTime,
-        'updated_at': fields.DateTime
+        'created_at': fields.DateTime('iso8601'),
+        'updated_at': fields.DateTime('iso8601')
     }
 
     aggregation_group_fields = {
@@ -67,15 +67,15 @@ class ResourceMixin(object):
         'parameters': fields.String,
         'orientation': fields.String,
         'user': fields.Nested(user_fields),
-        'created_at': fields.DateTime,
-        'updated_at': fields.DateTime
+        'created_at': fields.DateTime('iso8601'),
+        'updated_at': fields.DateTime('iso8601')
     }
 
     status_fields = {
         'id': fields.Integer,
         'status': fields.String,
-        'created_at': fields.DateTime,
-        'updated_at': fields.DateTime
+        'created_at': fields.DateTime('iso8601'),
+        'updated_at': fields.DateTime('iso8601')
     }
 
     searchindex_fields = {
@@ -87,8 +87,8 @@ class ResourceMixin(object):
         'status': fields.Nested(status_fields),
         'label_string': fields.String,
         'deleted': fields.Boolean,
-        'created_at': fields.DateTime,
-        'updated_at': fields.DateTime
+        'created_at': fields.DateTime('iso8601'),
+        'updated_at': fields.DateTime('iso8601')
     }
 
     timeline_fields = {
@@ -101,8 +101,8 @@ class ResourceMixin(object):
         'label_string': fields.String,
         'searchindex': fields.Nested(searchindex_fields),
         'deleted': fields.Boolean,
-        'created_at': fields.DateTime,
-        'updated_at': fields.DateTime
+        'created_at': fields.DateTime('iso8601'),
+        'updated_at': fields.DateTime('iso8601')
     }
 
     analysis_fields = {
@@ -117,16 +117,16 @@ class ResourceMixin(object):
         'user': fields.Nested(user_fields),
         'timeline': fields.Nested(timeline_fields),
         'status': fields.Nested(status_fields),
-        'created_at': fields.DateTime,
-        'updated_at': fields.DateTime
+        'created_at': fields.DateTime('iso8601'),
+        'updated_at': fields.DateTime('iso8601')
     }
 
     analysis_session_fields = {
         'id': fields.Integer,
         'user': fields.Nested(user_fields),
         'analyses': fields.Nested(analysis_fields),
-        'created_at': fields.DateTime,
-        'updated_at': fields.DateTime
+        'created_at': fields.DateTime('iso8601'),
+        'updated_at': fields.DateTime('iso8601')
     }
 
     searchtemplate_fields = {
@@ -136,8 +136,8 @@ class ResourceMixin(object):
         'query_string': fields.String,
         'query_filter': fields.String,
         'query_dsl': fields.String,
-        'created_at': fields.DateTime,
-        'updated_at': fields.DateTime
+        'created_at': fields.DateTime('iso8601'),
+        'updated_at': fields.DateTime('iso8601')
     }
 
     view_fields = {
@@ -150,8 +150,8 @@ class ResourceMixin(object):
         'query_dsl': fields.String,
         'searchtemplate': fields.Nested(searchtemplate_fields),
         'aggregation': fields.Nested(aggregation_fields),
-        'created_at': fields.DateTime,
-        'updated_at': fields.DateTime
+        'created_at': fields.DateTime('iso8601'),
+        'updated_at': fields.DateTime('iso8601')
     }
 
     story_fields = {
@@ -159,8 +159,8 @@ class ResourceMixin(object):
         'title': fields.String,
         'content': fields.String,
         'user': fields.Nested(user_fields),
-        'created_at': fields.DateTime,
-        'updated_at': fields.DateTime
+        'created_at': fields.DateTime('iso8601'),
+        'updated_at': fields.DateTime('iso8601')
     }
 
     graph_fields = {
@@ -168,16 +168,16 @@ class ResourceMixin(object):
         'name': fields.String,
         'user': fields.Nested(user_fields),
         'description': fields.String,
-        'created_at': fields.DateTime,
-        'updated_at': fields.DateTime
+        'created_at': fields.DateTime('iso8601'),
+        'updated_at': fields.DateTime('iso8601')
     }
 
     graphcache_fields = {
         'id': fields.Integer,
         'graph_elements': fields.String,
         'graph_config': fields.String,
-        'created_at': fields.DateTime,
-        'updated_at': fields.DateTime
+        'created_at': fields.DateTime('iso8601'),
+        'updated_at': fields.DateTime('iso8601')
     }
 
     sketch_fields = {
@@ -195,22 +195,22 @@ class ResourceMixin(object):
         'status': fields.Nested(status_fields),
         'all_permissions': fields.String,
         'my_permissions': fields.String,
-        'created_at': fields.DateTime,
-        'updated_at': fields.DateTime
+        'created_at': fields.DateTime('iso8601'),
+        'updated_at': fields.DateTime('iso8601')
     }
 
     comment_fields = {
         'comment': fields.String,
         'user': fields.Nested(user_fields),
-        'created_at': fields.DateTime,
-        'updated_at': fields.DateTime
+        'created_at': fields.DateTime('iso8601'),
+        'updated_at': fields.DateTime('iso8601')
     }
 
     label_fields = {
         'name': fields.String,
         'user': fields.Nested(user_fields),
-        'created_at': fields.DateTime,
-        'updated_at': fields.DateTime
+        'created_at': fields.DateTime('iso8601'),
+        'updated_at': fields.DateTime('iso8601')
     }
 
     fields_registry = {

--- a/timesketch/api/v1/resources/__init__.py
+++ b/timesketch/api/v1/resources/__init__.py
@@ -55,6 +55,7 @@ class ResourceMixin(object):
         'chart_type': fields.String,
         'label_string': fields.String,
         'user': fields.Nested(user_fields),
+        'aggregationgroup_id': fields.Integer,
         'created_at': fields.DateTime('iso8601'),
         'updated_at': fields.DateTime('iso8601')
     }
@@ -188,8 +189,6 @@ class ResourceMixin(object):
         'timelines': fields.List(fields.Nested(timeline_fields)),
         'stories': fields.List(fields.Nested(story_fields)),
         'graphs': fields.List(fields.Nested(graph_fields)),
-        'aggregations': fields.Nested(aggregation_fields),
-        'aggregationgroups': fields.Nested(aggregation_group_fields),
         'active_timelines': fields.List(fields.Nested(timeline_fields)),
         'label_string': fields.String,
         'status': fields.Nested(status_fields),

--- a/timesketch/api/v1/resources/aggregation.py
+++ b/timesketch/api/v1/resources/aggregation.py
@@ -19,6 +19,7 @@ import time
 from flask import jsonify
 from flask import request
 from flask import abort
+from flask_restful import marshal
 from flask_restful import Resource
 from flask_login import login_required
 from flask_login import current_user
@@ -292,7 +293,17 @@ class AggregationGroupResource(resources.ResourceMixin, Resource):
 
         _, objects, meta = utils.run_aggregator_group(
             group, sketch_id=sketch.id)
-        schema = {'meta': meta, 'objects': objects}
+
+        group_fields = self.fields_registry[group.__tablename__]
+        group_dict = marshal(group, group_fields)
+        group_dict['agg_ids'] = [a.id for a in group.aggregations]
+
+        objects[0].update(group_dict)
+
+        schema = {
+            'meta': meta,
+            'objects': objects
+        }
 
         # Update the last activity of a sketch.
         utils.update_sketch_last_activity(sketch)

--- a/timesketch/api/v1/resources/analysis.py
+++ b/timesketch/api/v1/resources/analysis.py
@@ -179,9 +179,9 @@ class AnalyzerRunResource(resources.ResourceMixin, Resource):
                 if fnmatch.fnmatch(correct_name, analyzer):
                     analyzers.append(correct_name)
 
-        return abort(
-            HTTP_STATUS_CODE_BAD_REQUEST,
-            ','.join(analyzers))
+        if not analyzers:
+            return abort(
+                HTTP_STATUS_CODE_BAD_REQUEST, 'No analyzers found to run.')
 
         # Import here to avoid circular imports.
         # pylint: disable=import-outside-toplevel

--- a/timesketch/api/v1/resources/analysis.py
+++ b/timesketch/api/v1/resources/analysis.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Analysis resources for version 1 of the Timesketch API."""
+import fnmatch
 
 from flask import jsonify
 from flask import request
@@ -170,13 +171,25 @@ class AnalyzerRunResource(resources.ResourceMixin, Resource):
                     HTTP_STATUS_CODE_BAD_REQUEST,
                     'Kwargs needs to be a dictionary of parameters.')
 
+        analyzers = []
+        all_analyzers = [
+            x for x, _ in analyzer_manager.AnalysisManager.get_analyzers()]
+        for analyzer in analyzer_names:
+            for correct_name in all_analyzers:
+                if fnmatch.fnmatch(correct_name, analyzer):
+                    analyzers.append(correct_name)
+
+        return abort(
+            HTTP_STATUS_CODE_BAD_REQUEST,
+            ','.join(analyzers))
+
         # Import here to avoid circular imports.
         # pylint: disable=import-outside-toplevel
         from timesketch.lib import tasks
         try:
             analyzer_group, session_id = tasks.build_sketch_analysis_pipeline(
                 sketch_id=sketch_id, searchindex_id=search_index.id,
-                user_id=current_user.id, analyzer_names=analyzer_names,
+                user_id=current_user.id, analyzer_names=analyzers,
                 analyzer_kwargs=analyzer_kwargs)
         except KeyError as e:
             return abort(

--- a/timesketch/api/v1/resources/sketch.py
+++ b/timesketch/api/v1/resources/sketch.py
@@ -257,8 +257,6 @@ class SketchResource(resources.ResourceMixin, Resource):
             'user': {'username': current_user.username},
             'timelines': [],
             'stories': [],
-            'aggregations': [],
-            'aggregationgroups': [],
             'active_timelines': [],
             'label_string': sketch.label_string,
             'status': [{

--- a/timesketch/lib/google_auth.py
+++ b/timesketch/lib/google_auth.py
@@ -210,7 +210,7 @@ def decode_jwt(encoded_jwt, public_key, algorithm, expected_audience):
     """
     try:
         decoded_jwt = jwt.decode(
-            encoded_jwt, public_key, algorithm=algorithm,
+            jwt=encoded_jwt, key=public_key, algorithms=[algorithm],
             audience=expected_audience)
         return decoded_jwt
     except (jwt.exceptions.InvalidTokenError,

--- a/timesketch/lib/google_auth.py
+++ b/timesketch/lib/google_auth.py
@@ -75,7 +75,7 @@ def _fetch_public_keys(url):
     try:
         resp = requests.get(url)
     except requests.exceptions.RequestException as e:
-        raise JwtKeyError('Cannot fetch public keys: {}'.format(e))
+        raise JwtKeyError('Cannot fetch public keys: {}'.format(e)) from e
     if resp.status_code != HTTP_STATUS_CODE_OK:
         raise JwtKeyError(
             'Cannot fetch public keys: {}'.format(resp.status_code))
@@ -95,7 +95,7 @@ def _fetch_oauth2_discovery_document():
         resp = requests.get(DISCOVERY_URL)
     except requests.exceptions.RequestException as e:
         raise DiscoveryDocumentError(
-            'Cannot fetch discovery document: {}'.format(e))
+            'Cannot fetch discovery document: {}'.format(e)) from e
     if resp.status_code != HTTP_STATUS_CODE_OK:
         raise DiscoveryDocumentError(
             'Cannot fetch discovery_document: {}'.format(resp.status_code))
@@ -182,7 +182,7 @@ def get_encoded_jwt_over_https(code):
         encoded_jwt = response.json().get('id_token')
     except requests.exceptions.RequestException as e:
         raise JwtFetchError(
-            'Cannot fetch JWT: {}'.format(e))
+            'Cannot fetch JWT: {}'.format(e)) from e
     if response.status_code != HTTP_STATUS_CODE_OK:
         raise JwtFetchError(
             'Cannot fetch JWT: {}'.format(response.status_code))
@@ -215,7 +215,7 @@ def decode_jwt(encoded_jwt, public_key, algorithm, expected_audience):
         return decoded_jwt
     except (jwt.exceptions.InvalidTokenError,
             jwt.exceptions.InvalidKeyError) as e:
-        raise JwtValidationError('JWT validation error: {}'.format(e))
+        raise JwtValidationError('JWT validation error: {}'.format(e)) from e
 
     return None
 
@@ -253,15 +253,15 @@ def validate_jwt(decoded_jwt, expected_issuer, expected_domain=None):
         if expires_at < now:
             raise JwtValidationError('Token has expired')
     except KeyError as e:
-        raise JwtValidationError('Missing timestamp: {}'.format(e))
+        raise JwtValidationError('Missing timestamp: {}'.format(e)) from e
 
     # Check that the issuer of the token is correct.
     try:
         issuer = decoded_jwt['iss']
         if issuer != expected_issuer:
             raise JwtValidationError('Wrong issuer: {}'.format(issuer))
-    except KeyError:
-        raise JwtValidationError('Missing issuer')
+    except KeyError as e:
+        raise JwtValidationError('Missing issuer') from e
 
     if 'email' not in decoded_jwt:
         raise JwtValidationError('Missing email field in token')
@@ -272,7 +272,7 @@ def validate_jwt(decoded_jwt, expected_issuer, expected_domain=None):
             if not domain == expected_domain:
                 raise JwtValidationError('Wrong domain: {}'.format(domain))
         except KeyError as e:
-            raise JwtValidationError('Missing domain: {}'.format(e))
+            raise JwtValidationError('Missing domain: {}'.format(e)) from e
 
 
 def get_public_key_for_jwt(encoded_jwt, url):


### PR DESCRIPTION
This PR adds or changes:

+ Aggregation contains timestamps, same with AggregationGroups
+ All timestamps returned back in the API are now ISO formatted
+ Sketch resource data no longer contains all of the aggregation info (#1548)
+ Fixed an issue with search object and interpreting stored query DSL.
+ Minor changes to the parameters sent to the JWT library (reflections of library updates)
+ Add checks in `run_analyzer` to skip running analyzers that have already been run, #1547