### PR TITLE
Fixed limitations in file size in the data source model.

### DIFF
--- a/docs/Admin-Guide.md
+++ b/docs/Admin-Guide.md
@@ -273,3 +273,12 @@ This makes sure that the database is current. Then create a revision file:
 ```shell
 tsctl db migrate -m "<message>"
 ```
+
+If the migration file is not created, which could be an indication that the schema change
+is not detected by the automation one can create an empty revision file:
+
+```shell
+tsctl db revision
+```
+
+And then fill in the blanks, see examples of changes in `timesketch/migrations/versions/*_.py`.

--- a/docs/Admin-Guide.md
+++ b/docs/Admin-Guide.md
@@ -258,10 +258,12 @@ tsctl similarity_score
 ### Upgrade DB After Schema Change
 
 
-After changin the schema for the database a revision file needs to be generated.
-To generate the file use the command:
+After changing the schema for the database a revision file needs to be generated.
+
+Inside the timesketch container, to generate the file use the command:
 
 ```shell
+cd /usr/local/src/timesketch/timesketch
 tsctl db stamp head
 tsctl db upgrade
 ```

--- a/timesketch/migrations/versions/41cae2c10cd7_.py
+++ b/timesketch/migrations/versions/41cae2c10cd7_.py
@@ -5,6 +5,7 @@ Revises: 654121a84a33
 Create Date: 2021-03-03 10:59:58.038715
 
 """
+# pylint: skip-file
 
 # revision identifiers, used by Alembic.
 revision = '41cae2c10cd7'

--- a/timesketch/migrations/versions/41cae2c10cd7_.py
+++ b/timesketch/migrations/versions/41cae2c10cd7_.py
@@ -1,0 +1,22 @@
+"""Change the file size value of the data source to a larger int.
+
+Revision ID: 41cae2c10cd7
+Revises: 654121a84a33
+Create Date: 2021-03-03 10:59:58.038715
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '41cae2c10cd7'
+down_revision = '654121a84a33'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.alter_column('datasource', 'file_size', type_=sa.BigInteger)
+
+
+def downgrade():
+    op.alter_column('datasource', 'file_size', type_=sa.Integer)

--- a/timesketch/models/sketch.py
+++ b/timesketch/models/sketch.py
@@ -20,6 +20,7 @@ import json
 from flask import current_app
 from flask import url_for
 
+from sqlalchemy import BigInteger
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
@@ -700,7 +701,7 @@ class DataSource(LabelMixin, StatusMixin, CommentMixin, BaseModel):
     provider = Column(UnicodeText())
     context = Column(UnicodeText())
     file_on_disk = Column(UnicodeText())
-    file_size = Column(Integer)
+    file_size = Column(BigInteger())
     original_filename = Column(UnicodeText())
     data_label = Column(UnicodeText())
 


### PR DESCRIPTION
An issue got reported that uploading large files failed.

Looking at it, with the recent change in adding the DataSource model we now record the byte size of uploaded files. This value is an integer, which in PostgreSQL is int4, which has severe limitations, which would limit all uploads to ~2Gb file size. This PR changes the schema to use bigint instead of int, giving us much more leg room.