### PR TITLE
Remove capitalize from event list

### DIFF
--- a/timesketch/frontend/src/components/Explore/EventList.vue
+++ b/timesketch/frontend/src/components/Explore/EventList.vue
@@ -22,7 +22,7 @@ limitations under the License.
           <input type="checkbox" v-on:click="toggleSelectAll" />
         </span>
       </th>
-      <th v-for="(field, index) in selectedFields" :key="index">{{ field.field | capitalize }}</th>
+      <th v-for="(field, index) in selectedFields" :key="index">{{ field.field }}</th>
       <th width="150">Timeline name</th>
     </thead>
     <ts-sketch-explore-event-list-row


### PR DESCRIPTION
Remove capitalize from the column names as it might confuse how to write search queries.

https://github.com/google/timesketch/issues/1427

**Closing issues**
closes #1427
