### PR TITLE
Check for history node

### DIFF
--- a/timesketch/api/v1/resources/explore.py
+++ b/timesketch/api/v1/resources/explore.py
@@ -501,7 +501,7 @@ class SearchHistoryTreeResource(resources.ResourceMixin, Resource):
             abort(HTTP_STATUS_CODE_NOT_FOUND, 'No sketch found with this ID.')
 
         tree = {}
-        
+
         try:
             root_node = SearchHistory.query.filter_by(
                 user=current_user, sketch=sketch).order_by(

--- a/timesketch/api/v1/resources/explore.py
+++ b/timesketch/api/v1/resources/explore.py
@@ -501,9 +501,14 @@ class SearchHistoryTreeResource(resources.ResourceMixin, Resource):
             abort(HTTP_STATUS_CODE_NOT_FOUND, 'No sketch found with this ID.')
 
         tree = {}
-        root_node = SearchHistory.query.filter_by(
-            user=current_user, sketch=sketch).order_by(
-                SearchHistory.id.desc()).limit(self.HISTORY_NODE_LIMIT)[-1]
+        
+        try:
+            root_node = SearchHistory.query.filter_by(
+                user=current_user, sketch=sketch).order_by(
+                    SearchHistory.id.desc()).limit(
+                        self.HISTORY_NODE_LIMIT)[-1]
+        except IndexError:
+            root_node = None
 
         last_node = SearchHistory.query.filter_by(
             user=current_user, sketch=sketch).order_by(


### PR DESCRIPTION
Make sure there is a root node for search history, otherwise return none to get an empty state.

**Fixes issues**
#1846 
