### PR TITLE
Another round of minor checks where unittests did not reflect the reality

### DIFF
--- a/api_client/python/timesketch_api_client/sigma.py
+++ b/api_client/python/timesketch_api_client/sigma.py
@@ -161,7 +161,6 @@ class Sigma(resource.BaseResource):
         objects = self.data.get('objects')
         if not objects:
             logger.error('Unable to parse rule with given text')
-                'Unable to parse rule with given text')
             raise ValueError('No rules found.')
         rule_dict = objects[0]
         for key, value in rule_dict.items():

--- a/api_client/python/timesketch_api_client/sigma.py
+++ b/api_client/python/timesketch_api_client/sigma.py
@@ -158,7 +158,13 @@ class Sigma(resource.BaseResource):
             api=self.api, resource_uri=self.resource_uri)
 
         self.lazyload_data(refresh_cache=True)
-        for key, value in self.resource_data.items():
+        objects = self.data.get('objects')
+        if not objects:
+            logger.warning(
+                'Unable to parse rule with given text')
+            raise ValueError('No rules found.')
+        rule_dict = objects[0]
+        for key, value in rule_dict.items():
             self.set_value(key, value)
 
     def from_text(self, rule_text):

--- a/api_client/python/timesketch_api_client/sigma.py
+++ b/api_client/python/timesketch_api_client/sigma.py
@@ -161,7 +161,6 @@ class Sigma(resource.BaseResource):
         for key, value in self.resource_data.items():
             self.set_value(key, value)
 
-
     def from_text(self, rule_text):
         """Get a Sigma object from a rule text.
 
@@ -173,11 +172,10 @@ class Sigma(resource.BaseResource):
         """
         self.resource_uri = '{0:s}/sigma/text/'.format(self.api.api_root)
         data = {'title': 'Get_Sigma_by_text', 'content': rule_text}
-        response = self.api.session.post(self.resource_uri, data=data)
+        response = self.api.session.post(self.resource_uri, json=data)
         response_dict = error.get_response_json(response, logger)
 
         objects = response_dict.get('objects')
-
         if not objects:
             logger.warning(
                 'Unable to parse rule with given text')

--- a/api_client/python/timesketch_api_client/sigma.py
+++ b/api_client/python/timesketch_api_client/sigma.py
@@ -160,7 +160,7 @@ class Sigma(resource.BaseResource):
         self.lazyload_data(refresh_cache=True)
         objects = self.data.get('objects')
         if not objects:
-            logger.warning(
+            logger.error('Unable to parse rule with given text')
                 'Unable to parse rule with given text')
             raise ValueError('No rules found.')
         rule_dict = objects[0]

--- a/api_client/python/timesketch_api_client/test_lib.py
+++ b/api_client/python/timesketch_api_client/test_lib.py
@@ -276,27 +276,33 @@ def mock_response(*args, **kwargs):
     }
 
     sigma_rule = {
-        'title': 'Suspicious Installation of Zenmap',
-        'id': '5266a592-b793-11ea-b3de-0242ac130004',
-        'description': 'Detects suspicious installation of Zenmap',
-        'references': ['httpx://foobar.com'],
-        'author': 'Alexander Jaeger',
-        'date': '2020/06/26',
-        'modified': '2021/01/01',
-        'logsource': {
-            'product': 'linux', 'service': 'shell'
-            },
-        'detection': {
-            'keywords': ['*apt-get install zmap*'],
-            'condition': 'keywords'
-            },
-        'falsepositives': ['Unknown'],
-        'level': 'high',
-        'es_query': '("*apt\\-get\\ install\\ zmap*")',
-        'file_name': 'lnx_susp_zenmap',
-        'file_relpath' : '/linux/syslog/foobar/'
+        'meta': {
+            'parsed': True
+        },
+        'objects':[
+            {
+            'title': 'Suspicious Installation of Zenmap',
+            'id': '5266a592-b793-11ea-b3de-0242ac130004',
+            'description': 'Detects suspicious installation of Zenmap',
+            'references': ['httpx://foobar.com'],
+            'author': 'Alexander Jaeger',
+            'date': '2020/06/26',
+            'modified': '2021/01/01',
+            'logsource': {
+                'product': 'linux', 'service': 'shell'
+                },
+            'detection': {
+                'keywords': ['*apt-get install zmap*'],
+                'condition': 'keywords'
+                },
+            'falsepositives': ['Unknown'],
+            'level': 'high',
+            'es_query': '("*apt\\-get\\ install\\ zmap*")',
+            'file_name': 'lnx_susp_zenmap',
+            'file_relpath' : '/linux/syslog/foobar/'
+            }
+        ]
     }
-
     sigma_rule_text_mock = {
         'meta': {
             'parsed': True

--- a/timesketch/api/v1/resources/sigma.py
+++ b/timesketch/api/v1/resources/sigma.py
@@ -84,7 +84,6 @@ class SigmaResource(resources.ResourceMixin, Resource):
             abort(
                 HTTP_STATUS_CODE_NOT_FOUND,
                 'OS Error, unable to get the path to the Sigma rules')
-        print(rule_uuid)
         for rule in sigma_rules:
             if rule is not None:
                 if rule_uuid == rule.get('id'):
@@ -96,7 +95,7 @@ class SigmaResource(resources.ResourceMixin, Resource):
 
         meta = {'current_user': current_user.username,
                 'rules_count': len(sigma_rules)}
-        return jsonify({'objects': return_rule, 'meta': meta})
+        return jsonify({'objects': [return_rule], 'meta': meta})
 
 
 class SigmaByTextResource(resources.ResourceMixin, Resource):

--- a/timesketch/api/v1/resources/sigma.py
+++ b/timesketch/api/v1/resources/sigma.py
@@ -84,7 +84,7 @@ class SigmaResource(resources.ResourceMixin, Resource):
             abort(
                 HTTP_STATUS_CODE_NOT_FOUND,
                 'OS Error, unable to get the path to the Sigma rules')
-
+        print(rule_uuid)
         for rule in sigma_rules:
             if rule is not None:
                 if rule_uuid == rule.get('id'):
@@ -113,14 +113,6 @@ class SigmaByTextResource(resources.ResourceMixin, Resource):
         form = request.json
         if not form:
             form = request.data
-
-        action = form.get('action', '')
-
-        # TODO: that can eventually go away since there are no other actions
-        if action != 'post':
-            return abort(
-                HTTP_STATUS_CODE_BAD_REQUEST,
-                'Action needs to be "post"')
 
         content = form.get('content')
         if not content:

--- a/timesketch/api/v1/resources/sigma.py
+++ b/timesketch/api/v1/resources/sigma.py
@@ -58,7 +58,7 @@ class SigmaListResource(resources.ResourceMixin, Resource):
         # TODO: idea for meta: add a list of folders that have been parsed
         meta = {'current_user': current_user.username,
                 'rules_count': len(sigma_rules)}
-        return jsonify({'objects': [sigma_rules], 'meta': meta})
+        return jsonify({'objects': sigma_rules, 'meta': meta})
 
 
 class SigmaResource(resources.ResourceMixin, Resource):

--- a/timesketch/api/v1/resources_test.py
+++ b/timesketch/api/v1/resources_test.py
@@ -395,7 +395,7 @@ class SigmaListResourceTest(BaseTest):
         'meta': {
             'current_user': 'test1', 'rules_count': 1
             },
-        'objects':[[{
+        'objects':[{
             'author': 'Alexander Jaeger',
             'date': '2020/06/26',
             'description': 'Detects suspicious installation of Zenmap',
@@ -420,7 +420,7 @@ class SigmaListResourceTest(BaseTest):
                 'https://rmusser.net/docs/ATT&CK-Stuff/ATT&CK/Discovery.html'
             ],
             'title': 'Suspicious Installation of Zenmap'
-        }]]}
+        }]}
     def test_get_sigma_rule_list(self):
         self.login()
         response = self.client.get(self.resource_url)

--- a/timesketch/api/v1/resources_test.py
+++ b/timesketch/api/v1/resources_test.py
@@ -489,7 +489,7 @@ class SigmaByTextResourceTest(BaseTest):
         """Authenticated request to get an sigma rule by text."""
         self.login()
 
-        data = dict(action='post', content=self.correct_rule)
+        data = dict(content=self.correct_rule)
         response = self.client.post(
             self.resource_url,
             data=json.dumps(data, ensure_ascii=False),
@@ -500,7 +500,7 @@ class SigmaByTextResourceTest(BaseTest):
         self.assert200(response)
 
         # wrong sigma rule
-        data = dict(action='post', content='foobar: asd')
+        data = dict(content='foobar: asd')
         response = self.client.post(
             self.resource_url,
             data=json.dumps(data, ensure_ascii=False),
@@ -508,17 +508,6 @@ class SigmaByTextResourceTest(BaseTest):
         data = json.loads(response.get_data(as_text=True))
 
         self.assertIn('No detection definitions found', data['message'])
-        self.assertEqual(response.status_code, HTTP_STATUS_CODE_BAD_REQUEST)
-
-        # wrong action
-        data = dict(action='get', content=self.correct_rule)
-        response = self.client.post(
-            self.resource_url,
-            data=json.dumps(data, ensure_ascii=False),
-            content_type='application/json')
-        data = json.loads(response.get_data(as_text=True))
-
-        self.assertIn('Action needs to be "post"', data['message'])
         self.assertEqual(response.status_code, HTTP_STATUS_CODE_BAD_REQUEST)
 
         # no content given


### PR DESCRIPTION
- remove the action from the form as not really needed / used
- removed one pair of ```[]``` who sneaked in
- adjusted the sigmy_by_uuid to match the structure of ```object```  and ```metadata``` with the from_text