### PR TITLE
Changed how ES object is created to support auth without ssl, as well as minor bug fix in analyzer selection.

### DIFF
--- a/timesketch/lib/analyzers/manager.py
+++ b/timesketch/lib/analyzers/manager.py
@@ -78,11 +78,14 @@ class AnalysisManager(object):
         cls._class_registry = {}
 
     @classmethod
-    def get_analyzers(cls, analyzer_names=None):
+    def get_analyzers(cls, analyzer_names=None, sketch_analyzers=True):
         """Retrieves the registered analyzers.
 
         Args:
             analyzer_names (list): List of analyzer names.
+            sketch_analyzers (bool): If True (default) then only sketch
+                analyzers are return, otherwise it will return Index
+                analyzers.
 
         Yields:
             tuple: containing:
@@ -99,7 +102,13 @@ class AnalysisManager(object):
                 if analyzer_name in completed_analyzers:
                     continue
                 analyzer_class = cls.get_analyzer(analyzer_name)
-                yield analyzer_name, analyzer_class
+                if sketch_analyzers:
+                    if analyzer_class.IS_SKETCH_ANALYZER:
+                        yield analyzer_name, analyzer_class
+                else:
+                    if not analyzer_class.IS_SKETCH_ANALYZER:
+                        yield analyzer_name, analyzer_class
+
                 completed_analyzers.add(analyzer_name)
 
     @classmethod

--- a/timesketch/lib/analyzers/manager_test.py
+++ b/timesketch/lib/analyzers/manager_test.py
@@ -24,6 +24,7 @@ class MockAnalyzer(object):
     NAME = 'MockAnalyzer'
 
     DEPENDENCIES = frozenset()
+    IS_SKETCH_ANALYZER = True
 
 
 class MockAnalyzer2(object):
@@ -31,6 +32,15 @@ class MockAnalyzer2(object):
     NAME = 'MockAnalyzer2'
 
     DEPENDENCIES = frozenset(['MockAnalyzer'])
+    IS_SKETCH_ANALYZER = True
+
+
+class MockIndexAnalyzer(object):
+    """Mock analyzer class,"""
+    NAME = 'MockIndexAnalyzer'
+
+    DEPENDENCIES = frozenset()
+    IS_SKETCH_ANALYZER = False
 
 
 class MockAnalyzer3(object):
@@ -38,6 +48,7 @@ class MockAnalyzer3(object):
     NAME = 'MockAnalyzer3'
 
     DEPENDENCIES = frozenset()
+    IS_SKETCH_ANALYZER = True
 
 
 class MockAnalyzer4(object):
@@ -45,6 +56,7 @@ class MockAnalyzer4(object):
     NAME = 'MockAnalyzer4'
 
     DEPENDENCIES = frozenset(['MockAnalyzer2', 'MockAnalyzer3'])
+    IS_SKETCH_ANALYZER = True
 
 
 class MockAnalyzerFail1(object):
@@ -52,6 +64,7 @@ class MockAnalyzerFail1(object):
     NAME = 'MockAnalyzerFail1'
 
     DEPENDENCIES = frozenset(['MockAnalyzerFail2'])
+    IS_SKETCH_ANALYZER = True
 
 
 class MockAnalyzerFail2(object):
@@ -59,6 +72,7 @@ class MockAnalyzerFail2(object):
     NAME = 'MockAnalyzerFail2'
 
     DEPENDENCIES = frozenset(['MockAnalyzerFail1'])
+    IS_SKETCH_ANALYZER = True
 
 
 class TestAnalysisManager(BaseTest):
@@ -91,6 +105,7 @@ class TestAnalysisManager(BaseTest):
         manager.AnalysisManager.register_analyzer(MockAnalyzer2)
         manager.AnalysisManager.register_analyzer(MockAnalyzer3)
         manager.AnalysisManager.register_analyzer(MockAnalyzer4)
+        manager.AnalysisManager.register_analyzer(MockIndexAnalyzer)
 
         analyzers = manager.AnalysisManager.get_analyzers()
         analyzer_names_list = [x for x, _ in analyzers]
@@ -111,6 +126,11 @@ class TestAnalysisManager(BaseTest):
         self.assertIn('mockanalyzer3', dependency_tree[0])
         self.assertIn('mockanalyzer2', dependency_tree[1])
         self.assertIn('mockanalyzer4', dependency_tree[2])
+
+        analyzers = [x for x, _ in manager.AnalysisManager.get_analyzers(
+            sketch_analyzers=False)]
+        self.assertEqual(len(analyzers), 1)
+        self.assertEqual(analyzers[0], 'mockindexanalyzer')
 
         manager.AnalysisManager.clear_registration()
         manager.AnalysisManager.register_analyzer(MockAnalyzerFail1)

--- a/timesketch/lib/analyzers/manager_test.py
+++ b/timesketch/lib/analyzers/manager_test.py
@@ -80,7 +80,7 @@ class TestAnalysisManager(BaseTest):
 
     def setUp(self):
         """Set up the tests."""
-        super(TestAnalysisManager, self).setUp()
+        super().setUp()
         manager.AnalysisManager.clear_registration()
         manager.AnalysisManager.register_analyzer(MockAnalyzer)
 

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -117,18 +117,16 @@ class ElasticsearchDataStore(object):
         self.ssl = current_app.config.get('ELASTIC_SSL', False)
         self.verify = current_app.config.get('ELASTIC_VERIFY_CERTS', True)
 
+        parameters = {}
         if self.ssl:
-            if self.user and self.password:
-                self.client = Elasticsearch(
-                    [{'host': host, 'port': port}],
-                    http_auth=(self.user, self.password),
-                    use_ssl=self.ssl, verify_certs=self.verify)
-            else:
-                self.client = Elasticsearch(
-                    [{'host': host, 'port': port}],
-                    use_ssl=self.ssl, verify_certs=self.verify)
-        else:
-            self.client = Elasticsearch([{'host': host, 'port': port}])
+            parameters['use_ssl'] = self.ssl
+            parameters['verify_certs'] = self.verify
+
+        if self.user and self.password:
+            parameters['http_auth'] = (self.user, self.password)
+
+        self.client = Elasticsearch(
+            [{'host': host, 'port': port}], **parameters)
 
         self.import_counter = Counter()
         self.import_events = []

--- a/timesketch/lib/tasks.py
+++ b/timesketch/lib/tasks.py
@@ -220,13 +220,13 @@ def _get_index_analyzers():
         None if index analyzers are disabled in config.
     """
     tasks = []
-    index_analyzers = current_app.config.get('AUTO_INDEX_ANALYZERS')
+    index_analyzers = current_app.config.get('AUTO_INDEX_ANALYZERS', [])
 
     if not index_analyzers:
         return None
 
     for analyzer_name, _ in manager.AnalysisManager.get_analyzers(
-            index_analyzers):
+            index_analyzers, sketch_analyzers=False):
         tasks.append(run_index_analyzer.s(analyzer_name))
 
     return chain(tasks)


### PR DESCRIPTION
This PR does the following things:

+ Changes how the ElasticSearch database object is created, so that you can have varied configuration (ssl/user/auth/etc)
+ Change how auto analyzers are selected, differentiating between index/sketch analyzers.

**Checks**

- [x] All tests succeed.
- [x] Unit tests added.
- [x] e2e tests added.
- [x] Documentation updated.

**Closing issues**

+ closes #1709 - fixing auth
+ closes #1706 - differentiating between index and sketch analyzers in lib/tasks