### PR TITLE
Add the ability to use elasticsearch with SSL but without username/password authentication.

### DIFF
--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -88,7 +88,11 @@ class ElasticsearchDataStore(object):
         self.ssl = current_app.config.get('ELASTIC_SSL', False)
         self.verify = current_app.config.get('ELASTIC_VERIFY_CERTS', True)
 
-        if self.ssl:
+        if self.ssl and not self.user and not self.password:
+            self.client = Elasticsearch([{'host': host, 'port': port}],
+                                        use_ssl=self.ssl,
+                                        verify_certs=self.verify)
+        elif self.ssl:
             self.client = Elasticsearch([{'host': host, 'port': port}],
                                         http_auth=(self.user, self.password),
                                         use_ssl=self.ssl,

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -90,14 +90,14 @@ class ElasticsearchDataStore(object):
 
         if self.ssl:
             if self.user and self.password:
-                self.client = Elasticsearch([{'host': host, 'port': port}],
-                                        http_auth=(self.user, self.password),
-                                        use_ssl=self.ssl,
-                                        verify_certs=self.verify)
+                self.client = Elasticsearch(
+                    [{'host': host, 'port': port}],
+                    http_auth=(self.user, self.password),
+                    use_ssl=self.ssl, verify_certs=self.verify)
             else:
-                self.client = Elasticsearch([{'host': host, 'port': port}],
-                                        use_ssl=self.ssl,
-                                        verify_certs=self.verify)
+                self.client = Elasticsearch(
+                    [{'host': host, 'port': port}],
+                    use_ssl=self.ssl, verify_certs=self.verify)
         else:
             self.client = Elasticsearch([{'host': host, 'port': port}])
 

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -88,13 +88,14 @@ class ElasticsearchDataStore(object):
         self.ssl = current_app.config.get('ELASTIC_SSL', False)
         self.verify = current_app.config.get('ELASTIC_VERIFY_CERTS', True)
 
-        if self.ssl and not self.user and not self.password:
-            self.client = Elasticsearch([{'host': host, 'port': port}],
+        if self.ssl:
+            if self.user and self.password:
+                self.client = Elasticsearch([{'host': host, 'port': port}],
+                                        http_auth=(self.user, self.password),
                                         use_ssl=self.ssl,
                                         verify_certs=self.verify)
-        elif self.ssl:
-            self.client = Elasticsearch([{'host': host, 'port': port}],
-                                        http_auth=(self.user, self.password),
+            else:
+                self.client = Elasticsearch([{'host': host, 'port': port}],
                                         use_ssl=self.ssl,
                                         verify_certs=self.verify)
         else:


### PR DESCRIPTION
Especially in cloud environments the authentication to elasticsearch is often not done with username/password. Although, it should be possible to use SSL.