### PR TITLE
Increased timeout value for bulk inserts by default, also made it configurable.

### DIFF
--- a/data/timesketch.conf
+++ b/data/timesketch.conf
@@ -39,6 +39,10 @@ ELASTIC_VERIFY_CERTS = True
 # deleted.
 LABELS_TO_PREVENT_DELETION = ['protected', 'preserved']
 
+# Number of seconds before a timeout occurs in bulk operations in the Elastic
+# client.
+TIMEOUT_FOR_EVENT_IMPORT = 30
+
 #-------------------------------------------------------------------------------
 # Single Sign On (SSO) configuration.
 

--- a/data/timesketch.conf
+++ b/data/timesketch.conf
@@ -40,8 +40,10 @@ ELASTIC_VERIFY_CERTS = True
 LABELS_TO_PREVENT_DELETION = ['protected', 'preserved']
 
 # Number of seconds before a timeout occurs in bulk operations in the Elastic
-# client.
-TIMEOUT_FOR_EVENT_IMPORT = 30
+# client. This is expressed in Elastic Time Units, see:
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/\
+# common-options.html#time-units
+TIMEOUT_FOR_EVENT_IMPORT = '3m'
 
 #-------------------------------------------------------------------------------
 # Single Sign On (SSO) configuration.

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -55,6 +55,8 @@ services:
     ports:
       - "127.0.0.1:8844:8844"
     restart: on-failure
+    links:
+      - elasticsearch
     volumes:
       - ../../:/usr/local/src/timesketch/:ro
       - /tmp/:/usr/local/src/picadata/

--- a/timesketch/api/v1/resources/explore.py
+++ b/timesketch/api/v1/resources/explore.py
@@ -104,12 +104,12 @@ class ExploreResource(resources.ResourceMixin, Resource):
         if '_all' in indices:
             indices = all_indices
 
-        # Remove indices that don't exist from search.
-        indices = utils.validate_indices(indices, self.datastore)
-
         # Make sure that the indices in the filter are part of the sketch.
         # This will also remove any deleted timeline from the search result.
         indices, timeline_ids = get_validated_indices(indices, sketch)
+
+        # Remove indices that don't exist from search.
+        indices = utils.validate_indices(indices, self.datastore)
 
         if not indices:
             abort(

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -76,7 +76,7 @@ class ElasticsearchDataStore(object):
     DEFAULT_STREAM_LIMIT = 5000 # Max events to return when streaming results
 
     DEFAULT_FLUSH_RETRY_LIMIT = 3 # Max retries for flushing the queue.
-    DEFAULT_EVENT_IMPORT_TIMEOUT = 30 # Max timeout value for importing events.
+    DEFAULT_EVENT_IMPORT_TIMEOUT = '3m' # Timeout value for importing events.
 
     def __init__(self, host='127.0.0.1', port=9200):
         """Create a Elasticsearch client."""
@@ -950,7 +950,7 @@ class ElasticsearchDataStore(object):
         try:
             # pylint: disable=unexpected-keyword-arg
             results = self.client.bulk(
-                body=self.import_events, request_timeout=self._request_timeout)
+                body=self.import_events, timeout=self._request_timeout)
         except (ConnectionTimeout, socket.timeout):
             if retry_count >= self.DEFAULT_FLUSH_RETRY_LIMIT:
                 es_logger.error(

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -76,6 +76,7 @@ class ElasticsearchDataStore(object):
     DEFAULT_STREAM_LIMIT = 5000 # Max events to return when streaming results
 
     DEFAULT_FLUSH_RETRY_LIMIT = 3 # Max retries for flushing the queue.
+    DEFAULT_EVENT_IMPORT_TIMEOUT = 30 # Max timeout value for importing events.
 
     def __init__(self, host='127.0.0.1', port=9200):
         """Create a Elasticsearch client."""
@@ -97,6 +98,8 @@ class ElasticsearchDataStore(object):
 
         self.import_counter = Counter()
         self.import_events = []
+        self._request_timeout = current_app.config.get(
+            'TIMEOUT_FOR_EVENT_IMPORT', self.DEFAULT_EVENT_IMPORT_TIMEOUT)
 
     @staticmethod
     def _build_labels_query(sketch_id, labels):
@@ -945,7 +948,8 @@ class ElasticsearchDataStore(object):
         }
 
         try:
-            results = self.client.bulk(body=self.import_events)
+            results = self.client.bulk(
+                body=self.import_events, request_timeout=self._request_timeout)
         except (ConnectionTimeout, socket.timeout):
             if retry_count >= self.DEFAULT_FLUSH_RETRY_LIMIT:
                 es_logger.error(

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -948,6 +948,7 @@ class ElasticsearchDataStore(object):
         }
 
         try:
+            # pylint: disable=unexpected-keyword-arg
             results = self.client.bulk(
                 body=self.import_events, request_timeout=self._request_timeout)
         except (ConnectionTimeout, socket.timeout):


### PR DESCRIPTION
This fixes #1564 

This PR does few things:

1. Fixes a bug in the validation of indices, where a `timeline_id` is set into the list of indices. Since that is done before the conversion of `indices` into actual indices and timelines, it can contain timeline IDs and therefore fail.
2. Add a configuration for the default timeout value for bulk inserts into ES. ATM it's the default behavior of 10 seconds, but a default value of 30 seconds was added.
3. Added the configuration into the `/etc/timesketch.conf` file to configure the timeout value