### PR TITLE
Adding additional sleep to e2e tests.

### DIFF
--- a/end_to_end_tests/interface.py
+++ b/end_to_end_tests/interface.py
@@ -87,6 +87,10 @@ class BaseEndToEndTest(object):
                 break
             retry_count += 1
             time.sleep(sleep_time_seconds)
+
+        # Adding in one more sleep for good measure (preventing flaky tests).
+        time.sleep(sleep_time_seconds)
+
         self._imported_files.append(filename)
 
     def _get_test_methods(self):


### PR DESCRIPTION
The e2e tests are somewhat flaky, that is search queries are being made prior to the timelines to be fully indexed and ready to be queried.

This PR adds in a single short extra sleep after the timeline has been marked as ready.