### PR TITLE
package name typo in the requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,5 +32,5 @@ xlrd==1.2.0
 tabulate==0.8.6
 markdown==3.2.2
 networkx==2.5
-prometheus-client==0.9.0
-prometheus-flask-exporter==0.18.1
+prometheus_client==0.9.0
+prometheus_flask_exporter==0.18.1


### PR DESCRIPTION
package name typo in the requirements, image @ us-docker.pkg.dev/osdfir-registry/timesketch/dev will also need to be rebuilt.