### PR TITLE
UI: Expose sketch attributes

### DIFF
--- a/timesketch/frontend/src/components/AppNavbarSecondary.vue
+++ b/timesketch/frontend/src/components/AppNavbarSecondary.vue
@@ -64,6 +64,12 @@ limitations under the License.
                   <span>Stories</span>
                 </router-link>
               </li>
+              <li v-bind:class="{'is-active': currentPage === 'attributes'}">
+                <router-link :to="{ name: 'Attributes' }">
+                  <span class="icon is-small"><i class="fas fa-table" aria-hidden="true"></i></span>
+                  <span>Attributes <b-tag type="is-light">{{sketchMeta.attributes.length}}</b-tag></span>
+                </router-link>
+              </li>
             </ul>
           </div>
         </div>
@@ -81,7 +87,12 @@ limitations under the License.
 <script>
 export default {
   name: 'ts-navbar-secondary',
-  props: ['currentAppContext', 'currentPage']
+  props: ['currentAppContext', 'currentPage', 'sketchMeta'],
+  methods: {
+    hasAttributeOntology: function (ontologyName) {
+      return this.sketchMeta.attributes.filter(item => item[2] === ontologyName).length > 0
+    }
+  }
 }
 </script>
 

--- a/timesketch/frontend/src/components/AppNavbarSecondary.vue
+++ b/timesketch/frontend/src/components/AppNavbarSecondary.vue
@@ -64,10 +64,10 @@ limitations under the License.
                   <span>Stories</span>
                 </router-link>
               </li>
-              <li v-bind:class="{'is-active': currentPage === 'attributes'}">
+              <li v-if="meta" v-bind:class="{'is-active': currentPage === 'attributes'}">
                 <router-link :to="{ name: 'Attributes' }">
                   <span class="icon is-small"><i class="fas fa-table" aria-hidden="true"></i></span>
-                  <span>Attributes <b-tag type="is-light">{{sketchMeta.attributes.length}}</b-tag></span>
+                  <span>Attributes <b-tag type="is-light">{{meta.attributes.length}}</b-tag></span>
                 </router-link>
               </li>
             </ul>
@@ -87,10 +87,18 @@ limitations under the License.
 <script>
 export default {
   name: 'ts-navbar-secondary',
-  props: ['currentAppContext', 'currentPage', 'sketchMeta'],
+  props: {
+    currentAppContext: String,
+    currentPage: String
+  },
   methods: {
     hasAttributeOntology: function (ontologyName) {
-      return this.sketchMeta.attributes.filter(item => item[2] === ontologyName).length > 0
+      return this.meta.attributes.filter(item => item.ontology === ontologyName).length > 0
+    }
+  },
+  computed: {
+    meta () {
+      return this.$store.state.meta
     }
   }
 }

--- a/timesketch/frontend/src/router.js
+++ b/timesketch/frontend/src/router.js
@@ -29,6 +29,7 @@ import Timelines from './views/Timelines'
 import Story from './views/Story'
 import StoryOverview from './views/StoryOverview'
 import StoryContent from './views/StoryContent'
+import Attributes from './views/Attributes'
 import SavedSearches from './views/SavedSearches'
 
 Vue.use(VueRouter)
@@ -106,6 +107,12 @@ const routes = [
         path: 'timelines',
         name: 'Timelines',
         component: Timelines,
+        props: true
+      },
+      {
+        path: 'attributes',
+        name: 'Attributes',
+        component: Attributes,
         props: true
       },
       {

--- a/timesketch/frontend/src/utils/RestApiClient.js
+++ b/timesketch/frontend/src/utils/RestApiClient.js
@@ -101,6 +101,18 @@ export default {
     }
     return RestApiBlobClient.post('/sketches/' + sketchId + '/archive/', formData)
   },
+  getSketchAttributes (sketchId) {
+    return RestApiClient.get('/sketches/' + sketchId + '/attribute/')
+  },
+  addSketchAttribute (sketchId, name, value, ontology) {
+    let attribute = {
+      name: name,
+      values: [value],
+      ontology: ontology,
+      action: 'post'
+    }
+    return RestApiClient.post('/sketches/' + sketchId + '/attribute/', attribute)
+  },
   getSketchTimeline (sketchId, timelineId) {
     return RestApiClient.get('/sketches/' + sketchId + '/timelines/' + timelineId + '/')
   },

--- a/timesketch/frontend/src/views/Attributes.vue
+++ b/timesketch/frontend/src/views/Attributes.vue
@@ -1,0 +1,93 @@
+<!--
+Copyright 2021 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<template>
+  <div>
+    <ts-navbar-main>
+      <template v-slot:left>
+        {{ sketch.name }}
+      </template>
+    </ts-navbar-main>
+
+    <ts-navbar-secondary
+      currentAppContext="sketch"
+      :sketchMeta="meta"
+      currentPage="attributes"
+    ></ts-navbar-secondary>
+
+    <!-- Timelines to add -->
+    <section v-if="meta.permissions.write" class="section">
+      <div class="container is-fluid">
+        <div class="card" style="min-height:160px;">
+          <header class="card-header">
+            <p class="card-header-title">Attribute list</p>
+          </header>
+          <div class="card-content">
+            <b-table :data="sketchAttributes" default-sort="name">
+              <b-table-column field="name" label="Attribute name" v-slot="data">
+                {{ data.row.name }}
+              </b-table-column>
+              <b-table-column field="ontology" label="Ontology" v-slot="data">
+                <code>{{ data.row.ontology }}</code>
+              </b-table-column>
+              <b-table-column field="value" label="Value" v-slot="data">
+                <pre v-if="typeof data.row.value === 'object'">{{
+                  data.row.value
+                }}</pre>
+                <span v-else>{{ data.row.value }}</span>
+              </b-table-column>
+            </b-table>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script>
+
+export default {
+  props: ["sketchId"],
+  components: {},
+  data() {
+    return {};
+  },
+  computed: {
+    sketch() {
+      return this.$store.state.sketch;
+    },
+    meta() {
+      return this.$store.state.meta;
+    },
+    timelines() {
+      let t = [];
+      this.sketch.timelines.forEach(timeline => {
+        t.push({
+          id: timeline.id,
+          name: timeline.name
+        });
+      });
+      return t;
+    },
+    sketchAttributes() {
+      return this.$store.state.meta.attributes.map(item => ({
+        name: item[0],
+        value: item[1],
+        ontology: item[2]
+      }));
+    }
+  }
+};
+</script>

--- a/timesketch/frontend/src/views/Attributes.vue
+++ b/timesketch/frontend/src/views/Attributes.vue
@@ -23,7 +23,6 @@ limitations under the License.
 
     <ts-navbar-secondary
       currentAppContext="sketch"
-      :sketchMeta="meta"
       currentPage="attributes"
     ></ts-navbar-secondary>
 

--- a/timesketch/frontend/src/views/Attributes.vue
+++ b/timesketch/frontend/src/views/Attributes.vue
@@ -55,7 +55,6 @@ limitations under the License.
 </template>
 
 <script>
-import ApiClient from '../utils/RestApiClient'
 
 export default {
   components: {},

--- a/timesketch/frontend/src/views/Attributes.vue
+++ b/timesketch/frontend/src/views/Attributes.vue
@@ -26,7 +26,7 @@ limitations under the License.
       currentPage="attributes"
     ></ts-navbar-secondary>
 
-    <section v-if="meta.permissions.read" class="section">
+    <section class="section">
       <div class="container is-fluid">
         <div class="card" style="min-height:160px;">
           <header class="card-header">

--- a/timesketch/frontend/src/views/Attributes.vue
+++ b/timesketch/frontend/src/views/Attributes.vue
@@ -70,7 +70,6 @@ export default {
       return this.$store.state.meta
     },
     sketchAttributes () {
-      // return this.$store.state.meta.attributes
       return this.$store.state.meta.attributes.map(item => ({
         name: item[0],
         value: item[1],

--- a/timesketch/frontend/src/views/Attributes.vue
+++ b/timesketch/frontend/src/views/Attributes.vue
@@ -70,11 +70,15 @@ export default {
       return this.$store.state.meta
     },
     sketchAttributes () {
-      return this.$store.state.meta.attributes.map(item => ({
-        name: item[0],
-        value: item[1],
-        ontology: item[2]
-      }))
+      let attributes = []
+      for (let item in this.$store.state.meta.attributes) {
+        attributes.push({
+          name: item,
+          ontology: this.$store.state.meta.attributes[item].ontology,
+          value: this.$store.state.meta.attributes[item].value
+        })
+      }
+      return attributes
     }
   }
 }

--- a/timesketch/frontend/src/views/Attributes.vue
+++ b/timesketch/frontend/src/views/Attributes.vue
@@ -58,7 +58,6 @@ limitations under the License.
 <script>
 
 export default {
-  props: ["sketchId"],
   components: {},
   data() {
     return {};

--- a/timesketch/frontend/src/views/Attributes.vue
+++ b/timesketch/frontend/src/views/Attributes.vue
@@ -56,26 +56,28 @@ limitations under the License.
 </template>
 
 <script>
+import ApiClient from '../utils/RestApiClient'
 
 export default {
   components: {},
-  data() {
-    return {};
+  data () {
+    return {}
   },
   computed: {
-    sketch() {
-      return this.$store.state.sketch;
+    sketch () {
+      return this.$store.state.sketch
     },
-    meta() {
-      return this.$store.state.meta;
+    meta () {
+      return this.$store.state.meta
     },
-    sketchAttributes() {
+    sketchAttributes () {
+      // return this.$store.state.meta.attributes
       return this.$store.state.meta.attributes.map(item => ({
         name: item[0],
         value: item[1],
         ontology: item[2]
-      }));
+      }))
     }
   }
-};
+}
 </script>

--- a/timesketch/frontend/src/views/Attributes.vue
+++ b/timesketch/frontend/src/views/Attributes.vue
@@ -27,8 +27,7 @@ limitations under the License.
       currentPage="attributes"
     ></ts-navbar-secondary>
 
-    <!-- Timelines to add -->
-    <section v-if="meta.permissions.write" class="section">
+    <section v-if="meta.permissions.read" class="section">
       <div class="container is-fluid">
         <div class="card" style="min-height:160px;">
           <header class="card-header">
@@ -70,16 +69,6 @@ export default {
     },
     meta() {
       return this.$store.state.meta;
-    },
-    timelines() {
-      let t = [];
-      this.sketch.timelines.forEach(timeline => {
-        t.push({
-          id: timeline.id,
-          name: timeline.name
-        });
-      });
-      return t;
     },
     sketchAttributes() {
       return this.$store.state.meta.attributes.map(item => ({


### PR DESCRIPTION
WIP - waiting on https://github.com/google/timesketch/pull/1792 to be merged

-----

+ What existing problem does this PR solve?

Sketch attributes are not visible / discoverable in the web UI.

+ What new feature is being introduced with this PR?

View a sketch's attributes in table form.

+ Overview of changes to existing functions if required.

This PR adds a Vue component to display attributes from a sketch. The navbar is adjusted to show the total number of attributes next to the corresponding tab, through a `sketchMeta` prop.

This PR also adds two functions to the `RestApi` client, to get and add attributes.

**Checks**

- [ ] All tests succeed.
- [ ] Unit tests added.
- [ ] e2e tests added.
- [ ] Documentation updated.

**Screenshot**

![image](https://user-images.githubusercontent.com/1257972/119834556-5ad8e080-bf00-11eb-882d-5a4fcca7714e.png)
