### PR TITLE
Issue when removing timeline with a shared index

### DIFF
--- a/timesketch/api/v1/resources/timeline.py
+++ b/timesketch/api/v1/resources/timeline.py
@@ -341,14 +341,20 @@ class TimelineResource(resources.ResourceMixin, Resource):
                     'Timelines with label [{0:s}] cannot be deleted.'.format(
                         label))
 
-        searchindex = timeline.searchindex
-
         # Check if this searchindex is used in other sketches.
         close_index = True
+        searchindex = timeline.searchindex
         for timeline_ in searchindex.timelines:
             if timeline_.sketch.id != sketch.id:
                 close_index = False
                 break
+
+            if timeline_.id != timeline_id:
+                # There are more than a single timeline using this index_name,
+                # we can't close it (unless this timeline is archived).
+                if timeline_.get_status.status != 'archived':
+                    close_index = False
+                    break
 
         if close_index:
             self.datastore.client.indices.close(index=searchindex.index_name)


### PR DESCRIPTION
There is an issue when a timeline is removed from a sketch, but the timeline is part of a larger index.

the index cannot be closed unless all timelines in the sketch are also closed.