### PR TITLE
Changed how sketch attributes are handled.

### DIFF
--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -239,8 +239,7 @@ class Sketch(resource.BaseResource):
             ValueError: If any of the parameters are of the wrong type.
 
         Returns:
-            Boolean value whether the attribute was successfully
-            added or not.
+            A dict with the results from the operation.
         """
         if not isinstance(name, str):
             raise ValueError('Name needs to be a string.')
@@ -257,13 +256,12 @@ class Sketch(resource.BaseResource):
             'ontology': ontology,
         }
         response = self.api.session.post(resource_url, json=data)
-        print(response.text)
 
         status = error.check_return_status(response, logger)
         if not status:
             logger.error('Unable to add the attribute to the sketch.')
 
-        return status
+        return error.get_response_json(response, logger)
 
     def add_attribute(self, name, value, ontology='text'):
         """Adds or modifies an attribute to the sketch.
@@ -279,8 +277,7 @@ class Sketch(resource.BaseResource):
             ValueError: If any of the parameters are of the wrong type.
 
         Returns:
-            Boolean value whether the attribute was successfully
-            added or not.
+            A dict with the results from the operation.
         """
         if not isinstance(name, str):
             raise ValueError('Name needs to be a string.')

--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -84,12 +84,7 @@ class Sketch(resource.BaseResource):
         """Property that returns the sketch attributes."""
         data = self.lazyload_data(refresh_cache=True)
         meta = data.get('meta', {})
-        return_dict = {}
-        for items in meta.get('attributes', []):
-            name, values, ontology = items
-            return_dict[name] = (values, ontology)
-
-        return return_dict
+        return meta.get('attributes', {})
 
     @property
     def attributes_table(self):

--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -225,7 +225,7 @@ class Sketch(resource.BaseResource):
         return status_list[0].get('status', 'Unknown')
 
     def add_attribute_list(self, name, values, ontology='text'):
-        """Add an attribute to the sketch.
+        """Adds or modifies attributes to the sketch.
 
         Args:
             name (str): The name of the attribute.
@@ -255,9 +255,9 @@ class Sketch(resource.BaseResource):
             'name': name,
             'values': values,
             'ontology': ontology,
-            'action': 'post',
         }
         response = self.api.session.post(resource_url, json=data)
+        print(response.text)
 
         status = error.check_return_status(response, logger)
         if not status:
@@ -266,7 +266,7 @@ class Sketch(resource.BaseResource):
         return status
 
     def add_attribute(self, name, value, ontology='text'):
-        """Add an attribute to the sketch.
+        """Adds or modifies an attribute to the sketch.
 
         Args:
             name (str): The name of the attribute.
@@ -319,11 +319,14 @@ class Sketch(resource.BaseResource):
 
         return status
 
-    def remove_attribute(self, name):
+    def remove_attribute(self, name, ontology):
         """Remove an attribute from the sketch.
 
         Args:
             name (str): The name of the attribute.
+            ontology (str): The ontology (matches with
+                /etc/ontology.yaml), which defines how the attribute
+                is interpreted.
 
         Raises:
             ValueError: If any of the parameters are of the wrong type.
@@ -340,10 +343,9 @@ class Sketch(resource.BaseResource):
 
         data = {
             'name': name,
-            'ontology': 'text',
-            'action': 'delete',
+            'ontology': ontology,
         }
-        response = self.api.session.post(resource_url, json=data)
+        response = self.api.session.delete(resource_url, json=data)
 
         status = error.check_return_status(response, logger)
         if not status:

--- a/api_client/python/timesketch_api_client/version.py
+++ b/api_client/python/timesketch_api_client/version.py
@@ -14,7 +14,7 @@
 """Version information for Timesketch API Client."""
 
 
-__version__ = '20210416'
+__version__ = '20210527'
 
 
 def get_version():

--- a/data/ontology.yaml
+++ b/data/ontology.yaml
@@ -10,7 +10,7 @@ text:
         description: "Free form text."
 
 int:
-        case_as: int
+        cast_as: int
         description: "Integer"
 
 url.safe:

--- a/timesketch/api/v1/resources/attribute.py
+++ b/timesketch/api/v1/resources/attribute.py
@@ -27,6 +27,7 @@ from timesketch.api.v1 import utils
 from timesketch.lib import ontology as ontology_lib
 from timesketch.lib.definitions import HTTP_STATUS_CODE_OK
 from timesketch.lib.definitions import HTTP_STATUS_CODE_BAD_REQUEST
+from timesketch.lib.definitions import HTTP_STATUS_CODE_CREATED
 from timesketch.lib.definitions import HTTP_STATUS_CODE_FORBIDDEN
 from timesketch.lib.definitions import HTTP_STATUS_CODE_NOT_FOUND
 from timesketch.models import db_session
@@ -87,7 +88,7 @@ class AttributeResource(resources.ResourceMixin, Resource):
         """Handles POST request to the resource.
 
         Returns:
-            A string with the response from running the analyzer.
+            A HTTP 200 if the attribute is successfully added or modified.
         """
         sketch = Sketch.query.get_with_acl(sketch_id)
         if not sketch:
@@ -106,7 +107,7 @@ class AttributeResource(resources.ResourceMixin, Resource):
         if not form:
             return abort(
                 HTTP_STATUS_CODE_FORBIDDEN,
-                'Unable to add or remove an attribute from a '
+                'Unable to add or modify an attribute from a '
                 'sketch without any data submitted.')
 
         for check in ['name', 'ontology']:
@@ -115,12 +116,6 @@ class AttributeResource(resources.ResourceMixin, Resource):
                 return abort(
                     HTTP_STATUS_CODE_BAD_REQUEST, error_message)
 
-        action = form.get('action', '')
-        if action not in ('post', 'delete'):
-            return abort(
-                HTTP_STATUS_CODE_BAD_REQUEST,
-                'Action needs to be either "post" or "delete"')
-
         name = form.get('name')
         ontology = form.get('ontology', 'text')
 
@@ -128,60 +123,116 @@ class AttributeResource(resources.ResourceMixin, Resource):
         ontology_dict = ontology_def.get(ontology, {})
         cast_as_string = ontology_dict.get('cast_as', 'str')
 
-        if action == 'post':
-            values = form.get('values')
-            if not values:
-                return abort(
-                    HTTP_STATUS_CODE_BAD_REQUEST,
-                    'Missing values from the request.')
+        values = form.get('values')
+        if not values:
+            return abort(
+                HTTP_STATUS_CODE_BAD_REQUEST,
+                'Missing values from the request.')
 
-            if not isinstance(values, (list, tuple)):
-                return abort(
-                    HTTP_STATUS_CODE_BAD_REQUEST, 'Values needs to be a list.')
+        if not isinstance(values, (list, tuple)):
+            return abort(
+                HTTP_STATUS_CODE_BAD_REQUEST, 'Values needs to be a list.')
 
-            value_strings = [ontology_lib.OntologyManager.encode_value(
-                x, cast_as_string) for x in values]
+        value_strings = [ontology_lib.OntologyManager.encode_value(
+            x, cast_as_string) for x in values]
 
-            if any([not isinstance(x, str) for x in value_strings]):
-                return abort(
-                    HTTP_STATUS_CODE_BAD_REQUEST,
-                    'All values needs to be stored as strings.')
+        if any([not isinstance(x, str) for x in value_strings]):
+            return abort(
+                HTTP_STATUS_CODE_BAD_REQUEST,
+                'All values needs to be stored as strings.')
 
-            for attribute in sketch.attributes:
-                if attribute.name == name:
-                    return abort(
-                        HTTP_STATUS_CODE_BAD_REQUEST,
-                        'Unable to add the attribute, it already exists.')
+        attribute = None
+        message = ''
+        update_attribute = False
+        for attribute in sketch.attributes:
+            if (attribute.name == name) and (attribute.ontology == ontology):
+                message = 'Attribute Updated'
+                update_attribute = True
+                break
 
+        if update_attribute:
+            attribute_values = AttributeValue.query.filter_by(
+                attribute=attribute).delete()
+        else:
             attribute = Attribute(
                 user=current_user,
                 sketch=sketch,
                 name=name,
                 ontology=ontology)
-            db_session.add(attribute)
-            db_session.commit()
-
-            for value in value_strings:
-                attribute_value = AttributeValue(
-                    user=current_user,
-                    attribute=attribute,
-                    value=value)
-                attribute.values.append(attribute_value)
-                db_session.add(attribute_value)
-                db_session.commit()
 
             db_session.add(attribute)
             db_session.commit()
 
-            return HTTP_STATUS_CODE_OK
+        for value in value_strings:
+            attribute_value = AttributeValue(
+                user=current_user,
+                attribute=attribute,
+                value=value)
+            attribute.values.append(attribute_value)
+            db_session.add(attribute_value)
+            db_session.commit()
 
-        if action != 'delete':
+        db_session.add(attribute)
+        db_session.commit()
+
+        return_data = {
+            'name': name,
+            'ontology': ontology,
+            'cast_as': cast_as_string,
+        }
+        response = None
+        if message:
+            return_data['action'] = 'update'
+            response = jsonify(return_data)
+            response.status_code = HTTP_STATUS_CODE_OK
+        else:
+            return_data['action'] = 'create'
+            response = jsonify(return_data)
+            response.status_code = HTTP_STATUS_CODE_CREATED
+
+        return response
+
+    def delete(self, sketch_id):
+        """Handles delete request to the resource.
+
+        Returns:
+            A HTTP response code.
+        """
+        sketch = Sketch.query.get_with_acl(sketch_id)
+        if not sketch:
+            abort(
+                HTTP_STATUS_CODE_NOT_FOUND, 'No sketch found with this ID.')
+
+        if not sketch.has_permission(current_user, 'write'):
             return abort(
-                HTTP_STATUS_CODE_BAD_REQUEST, 'Unable to proceed.')
+                HTTP_STATUS_CODE_FORBIDDEN,
+                'User does not have write permission on the sketch.')
+
+        form = request.json
+        if not form:
+            form = request.data
+
+        if not form:
+            return abort(
+                HTTP_STATUS_CODE_FORBIDDEN,
+                'Unable to remove an attribute from a '
+                'sketch without any data submitted.')
+
+        for check in ['name', 'ontology']:
+            error_message = self._validate_form_entry(form, check)
+            if error_message:
+                return abort(
+                    HTTP_STATUS_CODE_BAD_REQUEST, error_message)
+
+        name = form.get('name')
+        ontology = form.get('ontology', 'text')
 
         for attribute in sketch.attributes:
             if attribute.name != name:
                 continue
+            if attribute.ontology != ontology:
+                continue
+
             for value in attribute.values:
                 attribute.values.remove(value)
             sketch.attributes.remove(attribute)

--- a/timesketch/api/v1/resources/attribute.py
+++ b/timesketch/api/v1/resources/attribute.py
@@ -151,8 +151,7 @@ class AttributeResource(resources.ResourceMixin, Resource):
                 break
 
         if update_attribute:
-            attribute_values = AttributeValue.query.filter_by(
-                attribute=attribute).delete()
+            _ = AttributeValue.query.filter_by(attribute=attribute).delete()
         else:
             attribute = Attribute(
                 user=current_user,

--- a/timesketch/api/v1/utils.py
+++ b/timesketch/api/v1/utils.py
@@ -47,8 +47,8 @@ def bad_request(message):
 
 
 def get_sketch_attributes(sketch):
-    """Returns a list of attributes of a sketch."""
-    attributes = []
+    """Returns a dict with all attributes of a sketch."""
+    attributes = {}
     ontology_def = ontology.ONTOLOGY
     for attribute in sketch.attributes:
         if attribute.sketch_id != sketch.id:
@@ -71,11 +71,9 @@ def get_sketch_attributes(sketch):
             attribute_values.append(value)
 
         if len(attribute_values) == 1:
-            attributes.append(
-                (name, attribute_values[0], ontology_string))
+            attributes[name] = (attribute_values[0], ontology_string)
         else:
-            attributes.append(
-                (name, attribute_values, ontology_string))
+            attributes[name] = (attribute_values, ontology_string)
     return attributes
 
 

--- a/timesketch/api/v1/utils.py
+++ b/timesketch/api/v1/utils.py
@@ -70,10 +70,14 @@ def get_sketch_attributes(sketch):
 
             attribute_values.append(value)
 
+        values = attribute_values
         if len(attribute_values) == 1:
-            attributes[name] = (attribute_values[0], ontology_string)
-        else:
-            attributes[name] = (attribute_values, ontology_string)
+            values = attribute_values[0]
+
+        attributes[name] = {
+          'value': values,
+          'ontology': ontology_string,
+        }
     return attributes
 
 

--- a/timesketch/version.py
+++ b/timesketch/version.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Version information for Timesketch."""
 
-__version__ = '20210526'
+__version__ = '20210527'
 
 
 def get_version():


### PR DESCRIPTION
This PR changes few ways on how sketch attributes are handled:

1. Attributes are returned as a dict as an opposed to a list of tuples
2. Attributes can be modified, instead of just added/deleted
3. REST API now uses HTTP methods to determine whether you are adding/modifying or deleting, vs. relying on a `action` variable