### PR TITLE
Moved docker configs to the dev GIFT PPA

### DIFF
--- a/docker/dev/build/Dockerfile
+++ b/docker/dev/build/Dockerfile
@@ -1,7 +1,9 @@
 # Use the official Docker Hub Ubuntu 20.04 base image
 FROM ubuntu:20.04
 
+# TODO: Change back to Plaso stable track once version 20201228 is released.
 ARG PPA_TRACK=dev
+
 # Prevent needing to configure debian packages, stopping the setup of
 # the docker container.
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections

--- a/docker/dev/build/Dockerfile
+++ b/docker/dev/build/Dockerfile
@@ -1,6 +1,7 @@
 # Use the official Docker Hub Ubuntu 20.04 base image
 FROM ubuntu:20.04
 
+ARG PPA_TRACK=dev
 # Prevent needing to configure debian packages, stopping the setup of
 # the docker container.
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
@@ -21,7 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 # Install Plaso
-RUN add-apt-repository -y ppa:gift/stable
+RUN add-apt-repository -y ppa:gift/$PPA_TRACK
 RUN apt-get update && apt-get install -y --no-install-recommends \
     plaso-tools \
   && rm -rf /var/lib/apt/lists/*

--- a/docker/e2e/Dockerfile
+++ b/docker/e2e/Dockerfile
@@ -1,6 +1,7 @@
 # Use the official Docker Hub Ubuntu 20.04 base image
 FROM ubuntu:20.04
 
+# TODO: Change back to Plaso stable track once version 20201228 is released.
 ARG PPA_TRACK=dev
 
 # Prevent needing to configure debian packages, stopping the setup of

--- a/docker/e2e/Dockerfile
+++ b/docker/e2e/Dockerfile
@@ -1,6 +1,8 @@
 # Use the official Docker Hub Ubuntu 20.04 base image
 FROM ubuntu:20.04
 
+ARG PPA_TRACK=dev
+
 # Prevent needing to configure debian packages, stopping the setup of
 # the docker container.
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
@@ -16,7 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 # Install Plaso
-RUN add-apt-repository -y ppa:gift/stable
+RUN add-apt-repository -y ppa:gift/$PPA_TRACK
 RUN apt-get update && apt-get install -y --no-install-recommends \
     plaso-tools \
   && rm -rf /var/lib/apt/lists/*
@@ -38,15 +40,6 @@ RUN cp /tmp/timesketch/data/tags.yaml /etc/timesketch/
 RUN cp /tmp/timesketch/data/features.yaml /etc/timesketch/
 RUN cp /tmp/timesketch/data/plaso.mappings /etc/timesketch/
 RUN cp /tmp/timesketch/data/sigma_config.yaml /etc/timesketch/
-
-# TODO: This is only to enable e2e tests to run until a new dev release of
-# plaso has been released, REMOVE IMMEDIATELY AFTER THAT HAS BEEN DONE.
-# This will also fail as soon as the feature branch has been deleted.
-RUN cd && apt-get install -y git && \
-    git clone https://github.com/log2timeline/plaso.git && \
-    cd plaso && apt-get remove -y plaso-tools && \
-    python3 setup.py build && python3 setup.py install
-# END Temporary Hack to make plaso work in the e2e test.
 
 # Copy the entrypoint script into the container
 COPY docker/e2e/docker-entrypoint.sh /

--- a/docker/release/build/Dockerfile-latest
+++ b/docker/release/build/Dockerfile-latest
@@ -2,6 +2,7 @@
 FROM ubuntu:20.04
 
 MAINTAINER Timesketch <timesketch-dev@googlegroups.com>
+TODO: Change back to Plaso stable track once version 20201228 is released.
 ARG PPA_TRACK=dev
 
 # Prevent needing to configure debian packages, stopping the setup of

--- a/docker/release/build/Dockerfile-latest
+++ b/docker/release/build/Dockerfile-latest
@@ -2,6 +2,7 @@
 FROM ubuntu:20.04
 
 MAINTAINER Timesketch <timesketch-dev@googlegroups.com>
+ARG PPA_TRACK=dev
 
 # Prevent needing to configure debian packages, stopping the setup of
 # the docker container.
@@ -22,7 +23,7 @@ RUN pip3 install -r requirements.txt
 RUN pip3 install https://github.com/google/timesketch/archive/master.zip
 
 # Install Plaso
-RUN add-apt-repository -y ppa:gift/stable
+RUN add-apt-repository -y ppa:gift/$PPA_TRACK
 RUN apt-get update && apt-get install -y --no-install-recommends \
     plaso-tools \
   && rm -rf /var/lib/apt/lists/*

--- a/docker/release/build/Dockerfile-release
+++ b/docker/release/build/Dockerfile-release
@@ -3,6 +3,7 @@ FROM ubuntu:18.04
 
 MAINTAINER Timesketch <timesketch-dev@googlegroups.com>
 
+TODO: Change back to Plaso stable track once version 20201228 is released.
 ARG PPA_TRACK=dev
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/release/build/Dockerfile-release
+++ b/docker/release/build/Dockerfile-release
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 
 MAINTAINER Timesketch <timesketch-dev@googlegroups.com>
 
-ARG PPA_TRACK=stable
+ARG PPA_TRACK=dev
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/timesketch/lib/tasks.py
+++ b/timesketch/lib/tasks.py
@@ -498,9 +498,7 @@ def run_plaso(
             'files.')
 
     plaso_version = int(plaso.__version__)
-    # Uncomment once a new version is released.
-    #if plaso_version <= PLASO_MINIMUM_VERSION:
-    if plaso_version < PLASO_MINIMUM_VERSION:
+    if plaso_version <= PLASO_MINIMUM_VERSION:
         raise RuntimeError(
             'Plaso version is out of date (version {0:d}, please upgrade to a '
             'version that is later than {1:d}'.format(


### PR DESCRIPTION
This PR moves all docker configs to use the "dev" GIFT PPA to get the latest pre-release of plaso. This would enable the `elastic_ts` output module to make plaso ingestions possible again.

Also added an argument to the files so that we can easily switch back to stable branch as soon as the release hits the market.

This is connected to #1567