### PR TITLE
Changed upload behavior when appending to an already existing timeline

### DIFF
--- a/timesketch/api/v1/resources/upload.py
+++ b/timesketch/api/v1/resources/upload.py
@@ -195,7 +195,11 @@ class UploadFileResource(resources.ResourceMixin, Resource):
                 HTTP_STATUS_CODE_BAD_REQUEST,
                 'Unable to get or create a new Timeline object.')
 
-        timeline.set_status('processing')
+        # If the timeline already existed and has associated data sources
+        # then we don't want to set the status to processing.
+        if not timeline.datasources:
+            timeline.set_status('processing')
+
         sketch.timelines.append(timeline)
 
         labels_to_prevent_deletion = current_app.config.get(

--- a/timesketch/lib/tasks.py
+++ b/timesketch/lib/tasks.py
@@ -176,6 +176,7 @@ def _set_timeline_status(timeline_id, status, error_msg=None):
         logger.warning('Cannot set status: No such timeline')
         return
 
+    # Check if there is at least one data source that hasn't failed.
     multiple_sources = any([not x.error_message for x in timeline.datasources])
     print('Multiple sources: {}'.format(multiple_sources))
 

--- a/timesketch/lib/tasks.py
+++ b/timesketch/lib/tasks.py
@@ -50,7 +50,6 @@ from timesketch.lib.utils import send_email
 from timesketch.models import db_session
 from timesketch.models.sketch import Analysis
 from timesketch.models.sketch import AnalysisSession
-from timesketch.models.sketch import DataSource
 from timesketch.models.sketch import SearchIndex
 from timesketch.models.sketch import Sketch
 from timesketch.models.sketch import Timeline
@@ -178,7 +177,6 @@ def _set_timeline_status(timeline_id, status, error_msg=None):
 
     # Check if there is at least one data source that hasn't failed.
     multiple_sources = any([not x.error_message for x in timeline.datasources])
-    print('Multiple sources: {}'.format(multiple_sources))
 
     if multiple_sources:
         if status != 'fail':


### PR DESCRIPTION
This PR changes the behavior when new data is appended to an already existing timeline. What changes is:

+ The timeline status is no longer set to `processing` while the new data is being ingested
+ If one data source fails, that does not mean the entire timeline is no longer accessible.

**Checks**

- [x] All tests succeed.
