### PR TITLE
corrects README doc link to Sigma

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Timesketch is an open source tool for collaborative forensic timeline analysis. 
 
 #### Using Timesketch
 * [Users guide](docs/Users-Guide.md)
-* [Using Sigma Analyzer](docs/UseSigmaAnalyzer.md)
+* [Using Sigma](docs/UseSigma.md)
 
 ## Community
 * [Community guide](docs/Community-Guide.md)


### PR DESCRIPTION
Prev change #1499 renamed `SigmaAnalyzer.md` to `Sigma.md` breaking the README.md's reference to this documentation. This PR rectifies the linkage.