### PR TITLE
Added provider/context for uploads in the importer

### DIFF
--- a/importer_client/python/timesketch_import_client/importer.py
+++ b/importer_client/python/timesketch_import_client/importer.py
@@ -61,11 +61,12 @@ class ImportStreamer(object):
         self._format_string = None
         self._index = ''
         self._last_response = None
-        self._reason = 'Importer via the importer.'
+        self._provider = 'Imported via the importer library.'
         self._resource_url = ''
         self._sketch = None
         self._timeline_id = None
         self._timeline_name = None
+        self._upload_context = ''
 
         self._chunk = 1
 
@@ -233,11 +234,14 @@ class ImportStreamer(object):
             'sketch_id': self._sketch.id,
             'enable_stream': not end_stream,
             'data_label': self._data_label,
-            'reason': self._reason,
+            'provider': self._provider,
             'events': '\n'.join([json.dumps(x) for x in self._data_lines]),
         }
         if self._index:
             data['index_name'] = self._index
+
+        if self._upload_context:
+            data['context'] = self._upload_context
 
         logger.debug(
             'Data buffer ready for upload, took {0:.2f} seconds to '
@@ -283,11 +287,14 @@ class ImportStreamer(object):
             'sketch_id': self._sketch.id,
             'enable_stream': not end_stream,
             'data_label': self._data_label,
-            'reason': self._reason,
+            'provider': self._provider,
             'events': data_frame.to_json(orient='records', lines=True),
         }
         if self._index:
             data['index_name'] = self._index
+
+        if self._upload_context:
+            data['context'] = self._upload_context
 
         response = self._sketch.api.session.post(self._resource_url, data=data)
         self._chunk += 1
@@ -325,11 +332,14 @@ class ImportStreamer(object):
             'name': timeline_name,
             'sketch_id': self._sketch.id,
             'total_file_size': file_size,
-            'reason': self._reason,
+            'provider': self._provider,
             'data_label': self._data_label,
         }
         if self._index:
             data['index_name'] = self._index
+
+        if self._upload_context:
+            data['context'] = self._upload_context
 
         if file_size <= self._threshold_filesize:
             file_dict = {
@@ -678,9 +688,13 @@ class ImportStreamer(object):
         """Set the index name."""
         self._index = index
 
-    def set_reason(self, reason):
-        """Set the import reason."""
-        self._reason = reason
+    def set_provider(self, provider):
+        """Set the data provider."""
+        self._provider = provider
+
+    def set_upload_context(self, upload_context):
+        """Set the upload context for the data import."""
+        self._upload_context = upload_context
 
     def generate_index_name(self):
         """Generates a new index name."""

--- a/importer_client/python/timesketch_import_client/importer.py
+++ b/importer_client/python/timesketch_import_client/importer.py
@@ -61,6 +61,7 @@ class ImportStreamer(object):
         self._format_string = None
         self._index = ''
         self._last_response = None
+        self._reason = 'Importer via the importer.'
         self._resource_url = ''
         self._sketch = None
         self._timeline_id = None
@@ -232,6 +233,7 @@ class ImportStreamer(object):
             'sketch_id': self._sketch.id,
             'enable_stream': not end_stream,
             'data_label': self._data_label,
+            'reason': self._reason,
             'events': '\n'.join([json.dumps(x) for x in self._data_lines]),
         }
         if self._index:
@@ -281,6 +283,7 @@ class ImportStreamer(object):
             'sketch_id': self._sketch.id,
             'enable_stream': not end_stream,
             'data_label': self._data_label,
+            'reason': self._reason,
             'events': data_frame.to_json(orient='records', lines=True),
         }
         if self._index:
@@ -322,6 +325,7 @@ class ImportStreamer(object):
             'name': timeline_name,
             'sketch_id': self._sketch.id,
             'total_file_size': file_size,
+            'reason': self._reason,
             'data_label': self._data_label,
         }
         if self._index:
@@ -673,6 +677,10 @@ class ImportStreamer(object):
     def set_index_name(self, index):
         """Set the index name."""
         self._index = index
+
+    def set_reason(self, reason):
+        """Set the import reason."""
+        self._reason = reason
 
     def generate_index_name(self):
         """Generates a new index name."""

--- a/importer_client/python/timesketch_import_client/version.py
+++ b/importer_client/python/timesketch_import_client/version.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Version information for Timesketch Import Client."""
 
-__version__ = '20210217'
+__version__ = '20210224'
 
 
 def get_version():

--- a/timesketch/api/v1/resources/upload.py
+++ b/timesketch/api/v1/resources/upload.py
@@ -384,8 +384,9 @@ class UploadFileResource(resources.ResourceMixin, Resource):
 
         utils.update_sketch_last_activity(sketch)
 
-        # TODO: Read the data reason and save into the database.
-        # reason = form.get('reason', '')
+        # TODO: Read the data provider and save the information to the DB.
+        # provider = form.get('provider', '')
+        # context = form.get('context', '')
 
         index_name = form.get('index_name', '')
         file_storage = request.files.get('file')

--- a/timesketch/api/v1/resources/upload.py
+++ b/timesketch/api/v1/resources/upload.py
@@ -384,6 +384,9 @@ class UploadFileResource(resources.ResourceMixin, Resource):
 
         utils.update_sketch_last_activity(sketch)
 
+        # TODO: Read the data reason and save into the database.
+        # reason = form.get('reason', '')
+
         index_name = form.get('index_name', '')
         file_storage = request.files.get('file')
         if file_storage:


### PR DESCRIPTION
This PR adds support for:

1. Adding provider for the uploads
2. Adding upload context for the imported data.

This is for the upcoming #1641 , providing the support in the importer client.

Next steps would be to implement the backend support and database schema.