### PR TITLE
Bugfix: Ensure correct root history node is fetched

### DIFF
--- a/timesketch/api/v1/resources/explore.py
+++ b/timesketch/api/v1/resources/explore.py
@@ -425,7 +425,8 @@ class SearchHistoryResource(resources.ResourceMixin, Resource):
 
         tree = {}
         root_node = SearchHistory.query.filter_by(
-            user=current_user, sketch=sketch).first()
+            user=current_user, sketch=sketch).order_by(
+                SearchHistory.id).first()
         last_node = SearchHistory.query.filter_by(
             user=current_user, sketch=sketch).order_by(
                 SearchHistory.id.desc()).first()


### PR DESCRIPTION
Bug in how we get the root history node for a user. This fix adds the ordering on the ID of the node. This ensures that we always get the first entry.