### PR TITLE
Added ability to modifiy elasticsearch client timeout value

### DIFF
--- a/data/timesketch.conf
+++ b/data/timesketch.conf
@@ -32,6 +32,7 @@ ELASTIC_USER = None
 ELASTIC_PASSWORD = None
 ELASTIC_SSL = False
 ELASTIC_VERIFY_CERTS = True
+ELASTIC_TIMEOUT = 10
 
 # Define what labels should be defined that make it so that a sketch and
 # timelines will not be deleted. This can be used to add a list of different

--- a/timesketch/lib/datastores/elastic.py
+++ b/timesketch/lib/datastores/elastic.py
@@ -116,6 +116,7 @@ class ElasticsearchDataStore(object):
         self.password = current_app.config.get('ELASTIC_PASSWORD', 'pass')
         self.ssl = current_app.config.get('ELASTIC_SSL', False)
         self.verify = current_app.config.get('ELASTIC_VERIFY_CERTS', True)
+        self.timeout = current_app.config.get('ELASTIC_TIMEOUT')
 
         parameters = {}
         if self.ssl:
@@ -124,6 +125,9 @@ class ElasticsearchDataStore(object):
 
         if self.user and self.password:
             parameters['http_auth'] = (self.user, self.password)
+        
+        if self.timeout:
+            parameters['timeout'] = self.timeout
 
         self.client = Elasticsearch(
             [{'host': host, 'port': port}], **parameters)


### PR DESCRIPTION
The Default time out of the ElasticSearch client is 10 seconds this pull request allow configuring this timeout value.
Closes #1671 

+ What existing problem does this PR solve?
elasticsearch read timeout error
+ What new feature is being introduced with this PR?
the ability to control elasticsearch timeout value
+ Overview of changes to existing functions if required.

**Checks**

- [ ] All tests succeed.
- [ ] Unit tests added.
- [ ] e2e tests added.
- [ ] Documentation updated.
