### PR TITLE
First phase of new way of storing data in TS.

### DIFF
--- a/api_client/python/timesketch_api_client/config.py
+++ b/api_client/python/timesketch_api_client/config.py
@@ -321,6 +321,9 @@ class ConfigAssistant:
         if auth_mode == 'timesketch':
             auth_mode = 'userpass'
 
+        if not section:
+            section = 'timesketch'
+
         config[section] = {
             'host_uri': self._config.get('host_uri'),
             'username': self._config.get('username'),

--- a/api_client/python/timesketch_api_client/config.py
+++ b/api_client/python/timesketch_api_client/config.py
@@ -57,6 +57,11 @@ class ConfigAssistant:
         'client_secret',
     ])
 
+    EXTRA_FIELDS = frozenset([
+        'token_file_path',
+        'verify',
+    ])
+
     CONFIG_ORDERING = {
         'host_uri': 1,
         'auth_mode': 2,
@@ -265,6 +270,7 @@ class ConfigAssistant:
         """
         fields = list(self.CLIENT_NEEDED)
         fields.extend(list(self.OAUTH_CLIENT_NEEDED))
+        fields.extend(list(self.EXTRA_FIELDS))
 
         for key, value in config_dict.items():
             key = key.lower()

--- a/api_client/python/timesketch_api_client/search.py
+++ b/api_client/python/timesketch_api_client/search.py
@@ -706,17 +706,19 @@ class Search(resource.SketchResource):
                 'Indices needs to be a list of strings (indices that were '
                 'passed in were not a list).')
             return
-        if not all([isinstance(x, str) for x in indices]):
+        if not all([isinstance(x, (str, int)) for x in indices]):
             logger.warning(
-                'Indices needs to be a list of strings, not all entries '
-                'in the indices list are strings.')
+                'Indices needs to be a list of strings or ints, not all '
+                'entries in the indices list are valid string/int.')
             return
 
-        # Indices here can be either a list of timeline names or a list of
-        # search indices. We need to verify that these exist before saving
+        # Indices here can be either a list of timeline names, IDs or a list
+        # of search indices. We need to verify that these exist before saving
         # them.
         timelines = {
             t.index_name: t.name for t in self._sketch.list_timelines()}
+
+        valid_ids = [t.id for t in self._sketch.list_timelines()]
 
         new_indices = []
         for index in indices:
@@ -724,11 +726,18 @@ class Search(resource.SketchResource):
                 new_indices.append(index)
                 continue
 
+            if isinstance(index, int):
+                if index in valid_ids:
+                    new_indices.append(str(index))
+                    continue
+
+            if index.isdigit():
+                if int(index) in valid_ids:
+                    new_indices.append(index)
+                    continue
+
             if index in timelines.values():
-                for index_name, timeline_name in timelines.items():
-                    if timeline_name == index:
-                        new_indices.append(index_name)
-                        break
+                new_indices.append(index)
 
         if not new_indices:
             logger.warning('No valid indices found, not changin the value.')

--- a/api_client/python/timesketch_api_client/search.py
+++ b/api_client/python/timesketch_api_client/search.py
@@ -806,8 +806,6 @@ class Search(resource.SketchResource):
         """Property that returns the query filter."""
         if not self._query_filter:
             self._query_filter = {
-                'time_start': None,
-                'time_end': None,
                 'size': self.DEFAULT_SIZE_LIMIT,
                 'terminate_after': self.DEFAULT_SIZE_LIMIT,
                 'indices': self.indices,

--- a/api_client/python/timesketch_api_client/search_test.py
+++ b/api_client/python/timesketch_api_client/search_test.py
@@ -41,7 +41,6 @@ class SearchTest(unittest.TestCase):
         query_filter = search_obj.query_filter
 
         self.assertEqual(query_filter.get('chips'), [])
-        self.assertIsNone(query_filter.get('time_start', 'AA'))
 
     def test_from_manual(self):
         """Test fetching data."""

--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -885,13 +885,8 @@ class Sketch(resource.BaseResource):
         searches = []
         for saved_search in sketch['meta'].get('views', []):
             search_obj = search.Search(sketch=self)
-            try:
-                search_obj.from_saved(saved_search.get('id'))
-                searches.append(search_obj)
-            except ValueError:
-                logger.error(
-                    'Unable to load a saved search with ID: {0:d}'.format(
-                        saved_search.get('id',0)), exc_info=True)
+            search_obj.from_saved(saved_search.get('id'))
+            searches.append(search_obj)
 
         return searches
 
@@ -935,10 +930,9 @@ class Sketch(resource.BaseResource):
         # TODO: Deprecate this function.
         logger.warning(
             'This function is about to be deprecated, please use the '
-            'timesketch_import_client instead (this function is not '
-            'guaranteed to work)')
+            'timesketch_import_client instead')
 
-        resource_url = f'{self.api.api_root}/upload/'
+        resource_url = '{0:s}/upload/'.format(self.api.api_root)
         files = {'file': open(file_path, 'rb')}
         _, _, file_ending = file_path.rpartition('.')
         data = {

--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -930,12 +930,18 @@ class Sketch(resource.BaseResource):
         # TODO: Deprecate this function.
         logger.warning(
             'This function is about to be deprecated, please use the '
-            'timesketch_import_client instead')
+            'timesketch_import_client instead (this function is not '
+            'guaranteed to work)')
 
-        resource_url = '{0:s}/upload/'.format(self.api.api_root)
+        resource_url = f'{self.api.api_root}/upload/'
         files = {'file': open(file_path, 'rb')}
-        data = {'name': timeline_name, 'sketch_id': self.id,
-                'index_name': index}
+        _, _, file_ending = file_path.rpartition('.')
+        data = {
+            'name': timeline_name,
+            'sketch_id': self.id,
+            'label': file_ending,
+            'index_name': index}
+
         response = self.api.session.post(resource_url, files=files, data=data)
         response_dict = error.get_response_json(response, logger)
         timeline_dict = response_dict['objects'][0]
@@ -945,6 +951,7 @@ class Sketch(resource.BaseResource):
             api=self.api,
             name=timeline_dict['name'],
             searchindex=timeline_dict['searchindex']['index_name'])
+
         return timeline_obj
 
     def add_timeline(self, searchindex):

--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -885,8 +885,13 @@ class Sketch(resource.BaseResource):
         searches = []
         for saved_search in sketch['meta'].get('views', []):
             search_obj = search.Search(sketch=self)
-            search_obj.from_saved(saved_search.get('id'))
-            searches.append(search_obj)
+            try:
+                search_obj.from_saved(saved_search.get('id'))
+                searches.append(search_obj)
+            except ValueError:
+                logger.error(
+                    'Unable to load a saved search with ID: {0:d}'.format(
+                        saved_search.get('id',0)), exc_info=True)
 
         return searches
 

--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -530,8 +530,8 @@ class Sketch(resource.BaseResource):
         Returns:
             A boolean indicating whether the ACL change was successful.
         """
-        if not user_list and not group_list:
-            return True
+        if not user_list and not group_list and not make_public:
+            return False
 
         resource_url = '{0:s}/sketches/{1:d}/collaborators/'.format(
             self.api.api_root, self.id)

--- a/importer_client/python/timesketch_import_client/importer.py
+++ b/importer_client/python/timesketch_import_client/importer.py
@@ -59,6 +59,7 @@ class ImportStreamer(object):
         self._datetime_field = None
         self._format_string = None
         self._index = uuid.uuid4().hex
+        self._label = ''
         self._last_response = None
         self._resource_url = ''
         self._sketch = None
@@ -231,6 +232,7 @@ class ImportStreamer(object):
             'sketch_id': self._sketch.id,
             'enable_stream': not end_stream,
             'index_name': self._index,
+            'label': self._label,
             'events': '\n'.join([json.dumps(x) for x in self._data_lines]),
         }
         logger.debug(
@@ -272,6 +274,7 @@ class ImportStreamer(object):
             'sketch_id': self._sketch.id,
             'enable_stream': not end_stream,
             'index_name': self._index,
+            'label': self._label,
             'events': data_frame.to_json(orient='records', lines=True),
         }
 
@@ -308,6 +311,7 @@ class ImportStreamer(object):
             'name': timeline_name,
             'sketch_id': self._sketch.id,
             'total_file_size': file_size,
+            'label': self._label,
             'index_name': self._index,
         }
         if file_size <= self._threshold_filesize:
@@ -490,12 +494,14 @@ class ImportStreamer(object):
 
         self.add_data_frame(data_frame)
 
-    def add_file(self, filepath, delimiter=','):
+    def add_file(self, filepath, delimiter=',', label=''):
         """Add a CSV, JSONL or a PLASO file to the buffer.
 
         Args:
             filepath: the path to the file to add.
             delimiter: if this is a CSV file then a delimiter can be defined.
+            label: optional label of the timeline, used for determining whether
+                a new index is generated or not.
 
         Raises:
             TypeError: if the entry does not fulfill requirements.
@@ -511,6 +517,8 @@ class ImportStreamer(object):
             self.set_timeline_name(default_timeline_name)
 
         file_ending = filepath.lower().split('.')[-1]
+        self._label = label or file_ending
+
         if file_ending == 'csv':
             if self._csv_delimiter:
                 delimiter = self._csv_delimiter

--- a/importer_client/python/timesketch_import_client/importer.py
+++ b/importer_client/python/timesketch_import_client/importer.py
@@ -52,6 +52,7 @@ class ImportStreamer(object):
         """Initialize the upload streamer."""
         self._count = 0
         self._config_helper = None
+        self._data_label = ''
         self._dict_config_loaded = False
         self._csv_delimiter = None
         self._data_lines = []
@@ -59,7 +60,6 @@ class ImportStreamer(object):
         self._datetime_field = None
         self._format_string = None
         self._index = uuid.uuid4().hex
-        self._label = ''
         self._last_response = None
         self._resource_url = ''
         self._sketch = None
@@ -232,7 +232,7 @@ class ImportStreamer(object):
             'sketch_id': self._sketch.id,
             'enable_stream': not end_stream,
             'index_name': self._index,
-            'label': self._label,
+            'data_label': self._data_label,
             'events': '\n'.join([json.dumps(x) for x in self._data_lines]),
         }
         logger.debug(
@@ -274,7 +274,7 @@ class ImportStreamer(object):
             'sketch_id': self._sketch.id,
             'enable_stream': not end_stream,
             'index_name': self._index,
-            'label': self._label,
+            'data_label': self._data_label,
             'events': data_frame.to_json(orient='records', lines=True),
         }
 
@@ -311,7 +311,7 @@ class ImportStreamer(object):
             'name': timeline_name,
             'sketch_id': self._sketch.id,
             'total_file_size': file_size,
-            'label': self._label,
+            'data_label': self._data_label,
             'index_name': self._index,
         }
         if file_size <= self._threshold_filesize:
@@ -494,14 +494,12 @@ class ImportStreamer(object):
 
         self.add_data_frame(data_frame)
 
-    def add_file(self, filepath, delimiter=',', label=''):
+    def add_file(self, filepath, delimiter=','):
         """Add a CSV, JSONL or a PLASO file to the buffer.
 
         Args:
             filepath: the path to the file to add.
             delimiter: if this is a CSV file then a delimiter can be defined.
-            label: optional label of the timeline, used for determining whether
-                a new index is generated or not.
 
         Raises:
             TypeError: if the entry does not fulfill requirements.
@@ -517,7 +515,9 @@ class ImportStreamer(object):
             self.set_timeline_name(default_timeline_name)
 
         file_ending = filepath.lower().split('.')[-1]
-        self._label = label or file_ending
+
+        if not self._data_label:
+            self._data_label = file_ending
 
         if file_ending == 'csv':
             if self._csv_delimiter:
@@ -627,6 +627,10 @@ class ImportStreamer(object):
     def set_csv_delimiter(self, delimiter):
         """Set the CSV delimiter for CSV file parsing."""
         self._csv_delimiter = delimiter
+
+    def set_data_label(self, data_label):
+        """Set the data label of the imported data."""
+        self._data_label = data_label
 
     def set_data_type(self, data_type):
         """Sets the column where the data_type is defined in."""

--- a/importer_client/python/tools/timesketch_importer.py
+++ b/importer_client/python/tools/timesketch_importer.py
@@ -114,6 +114,10 @@ def upload_file(
         if size_threshold:
             streamer.set_filesize_threshold(size_threshold)
 
+        data_label = config_dict.get('data_label')
+        if data_label:
+            streamer.set_data_label(data_label)
+
         streamer.add_file(file_path)
 
     return 'File got successfully uploaded to sketch: {0:d}'.format(
@@ -191,6 +195,14 @@ def main(args=None):
         '--timeline_name', '--timeline-name', action='store', type=str,
         dest='timeline_name', default='', help=(
             'String that will be used as the timeline name.'))
+    config_group.add_argument(
+        '--data_label', '--data-label', action='store', type=str,
+        dest='data_label', default='', help=(
+            'The data label is used by the API to determine whether a new '
+            'search index needs to be created or if the data can be appended '
+            'to an already existing index. If a file is added this defaults '
+            'to the file extension, otherwise a default value of generic is '
+            'applied.'))
     config_group.add_argument(
         '--config_section', '--config-section', action='store', type=str,
         dest='config_section', default='', help=(
@@ -368,6 +380,7 @@ def main(args=None):
         'entry_threshold': options.entry_threshold,
         'size_threshold': options.size_threshold,
         'log_config_file': options.log_config_file,
+        'data_label': options.data_label,
     }
 
     logger.info('Uploading file.')

--- a/timesketch/api/v1/resources/explore.py
+++ b/timesketch/api/v1/resources/explore.py
@@ -92,7 +92,6 @@ class ExploreResource(resources.ResourceMixin, Resource):
             return_fields = [field['field'] for field in return_fields]
             return_fields.extend(DEFAULT_SOURCE_FIELDS)
 
-
         sketch_structure = {}
         for timeline in sketch.timelines:
             if timeline.get_status.status.lower() != 'ready':

--- a/timesketch/api/v1/resources/explore.py
+++ b/timesketch/api/v1/resources/explore.py
@@ -96,6 +96,13 @@ class ExploreResource(resources.ResourceMixin, Resource):
             for t in sketch.timelines
             if t.get_status.status.lower() == 'ready'
         }
+
+        sketch_timelines = {
+            t.name: t.id
+            for t in sketch.timelines
+            if t.get_status.status.lower() == 'ready'
+        }
+
         if not query_filter:
             query_filter = {}
 
@@ -107,7 +114,7 @@ class ExploreResource(resources.ResourceMixin, Resource):
 
         # Make sure that the indices in the filter are part of the sketch.
         # This will also remove any deleted timeline from the search result.
-        indices = get_validated_indices(indices, sketch_indices)
+        indices, timeline_ids = get_validated_indices(indices, sketch_indices)
 
         # Make sure we have a query string or star filter
         if not (form.query.data, query_filter.get('star'),
@@ -133,11 +140,12 @@ class ExploreResource(resources.ResourceMixin, Resource):
 
             try:
                 result = self.datastore.search(
-                    sketch_id,
-                    form.query.data,
-                    query_filter,
-                    query_dsl,
-                    indices,
+                    sketch_id=sketch_id,
+                    query_string=form.query.data,
+                    query_filter=query_filter,
+                    query_dsl=query_dsl,
+                    indices=indices,
+                    timeline_ids=timeline_ids,
                     count=True)
             except ValueError as e:
                 abort(
@@ -182,14 +190,15 @@ class ExploreResource(resources.ResourceMixin, Resource):
         else:
             try:
                 result = self.datastore.search(
-                    sketch_id,
-                    form.query.data,
-                    query_filter,
-                    query_dsl,
-                    indices,
+                    sketch_id=sketch_id,
+                    query_string=form.query.data,
+                    query_filter=query_filter,
+                    query_dsl=query_dsl,
+                    indices=indices,
                     aggregations=index_stats_agg,
                     return_fields=return_fields,
-                    enable_scroll=enable_scroll)
+                    enable_scroll=enable_scroll,
+                    timeline_ids=timeline_ids)
             except ValueError as e:
                 abort(
                     HTTP_STATUS_CODE_BAD_REQUEST, e)

--- a/timesketch/api/v1/resources/explore.py
+++ b/timesketch/api/v1/resources/explore.py
@@ -111,7 +111,7 @@ class ExploreResource(resources.ResourceMixin, Resource):
 
         # If _all in indices then execute the query on all indices
         if '_all' in indices:
-            indices = sketch_indices
+            indices = list(sketch_structure.keys())
 
         # Make sure that the indices in the filter are part of the sketch.
         # This will also remove any deleted timeline from the search result.

--- a/timesketch/api/v1/resources/upload.py
+++ b/timesketch/api/v1/resources/upload.py
@@ -143,12 +143,12 @@ class UploadFileResource(resources.ResourceMixin, Resource):
             if timeline.searchindex.index_name == searchindex.index_name:
                 timeline = timeline_
                 break
-            else:
-                abort(
-                    HTTP_STATUS_CODE_BAD_REQUEST,
-                    'There is a timeline in the sketch that has the same name '
-                    'but is stored in a different index, check the data_label '
-                    'on the uploaded data')
+
+            abort(
+                HTTP_STATUS_CODE_BAD_REQUEST,
+                'There is a timeline in the sketch that has the same name '
+                'but is stored in a different index, check the data_label '
+                'on the uploaded data')
 
         if not timeline:
             timeline = Timeline.get_or_create(

--- a/timesketch/api/v1/resources/upload.py
+++ b/timesketch/api/v1/resources/upload.py
@@ -42,7 +42,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
 
     def _get_index(
             self, name, description, sketch, index_name='',
-            label='', extension=''):
+            data_label='', extension=''):
         """Returns a SearchIndex object to be used for uploads.
 
         Args:
@@ -51,12 +51,12 @@ class UploadFileResource(resources.ResourceMixin, Resource):
             sketch: sketch object (instance of Sketch).
             index_name: optional index name, if supplied and if it exists
                 then the index associated with that will be returned.
-            label: optional label of the data, if supplied will be used to
+            data_label: optional label of the data, if supplied will be used to
                 determine whether an already existing index can be
                 used or a new one created.
             extension: optional file extension if a file is being uploaded,
-                if supplied and no label used, then the extension will be
-                used as a label.
+                if supplied and no data label used, then the extension will be
+                used as a data label.
 
         Returns:
             A SearchIndex object.
@@ -72,15 +72,15 @@ class UploadFileResource(resources.ResourceMixin, Resource):
                     permission='write', user=current_user):
                 return searchindex
 
-        if extension and not label:
-            label = extension
+        if extension and not data_label:
+            data_label = extension
 
-        if not label:
-            label = 'generic'
+        if not data_label:
+            data_label = 'generic'
 
         indices = [t.searchindex for t in sketch.active_timelines]
         for index in indices:
-            if index.has_label(label) and sketch.has_permission(
+            if index.has_label(data_label) and sketch.has_permission(
                     permission='write', user=current_user):
                 return index
 
@@ -99,13 +99,13 @@ class UploadFileResource(resources.ResourceMixin, Resource):
         db_session.add(searchindex)
         db_session.commit()
 
-        searchindex.add_label(label, user=current_user)
+        searchindex.add_label(data_label, user=current_user)
 
         return searchindex
 
     def _upload_and_index(
             self, file_extension, timeline_name, index_name, sketch,
-            enable_stream, label='', file_path='', events='', meta=None):
+            enable_stream, data_label='', file_path='', events='', meta=None):
         """Creates a full pipeline for an uploaded file and returns the results.
 
         Args:
@@ -116,7 +116,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
             sketch: Instance of timesketch.models.sketch.Sketch
             enable_stream: boolean indicating whether this is file is part of a
                            stream or not.
-            label: Optional string with a label for the search index.
+            data_label: Optional string with a data label for the search index.
             file_path: the path to the file to be uploaded (optional).
             events: a string with events to upload (optional).
             meta: optional dict with additional meta fields that will be
@@ -131,7 +131,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
             description=timeline_name,
             sketch=sketch,
             index_name=index_name,
-            label=label,
+            data_label=data_label,
             extension=file_extension)
         searchindex.set_status('processing')
 
@@ -191,7 +191,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
         """
         timeline_name = form.get('name', 'unknown_events')
         file_extension = 'jsonl'
-        label = form.get('label', '')
+        data_label = form.get('data_label', '')
 
         return self._upload_and_index(
             events=events,
@@ -199,7 +199,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
             timeline_name=timeline_name,
             index_name=index_name,
             sketch=sketch,
-            label=label,
+            data_label=data_label,
             enable_stream=form.get('enable_stream', False))
 
     def _upload_file(self, file_storage, form, sketch, index_name):
@@ -244,7 +244,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
             file_size = int(file_size)
         enable_stream = form.get('enable_stream', False)
 
-        label = form.get('label', '')
+        data_label = form.get('data_label', '')
 
         if chunk_total_chunks is None:
             file_storage.save(file_path)
@@ -254,7 +254,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
                 timeline_name=timeline_name,
                 index_name=index_name,
                 sketch=sketch,
-                label=label,
+                data_label=data_label,
                 enable_stream=enable_stream)
 
         # For file chunks we need the correct filepath, otherwise each chunk
@@ -302,7 +302,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
             timeline_name=timeline_name,
             index_name=index_name,
             sketch=sketch,
-            label=label,
+            data_label=data_label,
             enable_stream=enable_stream,
             meta=meta)
 

--- a/timesketch/api/v1/resources/upload.py
+++ b/timesketch/api/v1/resources/upload.py
@@ -91,6 +91,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
         index_name = uuid.uuid4().hex
         searchindex = SearchIndex.get_or_create(
             name=name,
+            index_name=index_name,
             description=description,
             user=current_user)
 
@@ -142,6 +143,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
             name=timeline_name,
             description=timeline_name,
             sketch=sketch,
+            user=current_user,
             searchindex=searchindex)
 
         if not timeline:

--- a/timesketch/api/v1/resources/upload.py
+++ b/timesketch/api/v1/resources/upload.py
@@ -171,7 +171,8 @@ class UploadFileResource(resources.ResourceMixin, Resource):
         pipeline = tasks.build_index_pipeline(
             file_path=file_path, events=events, timeline_name=timeline_name,
             index_name=index_name, file_extension=file_extension,
-            sketch_id=sketch_id, only_index=enable_stream)
+            sketch_id=sketch_id, only_index=enable_stream,
+            timeline_id=timeline.id)
         pipeline.apply_async()
 
         return self.to_json(

--- a/timesketch/api/v1/resources/upload.py
+++ b/timesketch/api/v1/resources/upload.py
@@ -229,18 +229,18 @@ class UploadFileResource(resources.ResourceMixin, Resource):
         file_path = os.path.join(upload_folder, filename)
 
         chunk_index = form.get('chunk_index')
-        if isinstance(chunk_index, str) and chunk_index.is_digit():
+        if isinstance(chunk_index, str) and chunk_index.isdigit():
             chunk_index = int(chunk_index)
         chunk_byte_offset = form.get('chunk_byte_offset')
         if isinstance(
-                chunk_byte_offset, str) and chunk_byte_offset.is_digit():
+                chunk_byte_offset, str) and chunk_byte_offset.isdigit():
             chunk_byte_offset = int(chunk_byte_offset)
         chunk_total_chunks = form.get('chunk_total_chunks')
         if isinstance(
-                chunk_total_chunks, str) and chunk_total_chunks.is_digit():
+                chunk_total_chunks, str) and chunk_total_chunks.isdigit():
             chunk_total_chunks = int(chunk_total_chunks)
         file_size = form.get('total_file_size')
-        if isinstance(file_size, str) and file_size.is_digit():
+        if isinstance(file_size, str) and file_size.isdigit():
             file_size = int(file_size)
         enable_stream = form.get('enable_stream', False)
 

--- a/timesketch/api/v1/resources/upload.py
+++ b/timesketch/api/v1/resources/upload.py
@@ -279,11 +279,13 @@ class UploadFileResource(resources.ResourceMixin, Resource):
                 abort(
                     HTTP_STATUS_CODE_NOT_FOUND,
                     'No sketch found with this ID.')
+
             if sketch.get_status.status == 'archived':
                 abort(
                     HTTP_STATUS_CODE_BAD_REQUEST,
                     'Unable to upload a file to an archived sketch.')
 
+        # TODO REPLACE THIS WITH GET INDEX!
         index_name = form.get('index_name', uuid.uuid4().hex)
         if not isinstance(index_name, six.text_type):
             index_name = codecs.decode(index_name, 'utf-8')

--- a/timesketch/api/v1/resources/upload.py
+++ b/timesketch/api/v1/resources/upload.py
@@ -16,7 +16,6 @@
 import codecs
 import os
 import uuid
-import six
 
 from flask import jsonify
 from flask import request
@@ -63,7 +62,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
             A SearchIndex object.
         """
         if index_name:
-            if not isinstance(index_name, six.text_type):
+            if not isinstance(index_name, str):
                 index_name = codecs.decode(index_name, 'utf-8')
 
             searchindex = SearchIndex.query.filter_by(
@@ -77,12 +76,9 @@ class UploadFileResource(resources.ResourceMixin, Resource):
             label = extension
 
         if not label:
-            label = 'log'
+            label = 'generic'
 
-        timelines = Timeline.query.filter_by(
-            sketch=sketch).all()
-
-        indices = [t.searchindex for t in timelines]
+        indices = [t.searchindex for t in sketch.active_timelines]
         for index in indices:
             if index.has_label(label) and sketch.has_permission(
                     permission='write', user=current_user):
@@ -226,23 +222,25 @@ class UploadFileResource(resources.ResourceMixin, Resource):
         # We do not need a human readable filename or
         # datastore index name, so we use UUIDs here.
         filename = uuid.uuid4().hex
-        if not isinstance(filename, six.text_type):
+        if not isinstance(filename, str):
             filename = codecs.decode(filename, 'utf-8')
 
         upload_folder = current_app.config['UPLOAD_FOLDER']
         file_path = os.path.join(upload_folder, filename)
 
         chunk_index = form.get('chunk_index')
-        if isinstance(chunk_index, six.string_types):
+        if isinstance(chunk_index, str) and chunk_index.is_digit():
             chunk_index = int(chunk_index)
         chunk_byte_offset = form.get('chunk_byte_offset')
-        if isinstance(chunk_byte_offset, six.string_types):
+        if isinstance(
+                chunk_byte_offset, str) and chunk_byte_offset.is_digit():
             chunk_byte_offset = int(chunk_byte_offset)
         chunk_total_chunks = form.get('chunk_total_chunks')
-        if isinstance(chunk_total_chunks, six.string_types):
+        if isinstance(
+                chunk_total_chunks, str) and chunk_total_chunks.is_digit():
             chunk_total_chunks = int(chunk_total_chunks)
         file_size = form.get('total_file_size')
-        if isinstance(file_size, six.string_types):
+        if isinstance(file_size, str) and file_size.is_digit():
             file_size = int(file_size)
         enable_stream = form.get('enable_stream', False)
 

--- a/timesketch/api/v1/resources/upload.py
+++ b/timesketch/api/v1/resources/upload.py
@@ -172,7 +172,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
         from timesketch.lib import tasks
         pipeline = tasks.build_index_pipeline(
             file_path=file_path, events=events, timeline_name=timeline_name,
-            index_name=index_name, file_extension=file_extension,
+            index_name=searchindex.index_name, file_extension=file_extension,
             sketch_id=sketch_id, only_index=enable_stream,
             timeline_id=timeline.id)
         pipeline.apply_async()

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -237,6 +237,10 @@ class ElasticsearchDataStore(object):
             }
         }
 
+        # TODO: Simplify this when we don't have to support both timelines
+        # that have __timeline_id set and those that don't.
+        # (query_string AND timeline_id NOT EXISTS) OR (
+        #       query_string AND timeline_id in LIST)
         if timeline_ids and isinstance(timeline_ids, (list, tuple)):
             query_dsl = {
                 'query': {

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -417,9 +417,6 @@ class ElasticsearchDataStore(object):
 
         # The argument " _source_include" changed to "_source_includes" in
         # ES version 7. This check add support for both version 6 and 7 clients.
-        print('DSL')
-        print(query_dsl)
-        print('DSL END')
         # pylint: disable=unexpected-keyword-arg
         try:
             if self.version.startswith('6'):

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -237,27 +237,6 @@ class ElasticsearchDataStore(object):
             }
         }
 
-        # TODO: Remove when old UI has been deprecated.
-        if query_filter.get('star', None):
-            label_query = self._build_labels_query(sketch_id, ['__ts_star'])
-            query_string = '*'
-            query_dsl['query']['bool']['must'].append(label_query)
-
-        # TODO: Remove when old UI has been deprecated.
-        if query_filter.get('time_start', None):
-            query_dsl['query']['bool']['filter'] = [{
-                'bool': {
-                    'should': [{
-                        'range': {
-                            'datetime': {
-                                'gte': query_filter['time_start'],
-                                'lte': query_filter['time_end']
-                            }
-                        }
-                    }]
-                }
-            }]
-
         if timeline_ids and isinstance(timeline_ids, (list, tuple)):
             query_dsl = {
                 'query': {

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -349,6 +349,7 @@ class ElasticsearchDataStore(object):
 
         return query_dsl
 
+    # pylint: disable=too-many-arguments
     def search(self, sketch_id, query_string, query_filter, query_dsl, indices,
                count=False, aggregations=None, return_fields=None,
                enable_scroll=False, timeline_ids=None):

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -209,12 +209,14 @@ class ElasticsearchDataStore(object):
             Elasticsearch DSL query as a dictionary
         """
 
+        # TODO: Support query DSL when it comes to timeline filtering.
         if query_dsl:
             if not isinstance(query_dsl, dict):
                 query_dsl = json.loads(query_dsl)
 
             if not query_dsl:
                 query_dsl = {}
+
             # Remove any aggregation coming from user supplied Query DSL.
             # We have no way to display this data in a good way today.
             if query_dsl.get('aggregations', None):
@@ -261,9 +263,9 @@ class ElasticsearchDataStore(object):
                 {'query_string': {'query': query_string}})
 
         if timeline_ids and isinstance(timeline_ids, (list, tuple)):
-            timeline_add = [
-                f'__timeline_id:"{t}"' for t in timeline_ids if isinstance(
-                    t, int)]
+            timeline_add = [{'query_string': {
+                'query': f'__timeline_id:"{t}"'
+            }} for t in timeline_ids if isinstance(t, int)]
             query_dsl['query']['bool']['must'].extend(timeline_add)
 
         # New UI filters
@@ -373,7 +375,6 @@ class ElasticsearchDataStore(object):
         Returns:
             Set of event documents in JSON format
         """
-
         scroll_timeout = None
         if enable_scroll:
             scroll_timeout = '1m'  # Default to 1 minute scroll timeout

--- a/timesketch/lib/tasks.py
+++ b/timesketch/lib/tasks.py
@@ -108,7 +108,7 @@ class SqlAlchemyTask(celery.Task):
     def after_return(self, *args, **kwargs):
         """Close the database session on task completion."""
         db_session.remove()
-        super(SqlAlchemyTask, self).after_return(*args, **kwargs)
+        super().after_return(*args, **kwargs)
 
 
 # pylint: disable=unused-argument

--- a/timesketch/lib/utils.py
+++ b/timesketch/lib/utils.py
@@ -39,7 +39,7 @@ logger = logging.getLogger('timesketch.utils')
 csv.field_size_limit(sys.maxsize)
 
 # Fields to scrub from timelines.
-FIELDS_TO_REMOVE = ['_id', '_type', '_index', '_source']
+FIELDS_TO_REMOVE = ['_id', '_type', '_index', '_source', '__timeline_id']
 
 
 def random_color():
@@ -241,35 +241,50 @@ def read_and_validate_jsonl(file_handle):
                 'Error parsing JSON at line {0:n}: {1:s}'.format(lineno, e))
 
 
-def get_validated_indices(indices, sketch_indices, sketch_timelines):
+def get_validated_indices(indices, sketch_structure):
     """Exclude any deleted search index references.
 
     Args:
         indices: List of indices from the user
-        sketch_indices: List of indices in the sketch
-        sketch_timelines: A dict with all the timelines in the sketch, with
-            timeline name as the key and the timeline ID as the value.
+        sketch_structure: A dict whose key is all valid indices in the sketch
+            and the value is a list of dicts, with two keys: "name" and "id",
+            which correspond to the timeline ID and timeline Name associated
+            with that index.
 
     Returns:
         Tuple of two items:
-          Set of indices with those removed that is not in the sketch
-          Set of timeline IDs that should be part of the output.
+          List of indices with those removed that is not in the sketch
+          List of timeline IDs that should be part of the output.
     """
-    exclude = set(indices) - set(sketch_indices)
+    sketch_indices = set(sketch_structure.keys())
+    exclude = set(indices) - sketch_indices
     timelines = set()
+
     if exclude:
         indices = [index for index in indices if index not in exclude]
         for item in exclude:
-            timeline_id = sketch_timelines.get(item)
-            if timeline_id:
-                timelines.add(timeline_id)
+            for index, timeline_list in sketch_structure.items():
+                for timeline_struct in timeline_list:
+                    timeline_id = timeline_struct.get('id')
+                    timeline_name = timeline_struct.get('name')
 
-            if isinstance(item, str) and item.isdigit():
-                timeline_id = int(item)
-                if timeline_id in sketch_timelines.values():
-                    timelines.add(timeline_id)
+                    if not timeline_id:
+                        continue
 
-    return indices, timelines
+                    if isinstance(item, str) and item.isdigit():
+                        item = int(item)
+
+                    if item == timeline_id:
+                        timelines.add(timeline_id)
+                        indices.append(index)
+
+                    if isinstance(
+                            item, str) and item.lower(
+                                ) == timeline_name.lower():
+                        timelines.add(timeline_id)
+                        indices.append(index)
+
+    return list(set(indices)), list(timelines)
 
 
 def send_email(subject, body, to_username, use_html=False):

--- a/timesketch/lib/utils.py
+++ b/timesketch/lib/utils.py
@@ -241,21 +241,35 @@ def read_and_validate_jsonl(file_handle):
                 'Error parsing JSON at line {0:n}: {1:s}'.format(lineno, e))
 
 
-def get_validated_indices(indices, sketch_indices):
+def get_validated_indices(indices, sketch_indices, sketch_timelines):
     """Exclude any deleted search index references.
 
     Args:
         indices: List of indices from the user
         sketch_indices: List of indices in the sketch
+        sketch_timelines: A dict with all the timelines in the sketch, with
+            timeline name as the key and the timeline ID as the value.
 
     Returns:
-        Set of indices with those removed that is not in the sketch
+        Tuple of two items:
+          Set of indices with those removed that is not in the sketch
+          Set of timeline IDs that should be part of the output.
     """
     exclude = set(indices) - set(sketch_indices)
+    timelines = set()
     if exclude:
         indices = [index for index in indices if index not in exclude]
+        for item in exclude:
+            timeline_id = sketch_timelines.get(item)
+            if timeline_id:
+                timelines.add(timeline_id)
 
-    return indices
+            if isinstance(item, str) and item.isdigit():
+                timeline_id = int(item)
+                if timeline_id in sketch_timelines.values():
+                    timelines.add(timeline_id)
+
+    return indices, timelines
 
 
 def send_email(subject, body, to_username, use_html=False):

--- a/timesketch/lib/utils_test.py
+++ b/timesketch/lib/utils_test.py
@@ -34,10 +34,20 @@ class TestUtils(BaseTest):
         """Test for validating indices."""
         sketch = self.sketch1
         sketch_indices = [t.searchindex.index_name for t in sketch.timelines]
+
+        sketch_timelines = {
+            t.name: t.id
+            for t in sketch.timelines
+            if t.get_status.status.lower() == 'ready'
+        }
+
         valid_indices = ['test']
         invalid_indices = ['test', 'fail']
-        self.assertListEqual(sketch_indices,
-                             get_validated_indices(valid_indices,
-                                                   sketch_indices))
-        self.assertFalse('fail' in get_validated_indices(
-            invalid_indices, sketch_indices))
+
+        test_indices, _ = get_validated_indices(
+            valid_indices, sketch_indices, sketch_timelines)
+        self.assertListEqual(sketch_indices, test_indices)
+
+        test_indices, _ = get_validated_indices(
+            invalid_indices, sketch_indices, sketch_timelines)
+        self.assertFalse('fail' in test_indices)

--- a/timesketch/lib/utils_test.py
+++ b/timesketch/lib/utils_test.py
@@ -35,19 +35,24 @@ class TestUtils(BaseTest):
         sketch = self.sketch1
         sketch_indices = [t.searchindex.index_name for t in sketch.timelines]
 
-        sketch_timelines = {
-            t.name: t.id
-            for t in sketch.timelines
-            if t.get_status.status.lower() == 'ready'
-        }
+        sketch_structure = {}
+        for timeline in sketch.timelines:
+            if timeline.get_status.status.lower() != 'ready':
+                continue
+            index_ = timeline.searchindex.index_name
+            sketch_structure.setdefault(index_, [])
+            sketch_structure[index_].append({
+                'name': timeline.name,
+                'id': timeline.id,
+            })
+
 
         valid_indices = ['test']
         invalid_indices = ['test', 'fail']
 
-        test_indices, _ = get_validated_indices(
-            valid_indices, sketch_indices, sketch_timelines)
+        test_indices, _ = get_validated_indices(valid_indices, sketch_structure)
         self.assertListEqual(sketch_indices, test_indices)
 
         test_indices, _ = get_validated_indices(
-            invalid_indices, sketch_indices, sketch_timelines)
+            invalid_indices, sketch_structure)
         self.assertFalse('fail' in test_indices)

--- a/timesketch/models/sketch.py
+++ b/timesketch/models/sketch.py
@@ -295,8 +295,6 @@ class View(AccessControlMixin, LabelMixin, StatusMixin, CommentMixin,
         DEFAULT_SIZE = 40 # Number of resulting documents to return
         DEFAULT_LIMIT = DEFAULT_SIZE  # Number of resulting documents to return
         DEFAULT_VALUES = {
-            'time_start': None,
-            'time_end': None,
             'from': DEFAULT_FROM,
             'size': DEFAULT_SIZE,
             'terminate_after': DEFAULT_LIMIT,
@@ -361,8 +359,6 @@ class SearchTemplate(AccessControlMixin, LabelMixin, StatusMixin, CommentMixin,
             filter_template = {
                 'exclude': [],
                 'indices': '_all',
-                'time_start': None,
-                'time_end': None,
                 'terminate_after': 40,
                 'from': 0,
                 'order': 'asc',

--- a/timesketch/models/sketch.py
+++ b/timesketch/models/sketch.py
@@ -65,7 +65,7 @@ class Sketch(AccessControlMixin, LabelMixin, StatusMixin, CommentMixin,
             description: Description of the sketch
             user: A user (instance of timesketch.models.user.User)
         """
-        super(Sketch, self).__init__()
+        super().__init__()
         self.name = name
         self.description = description
         self.user = user
@@ -191,7 +191,7 @@ class Timeline(LabelMixin, StatusMixin, CommentMixin, BaseModel):
             color: Color for the timeline in HEX as string (e.g. F1F1F1F1)
             description: The description for the timeline
         """
-        super(Timeline, self).__init__()
+        super().__init__()
         self.name = name
         self.description = description
 
@@ -224,7 +224,7 @@ class SearchIndex(AccessControlMixin, LabelMixin, StatusMixin, CommentMixin,
             index_name: The name of the searchindex
             user: A user (instance of timesketch.models.user.User)
         """
-        super(SearchIndex, self).__init__()
+        super().__init__()
         self.name = name
         self.description = description
         self.index_name = index_name
@@ -267,7 +267,7 @@ class View(AccessControlMixin, LabelMixin, StatusMixin, CommentMixin,
             query_filter: The filter to apply (JSON format as string)
             query_dsl: A query DSL document (JSON format as string)
         """
-        super(View, self).__init__()
+        super().__init__()
         self.name = name
         self.sketch = sketch
         self.user = user
@@ -350,7 +350,7 @@ class SearchTemplate(AccessControlMixin, LabelMixin, StatusMixin, CommentMixin,
             query_filter: The filter to apply (JSON format as string)
             query_dsl: A query DSL document (JSON format as string)
         """
-        super(SearchTemplate, self).__init__()
+        super().__init__()
         self.name = name
         self.user = user
         self.description = description
@@ -384,7 +384,7 @@ class Event(LabelMixin, StatusMixin, CommentMixin, BaseModel):
                 (instance of timesketch.models.sketch.SearchIndex)
             document_id = String with the datastore document ID
         """
-        super(Event, self).__init__()
+        super().__init__()
         self.sketch = sketch
         self.searchindex = searchindex
         self.document_id = document_id
@@ -407,7 +407,7 @@ class Story(AccessControlMixin, LabelMixin, StatusMixin, CommentMixin,
             sketch: A sketch (instance of timesketch.models.sketch.Sketch)
             user: A user (instance of timesketch.models.user.User)
         """
-        super(Story, self).__init__()
+        super().__init__()
         self.title = title
         self.content = content
         self.sketch = sketch
@@ -443,7 +443,7 @@ class Aggregation(AccessControlMixin, LabelMixin, StatusMixin, CommentMixin,
             aggregationgroup (AggregationGroup): Optional, an AggregationGroup
                 that the aggregation is bound to.
         """
-        super(Aggregation, self).__init__()
+        super().__init__()
         self.name = name
         self.description = description
         self.agg_type = agg_type
@@ -484,7 +484,7 @@ class AggregationGroup(
             orientation (str): Describes how charts should be joined together.
             view (View): Optional: The view that the aggregation is bound to
         """
-        super(AggregationGroup, self).__init__()
+        super().__init__()
         self.name = name
         self.description = description
         self.aggregations = aggregations or []
@@ -524,7 +524,7 @@ class Analysis(LabelMixin, StatusMixin, CommentMixin, BaseModel):
             searchindex (SearchIndex): SearchIndex the analysis was run on
             result (str): Result report of the analysis
         """
-        super(Analysis, self).__init__()
+        super().__init__()
         self.name = name
         self.description = description
         self.analyzer_name = analyzer_name
@@ -551,7 +551,7 @@ class AnalysisSession(LabelMixin, StatusMixin, CommentMixin, BaseModel):
             user (User): The user who created the aggregation
             sketch (Sketch): The sketch that the aggregation is bound to
         """
-        super(AnalysisSession, self).__init__()
+        super().__init__()
         self.user = user
         self.sketch = sketch
 
@@ -575,7 +575,7 @@ class Attribute(BaseModel):
             ontology (str): The ontology of the value, The values that can
                 be used are defined in timesketch/lib/ontology.py (ONTOLOGY).
         """
-        super(Attribute, self).__init__()
+        super().__init__()
         self.user = user
         self.sketch = sketch
         self.name = name
@@ -599,7 +599,7 @@ class AttributeValue(BaseModel):
                 The ontology could influence how this will be cast when
                 interpreted.
         """
-        super(AttributeValue, self).__init__()
+        super().__init__()
         self.user = user
         self.attribute = attribute
         self.value = value
@@ -633,7 +633,7 @@ class Graph(LabelMixin, CommentMixin, BaseModel):
             num_nodes (int): Number of nodes in the graph.
             num_edges (int): Number of edges in the graph.
         """
-        super(Graph, self).__init__()
+        super().__init__()
         self.user = user
         self.sketch = sketch
         self.name = name
@@ -666,7 +666,7 @@ class GraphCache(BaseModel):
             num_nodes (int): Number of nodes in the graph.
             num_edges (int): Number of edges in the graph.
         """
-        super(GraphCache, self).__init__()
+        super().__init__()
         self.sketch = sketch
         self.graph_plugin = graph_plugin
         self.graph_config = graph_config

--- a/timesketch/models/sketch_test.py
+++ b/timesketch/models/sketch_test.py
@@ -103,8 +103,6 @@ class SketchModelTest(ModelBaseTest):
         DEFAULT_LIMIT = 40
         default_values = {
             'from': 0,
-            'time_start': None,
-            'time_end': None,
             'size': DEFAULT_LIMIT,
             'terminate_after': DEFAULT_LIMIT,
             'indices': [],


### PR DESCRIPTION
The first part of #1567

This PR is the first step into changing how newly uploaded data is indexed in Timesketch.

Instead of each new file that is uploaded to have it's own search index object and a timeline there is now only a single (or at most few) actual search indexes created for each sketch, and then all files are uploaded to that index.

This changes quite a few things internally with TS, since indexes are used in the UI to distinguish timelines, it is also used for filtering and other things.

This PR also does not include a UI element to it, making some UI elements potentially not work as well as they should.

There is also a missing piece of plaso file handling. That is, in order for this to work properly a change needs to happen in plaso (psort module) to accommodate the changes here.

Additionally this PR adds in the feature that in search if you add `comment` to the list of return fields the comment is extracted from the database and added to the output. 