### PR TITLE
Change default search operator

### DIFF
--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -338,7 +338,10 @@ class ElasticsearchDataStore(object):
 
         if query_string:
             query_dsl['query']['bool']['must'].append(
-                {'query_string': {'query': query_string}})
+                {'query_string': {
+                    'query': query_string,
+                    'default_operator': 'AND'}
+                })
 
         # New UI filters
         if query_filter.get('chips', None):


### PR DESCRIPTION
The current default search operator for string queries is OR. This is somewhat unintuitive, as the defactor standard for search is to have AND as default operator.

This PR changes the default ES search operator to AND for query_string queries.

**Closing issues**
Closes #1774 