### PR TITLE
Add additional regexes to extract IP addresses from sshd messages

### DIFF
--- a/data/features.yaml
+++ b/data/features.yaml
@@ -124,9 +124,23 @@ ssh_client_ipv4_addresses:
         re: '^\[sshd\] \[\d+\]: Connection from ((?:[0-9]{1,3}\.){3}[0-9]{1,3}) 
           port \d+ on (?:[0-9]{1,3}\.){3}[0-9]{1,3} port \d+(?: rdomain ? .*)?$'
 
+ssh_client_ipv4_addresses_2:
+        query_string: 'reporter:"sshd"'
+        attribute: 'message'
+        store_as: 'client_ip'
+        re: '\[sshd, pid: \d+\] Connection [a-z]+ by 
+          ((?:[0-9]{1,3}\.){3}[0-9]{1,3}) port \d+'
+
 ssh_host_ipv4_addresses:
         query_string: 'reporter:"sshd"'
         attribute: 'message'
         store_as: 'host_ip'
         re: '^\[sshd\] \[\d+\]: Connection from (?:[0-9]{1,3}\.){3}[0-9]{1,3} 
           port \d+ on ((?:[0-9]{1,3}\.){3}[0-9]{1,3}) port \d+(?: rdomain ? .*)?$'
+
+ssh_client_password_ipv4_addresses:
+        query_string: 'reporter:"sshd"'
+        attribute: 'message'
+        store_as: 'client_ip'
+        re: '^\[sshd, pid: \d+\] (Accepted|Failed) password for \w+ 
+          from ((?:[0-9]{1,3}\.){3}[0-9]{1,3}) port \d+'


### PR DESCRIPTION
The following types of sshd messages are not being picked up by the feature extraction as is (and also not by the ssh_sessionizer analyzer, but there will be another PR for that one):

[sshd, pid: 19774] Accepted password for admin from 1.1.1.1 port 62867 ssh2
[sshd, pid: 19774] Failed password for admin from 1.1.1.1 port 62867 ssh2
[sshd, pid: 23794] Connection reset by 1.1.1.1 port 10854 [preauth]
[sshd, pid: 27039] Connection closed by 1.1.1.1 port 55752 [preauth]
