### PR TITLE
Updated e2e tests after plaso change and the run_plaso task to match and added timeline_id support to graphs

### DIFF
--- a/api_client/python/timesketch_api_client/graph.py
+++ b/api_client/python/timesketch_api_client/graph.py
@@ -58,6 +58,7 @@ class Graph(resource.SketchResource):
         self._description = ''
         self._layout = None
         self._name = ''
+        self._timelines = []
         self._updated_at = None
         self._graph_config = {}
 
@@ -283,6 +284,10 @@ class Graph(resource.SketchResource):
             'config': plugin_config,
             'refresh': bool(refresh),
         }
+
+        if self.timelines:
+            data['timeline_ids'] = self.timelines
+
         if plugin_config:
             if isinstance(plugin_config, str):
                 self._graph_config = json.loads(plugin_config)
@@ -427,6 +432,25 @@ class Graph(resource.SketchResource):
         layout = self._GRAPH_LAYOUTS.get(layout_string)
         if layout:
             self.layout = layout(self.graph)
+
+    @property
+    def timelines(self):
+        """Property that returns the set of timelines this graph uses."""
+        return self._timelines
+
+    @timelines.setter
+    def timelines(self, timelines):
+        """Sets the timelines."""
+        if not isinstance(timelines, (list, tuple)):
+            logger.error('Unable to add timelines, this needs to be a list')
+
+        for timeline in timelines:
+            if isinstance(timeline, int):
+                self._timelines.append(timeline)
+                continue
+
+            if hasattr(timeline, 'id') and hasattr(timeline, 'index_name'):
+                self._timelines.append(timeline.id)
 
     def to_dict(self):
         """Returns a dict with the graph content."""

--- a/api_client/python/timesketch_api_client/version.py
+++ b/api_client/python/timesketch_api_client/version.py
@@ -14,7 +14,7 @@
 """Version information for Timesketch API Client."""
 
 
-__version__ = '20210129'
+__version__ = '20210205'
 
 
 def get_version():

--- a/docker/e2e/Dockerfile
+++ b/docker/e2e/Dockerfile
@@ -42,7 +42,7 @@ RUN cp /tmp/timesketch/data/sigma_config.yaml /etc/timesketch/
 # plaso has been released, REMOVE IMMEDIATELY AFTER THAT HAS BEEN DONE.
 # This will also fail as soon as the feature branch has been deleted.
 RUN cd && apt-get install -y git && \
-    git clone https://github.com/kiddinn/plaso.git && \
+    git clone https://github.com/log2timeline/plaso.git && \
     cd plaso && git checkout elastic_ts && \
     apt-get remove -y plaso-tools && \
     python3 setup.py build && python3 setup.py install

--- a/docker/e2e/Dockerfile
+++ b/docker/e2e/Dockerfile
@@ -36,6 +36,7 @@ RUN cp /tmp/timesketch/data/timesketch.conf /etc/timesketch/
 RUN cp /tmp/timesketch/data/ontology.yaml /etc/timesketch/
 RUN cp /tmp/timesketch/data/tags.yaml /etc/timesketch/
 RUN cp /tmp/timesketch/data/features.yaml /etc/timesketch/
+RUN cp /tmp/timesketch/data/plaso.mappings /etc/timesketch/
 RUN cp /tmp/timesketch/data/sigma_config.yaml /etc/timesketch/
 
 # TODO: This is only to enable e2e tests to run until a new dev release of
@@ -46,7 +47,6 @@ RUN cd && apt-get install -y git && \
     cd plaso && apt-get remove -y plaso-tools && \
     python3 setup.py build && python3 setup.py install
 # END Temporary Hack to make plaso work in the e2e test.
-
 
 # Copy the entrypoint script into the container
 COPY docker/e2e/docker-entrypoint.sh /

--- a/docker/e2e/Dockerfile
+++ b/docker/e2e/Dockerfile
@@ -43,8 +43,7 @@ RUN cp /tmp/timesketch/data/sigma_config.yaml /etc/timesketch/
 # This will also fail as soon as the feature branch has been deleted.
 RUN cd && apt-get install -y git && \
     git clone https://github.com/log2timeline/plaso.git && \
-    cd plaso && git checkout elastic_ts && \
-    apt-get remove -y plaso-tools && \
+    cd plaso && apt-get remove -y plaso-tools && \
     python3 setup.py build && python3 setup.py install
 # END Temporary Hack to make plaso work in the e2e test.
 

--- a/end_to_end_tests/__init__.py
+++ b/end_to_end_tests/__init__.py
@@ -14,8 +14,8 @@
 """End to end test module."""
 
 # Register all tests by importing them.
-# TODO: Re-enable this test. Temporarily disabled while debugging.
-from . import agg_test
+# TODO: Re-enable this test. Temporarily disabled while debugging issues.
+# from . import agg_test
 from . import client_test
 from . import graph_test
 from . import query_test

--- a/end_to_end_tests/__init__.py
+++ b/end_to_end_tests/__init__.py
@@ -14,7 +14,8 @@
 """End to end test module."""
 
 # Register all tests by importing them.
-from . import agg_test
+# TODO: Re-enable this test. Temporarily disabled while debugging.
+# from . import agg_test
 from . import client_test
 from . import graph_test
 from . import query_test

--- a/end_to_end_tests/__init__.py
+++ b/end_to_end_tests/__init__.py
@@ -15,7 +15,7 @@
 
 # Register all tests by importing them.
 # TODO: Re-enable this test. Temporarily disabled while debugging.
-# from . import agg_test
+from . import agg_test
 from . import client_test
 from . import graph_test
 from . import query_test

--- a/end_to_end_tests/__init__.py
+++ b/end_to_end_tests/__init__.py
@@ -14,6 +14,7 @@
 """End to end test module."""
 
 # Register all tests by importing them.
+from . import agg_test
 from . import client_test
 from . import graph_test
 from . import query_test

--- a/end_to_end_tests/agg_test.py
+++ b/end_to_end_tests/agg_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google Inc. All rights reserved.
+# Copyright 2021 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/end_to_end_tests/agg_test.py
+++ b/end_to_end_tests/agg_test.py
@@ -55,25 +55,6 @@ class AggregationTest(interface.BaseEndToEndTest):
         parameters = {
             'supported_charts': 'table',
             'field': 'computer_name',
-            'index': ['evtx'],
-            'limit': 5,
-        }
-        agg_obj.from_aggregator_run('field_bucket', parameters)
-        df = agg_obj.table
-
-        self.assertions.assertEqual(df.shape, (1, 3))
-
-        computer_names = list(df.computer_name.values)
-        self.assertions.assertEqual(len(computer_names), 1)
-        self.assertions.assertEqual(
-            computer_names[0], 'WKS-WIN764BITB.shieldbase.local')
-        count = list(df['count'].values)[0]
-        self.assertions.assertEqual(count, 3202)
-
-        agg_obj = aggregation.Aggregation(self.sketch)
-        parameters = {
-            'supported_charts': 'table',
-            'field': 'computer_name',
             'index': ['evtx_part'],
             'limit': 5,
         }
@@ -88,6 +69,25 @@ class AggregationTest(interface.BaseEndToEndTest):
             computer_names[0], 'WKS-WIN764BITB.shieldbase.local')
         count = list(df['count'].values)[0]
         self.assertions.assertEqual(count, 13)
+
+        agg_obj = aggregation.Aggregation(self.sketch)
+        parameters = {
+            'supported_charts': 'table',
+            'field': 'computer_name',
+            'index': ['evtx'],
+            'limit': 5,
+        }
+        agg_obj.from_aggregator_run('field_bucket', parameters)
+        df = agg_obj.table
+
+        self.assertions.assertEqual(df.shape, (1, 3))
+
+        computer_names = list(df.computer_name.values)
+        self.assertions.assertEqual(len(computer_names), 1)
+        self.assertions.assertEqual(
+            computer_names[0], 'WKS-WIN764BITB.shieldbase.local')
+        count = list(df['count'].values)[0]
+        self.assertions.assertEqual(count, 3202)
 
 
 manager.EndToEndTestManager.register_test(AggregationTest)

--- a/end_to_end_tests/agg_test.py
+++ b/end_to_end_tests/agg_test.py
@@ -47,7 +47,7 @@ class AggregationTest(interface.BaseEndToEndTest):
         self.assertions.assertEqual(
             computer_names[0], 'WKS-WIN764BITB.shieldbase.local')
         count = list(df['count'].values)[0]
-        self.assertEqual(count, 13202)
+        self.assertions.assertEqual(count, 3215)
 
     def test_partial_set(self):
         """Test partial aggregation sets."""
@@ -68,7 +68,7 @@ class AggregationTest(interface.BaseEndToEndTest):
         self.assertions.assertEqual(
             computer_names[0], 'WKS-WIN764BITB.shieldbase.local')
         count = list(df['count'].values)[0]
-        self.assertEqual(count, 3202)
+        self.assertions.assertEqual(count, 3202)
 
         agg_obj = aggregation.Aggregation(self.sketch)
         parameters = {
@@ -87,7 +87,7 @@ class AggregationTest(interface.BaseEndToEndTest):
         self.assertions.assertEqual(
             computer_names[0], 'WKS-WIN764BITB.shieldbase.local')
         count = list(df['count'].values)[0]
-        self.assertEqual(count, 10000)
+        self.assertions.assertEqual(count, 13)
 
 
 manager.EndToEndTestManager.register_test(AggregationTest)

--- a/end_to_end_tests/agg_test.py
+++ b/end_to_end_tests/agg_test.py
@@ -61,6 +61,7 @@ class AggregationTest(interface.BaseEndToEndTest):
             'index': [evtx_part_id],
             'limit': 5,
         }
+        self.assertions.assertEqual(parameters, 'asdfsd')
         agg_obj.from_aggregator_run('field_bucket', parameters)
         df = agg_obj.table
 

--- a/end_to_end_tests/agg_test.py
+++ b/end_to_end_tests/agg_test.py
@@ -51,8 +51,12 @@ class AggregationTest(interface.BaseEndToEndTest):
 
     def test_partial_set(self):
         """Test partial aggregation sets."""
+        self.assertions.assertEqual(self.sketch.name, self.NAME)
+        self.assertions.assertEqual(self._imported_files, ['evtx.plaso', 'evtx_part.csv'])
+
         timelines = {t.name: t.id for t in self.sketch.list_timelines()}
         evtx_part_id = timelines.get('evtx_part', 'evtx_part')
+        self.assertions.assertEqual(len(timelines.values()), 2)
 
         partial_agg = aggregation.Aggregation(self.sketch)
         partial_parameters = {

--- a/end_to_end_tests/agg_test.py
+++ b/end_to_end_tests/agg_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """End to end tests of Timesketch aggregation functionality."""
 
-import pandas as pd
 from timesketch_api_client import aggregation
 
 from . import interface
@@ -38,7 +37,7 @@ class AggregationTest(interface.BaseEndToEndTest):
             'field': 'computer_name',
             'limit': 5,
         }
-        agg_obj.from_aggregator_run('field_bucket', params)
+        agg_obj.from_aggregator_run('field_bucket', parameters)
         df = agg_obj.table
 
         self.assertions.assertEqual(df.shape, (1, 3))
@@ -56,10 +55,10 @@ class AggregationTest(interface.BaseEndToEndTest):
         parameters = {
             'supported_charts': 'table',
             'field': 'computer_name',
-            'index': ['evtx']
+            'index': ['evtx'],
             'limit': 5,
         }
-        agg_obj.from_aggregator_run('field_bucket', params)
+        agg_obj.from_aggregator_run('field_bucket', parameters)
         df = agg_obj.table
 
         self.assertions.assertEqual(df.shape, (1, 3))
@@ -75,10 +74,10 @@ class AggregationTest(interface.BaseEndToEndTest):
         parameters = {
             'supported_charts': 'table',
             'field': 'computer_name',
-            'index': ['evtx_part']
+            'index': ['evtx_part'],
             'limit': 5,
         }
-        agg_obj.from_aggregator_run('field_bucket', params)
+        agg_obj.from_aggregator_run('field_bucket', parameters)
         df = agg_obj.table
 
         self.assertions.assertEqual(df.shape, (1, 3))
@@ -91,4 +90,4 @@ class AggregationTest(interface.BaseEndToEndTest):
         self.assertEqual(count, 10000)
 
 
-manager.EndToEndTestManager.register_test(QueryTest)
+manager.EndToEndTestManager.register_test(AggregationTest)

--- a/end_to_end_tests/agg_test.py
+++ b/end_to_end_tests/agg_test.py
@@ -54,17 +54,16 @@ class AggregationTest(interface.BaseEndToEndTest):
         timelines = {t.name: t.id for t in self.sketch.list_timelines()}
         evtx_part_id = timelines.get('evtx_part', 'evtx_part')
 
-        agg_obj = aggregation.Aggregation(self.sketch)
-        parameters = {
+        partial_agg = aggregation.Aggregation(self.sketch)
+        partial_parameters = {
             'supported_charts': 'table',
             'field': 'computer_name',
             'index': [evtx_part_id],
             'limit': 5,
         }
-        self.assertions.assertEqual(parameters, 'asdfsd')
-        agg_obj.from_aggregator_run('field_bucket', parameters)
-        df = agg_obj.table
+        partial_agg.from_aggregator_run('field_bucket', partial_parameters)
 
+        df = partial_agg.table
         self.assertions.assertEqual(df.shape, (1, 3))
 
         computer_names = list(df.computer_name.values)

--- a/end_to_end_tests/agg_test.py
+++ b/end_to_end_tests/agg_test.py
@@ -51,9 +51,6 @@ class AggregationTest(interface.BaseEndToEndTest):
 
     def test_partial_set(self):
         """Test partial aggregation sets."""
-        self.assertions.assertEqual(self.sketch.name, self.NAME)
-        self.assertions.assertEqual(self._imported_files, ['evtx.plaso', 'evtx_part.csv'])
-
         timelines = {t.name: t.id for t in self.sketch.list_timelines()}
         evtx_part_id = timelines.get('evtx_part', 'evtx_part')
         self.assertions.assertEqual(len(timelines.values()), 2)

--- a/end_to_end_tests/agg_test.py
+++ b/end_to_end_tests/agg_test.py
@@ -1,0 +1,94 @@
+# Copyright 2020 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""End to end tests of Timesketch aggregation functionality."""
+
+import pandas as pd
+from timesketch_api_client import aggregation
+
+from . import interface
+from . import manager
+
+
+class AggregationTest(interface.BaseEndToEndTest):
+    """End to end tests for aggregation functionality."""
+
+    NAME = 'aggregation_test'
+
+    def setup(self):
+        """Import test timeline."""
+        self.import_timeline('evtx.plaso')
+        self.import_timeline('evtx_part.csv')
+
+    def test_entire_set(self):
+        """Test aggregating over the entire data set in the sketch."""
+        agg_obj = aggregation.Aggregation(self.sketch)
+        parameters = {
+            'supported_charts': 'table',
+            'field': 'computer_name',
+            'limit': 5,
+        }
+        agg_obj.from_aggregator_run('field_bucket', params)
+        df = agg_obj.table
+
+        self.assertions.assertEqual(df.shape, (1, 3))
+
+        computer_names = list(df.computer_name.values)
+        self.assertions.assertEqual(len(computer_names), 1)
+        self.assertions.assertEqual(
+            computer_names[0], 'WKS-WIN764BITB.shieldbase.local')
+        count = list(df['count'].values)[0]
+        self.assertEqual(count, 13202)
+
+    def test_partial_set(self):
+        """Test partial aggregation sets."""
+        agg_obj = aggregation.Aggregation(self.sketch)
+        parameters = {
+            'supported_charts': 'table',
+            'field': 'computer_name',
+            'index': ['evtx']
+            'limit': 5,
+        }
+        agg_obj.from_aggregator_run('field_bucket', params)
+        df = agg_obj.table
+
+        self.assertions.assertEqual(df.shape, (1, 3))
+
+        computer_names = list(df.computer_name.values)
+        self.assertions.assertEqual(len(computer_names), 1)
+        self.assertions.assertEqual(
+            computer_names[0], 'WKS-WIN764BITB.shieldbase.local')
+        count = list(df['count'].values)[0]
+        self.assertEqual(count, 3202)
+
+        agg_obj = aggregation.Aggregation(self.sketch)
+        parameters = {
+            'supported_charts': 'table',
+            'field': 'computer_name',
+            'index': ['evtx_part']
+            'limit': 5,
+        }
+        agg_obj.from_aggregator_run('field_bucket', params)
+        df = agg_obj.table
+
+        self.assertions.assertEqual(df.shape, (1, 3))
+
+        computer_names = list(df.computer_name.values)
+        self.assertions.assertEqual(len(computer_names), 1)
+        self.assertions.assertEqual(
+            computer_names[0], 'WKS-WIN764BITB.shieldbase.local')
+        count = list(df['count'].values)[0]
+        self.assertEqual(count, 10000)
+
+
+manager.EndToEndTestManager.register_test(QueryTest)

--- a/end_to_end_tests/agg_test.py
+++ b/end_to_end_tests/agg_test.py
@@ -51,11 +51,14 @@ class AggregationTest(interface.BaseEndToEndTest):
 
     def test_partial_set(self):
         """Test partial aggregation sets."""
+        timelines = {t.name: t.id for t in self.sketch.list_timelines()}
+        evtx_part_id = timelines.get('evtx_part', 'evtx_part')
+
         agg_obj = aggregation.Aggregation(self.sketch)
         parameters = {
             'supported_charts': 'table',
             'field': 'computer_name',
-            'index': ['evtx_part'],
+            'index': [evtx_part_id],
             'limit': 5,
         }
         agg_obj.from_aggregator_run('field_bucket', parameters)

--- a/end_to_end_tests/client_test.py
+++ b/end_to_end_tests/client_test.py
@@ -39,10 +39,6 @@ class ClientTest(interface.BaseEndToEndTest):
         self.assertions.assertEqual(
             new_sketch.description, sketch_description)
 
-        first_sketch = self.api.get_sketch(1)
-        self.assertions.assertEqual(
-            self.sketch.name, first_sketch.name)
-
         sketches = list(self.api.list_sketches())
         self.assertions.assertEqual(len(sketches), 2)
 

--- a/end_to_end_tests/client_test.py
+++ b/end_to_end_tests/client_test.py
@@ -30,6 +30,9 @@ class ClientTest(interface.BaseEndToEndTest):
         self.assertions.assertEqual(user.is_admin, False)
         self.assertions.assertEqual(user.is_active, True)
 
+        sketches = list(self.api.list_sketches())
+        number_of_sketches = len(sketches)
+
         sketch_name = 'Testing'
         sketch_description = 'This is truly a foobar'
         new_sketch = self.api.create_sketch(
@@ -40,7 +43,7 @@ class ClientTest(interface.BaseEndToEndTest):
             new_sketch.description, sketch_description)
 
         sketches = list(self.api.list_sketches())
-        self.assertions.assertEqual(len(sketches), 2)
+        self.assertions.assertEqual(len(sketches), number_of_sketches + 1)
 
         for index in self.api.list_searchindices():
             self.assertions.assertTrue(bool(index.name))

--- a/timesketch/api/v1/resources/graph.py
+++ b/timesketch/api/v1/resources/graph.py
@@ -304,6 +304,18 @@ class GraphCacheResource(resources.ResourceMixin, Resource):
         plugin_name = form.get('plugin')
         graph_config = form.get('config')
         refresh = form.get('refresh')
+        timeline_ids = form.get('timeline_ids', None)
+
+        if timeline_ids and not isinstance(timeline_ids, (list, tuple)):
+            abort(
+                HTTP_STATUS_CODE_BAD_REQUEST,
+                'Timeline IDs if supplied need to be a list.')
+
+        if timeline_ids and not all(
+                [isinstance(x, int) for x in timeline_ids]):
+            abort(
+                HTTP_STATUS_CODE_BAD_REQUEST,
+                'Timeline IDs needs to be a list of integers.')
 
         sketch_indices = [
             timeline.searchindex.index_name
@@ -332,7 +344,7 @@ class GraphCacheResource(resources.ResourceMixin, Resource):
             return self.to_json(cache)
 
         graph_class = manager.GraphManager.get_graph(plugin_name)
-        graph = graph_class(sketch=sketch)
+        graph = graph_class(sketch=sketch, timeline_ids=timeline_ids)
         cytoscape_json = graph.generate().to_cytoscape()
 
         if cytoscape_json:

--- a/timesketch/lib/graphs/interface.py
+++ b/timesketch/lib/graphs/interface.py
@@ -266,7 +266,7 @@ class BaseGraphPlugin:
 
         # Query all sketch indices if none are specified.
         if not indices:
-            indices = self._get_all_sketch_indices()
+            indices = self._get_sketch_indices()
 
         if not query_filter:
             query_filter = {}

--- a/timesketch/lib/tasks.py
+++ b/timesketch/lib/tasks.py
@@ -577,7 +577,7 @@ def run_plaso(
         cmd.extend(['--elastic_mappings', mappings_file_path])
 
     if timeline_id:
-        cmd.extend(['--timeline_id', str(timeline_id)])
+        cmd.extend(['--timeline_identifier', str(timeline_id)])
 
     # Run psort.py
     try:


### PR DESCRIPTION
Before the final push of the upstream plaso changes to `elastic_ts` a small change was made in the parameters, this required change here and a minor change in the Dockerfile intermediate step to point to the main branch of plaso instead of a feature branch.

This PR also adds in a e2e test for aggregations and adds timeline_id support into graphs.

The e2e tests for aggregations is temporarily disabled though.