### PR TITLE
Make access to intelligence attributes safer

### DIFF
--- a/timesketch/frontend/src/components/Common/TsDynamicTable.vue
+++ b/timesketch/frontend/src/components/Common/TsDynamicTable.vue
@@ -82,7 +82,7 @@ limitations under the License.
               </b-table-column>
             </b-table>
           </div>
-          <div v-else>Empty table</div>
+          <div class="card-content" v-else>Empty table</div>
         </div>
       </div>
     </section>

--- a/timesketch/frontend/src/components/Common/TsDynamicTable.vue
+++ b/timesketch/frontend/src/components/Common/TsDynamicTable.vue
@@ -76,7 +76,7 @@ limitations under the License.
                   class="icon is-small"
                   style="cursor:pointer;"
                   title="Apply 'Exclude' filter"
-                  v-on:click="deleteCallback(props.row)"
+                  @click="$emit('table-delete', props.row)"
                   ><i class="fas fa-trash"></i
                 ></span>
               </b-table-column>
@@ -93,7 +93,7 @@ limitations under the License.
 export default {
   name: 'TsDynamicTable',
   components: {},
-  props: ['section', 'data', 'deleteCallback'],
+  props: ['section', 'data'],
   computed: {
     sketch() {
       return this.$store.state.sketch

--- a/timesketch/frontend/src/views/Intelligence.vue
+++ b/timesketch/frontend/src/views/Intelligence.vue
@@ -27,7 +27,7 @@ limitations under the License.
         v-if="localIntelligence.data.length > 0"
         :data="localIntelligence.data"
         :section="localIntelligenceMeta"
-        :deleteCallback="localIntelligenceDeleteCallback"
+        @table-delete="deleteIoc"
       >
       </ts-dynamic-table>
       <div v-else class="card-content">
@@ -91,7 +91,7 @@ export default {
     }
   },
   methods: {
-    localIntelligenceDeleteCallback(ioc) {
+    deleteIoc(ioc) {
       const data = this.localIntelligence.data.filter(i => i.ioc !== ioc.ioc)
       ApiClient.addSketchAttribute(this.sketch.id, 'intelligence_local', { data: data }, 'intelligence').then(() => {
         this.localIntelligence.data = data

--- a/timesketch/frontend/src/views/Intelligence.vue
+++ b/timesketch/frontend/src/views/Intelligence.vue
@@ -59,6 +59,7 @@ limitations under the License.
 
 <script>
 import ApiClient from '../utils/RestApiClient'
+import _ from 'lodash'
 
 import TsDynamicTable from '../components/Common/TsDynamicTable'
 
@@ -111,10 +112,16 @@ export default {
       return this.$store.state.meta
     },
     externalIntelligence() {
-      return this.meta.attributes.intelligence.value || { data: {}, meta: {} }
+      if (_.isEmpty(this.meta.attributes.intelligence.value)) {
+        return { data: {}, meta: {} }
+      }
+      return this.meta.attributes.intelligence.value
     },
     localIntelligence() {
-      return this.meta.attributes.intelligence_local.value || { data: [] }
+      if (_.isEmpty(this.meta.attributes.intelligence_local.value)) {
+        return { data: [] }
+      }
+      return this.meta.attributes.intelligence_local.value
     },
   },
   mounted() {


### PR DESCRIPTION
Fixes #1883

* `TsDynamicTable` now emits events instead of calling a callback passed as a prop.