### PR TITLE
Fixes for read_and_validate_csv

### DIFF
--- a/timesketch/lib/utils.py
+++ b/timesketch/lib/utils.py
@@ -168,7 +168,7 @@ def read_and_validate_csv(
                 chunk['datetime'] = pandas.to_datetime(
                     chunk['datetime'], errors='coerce')
                 num_chunk_rows = chunk.shape[0]
-                chunk.dropna(inplace=True)
+                chunk.dropna(subset=['datetime'], inplace=True)
                 if len(chunk) < num_chunk_rows:
                     warning_string = (
                         '{0} rows dropped from Rows {1} to {2} due to invalid '

--- a/timesketch/lib/utils.py
+++ b/timesketch/lib/utils.py
@@ -165,29 +165,30 @@ def read_and_validate_csv(
 
             # Normalize datetime to ISO 8601 format if it's not the case.
             try:
+                # Lines with unrecognized datetime format will result in "NaT"
+                # (not available) as its value and the event row will be
+                # dropped in the next line
                 chunk['datetime'] = pandas.to_datetime(
                     chunk['datetime'], errors='coerce')
                 num_chunk_rows = chunk.shape[0]
                 chunk.dropna(subset=['datetime'], inplace=True)
                 if len(chunk) < num_chunk_rows:
-                    warning_string = (
+                    logger.warning(
                         '{0} rows dropped from Rows {1} to {2} due to invalid '
-                        'datetime values')
-                    logger.warning(warning_string.format(
-                        num_chunk_rows - len(chunk),
-                        idx * reader.chunksize,
-                        idx * reader.chunksize + num_chunk_rows))
+                        'datetime values'.format(
+                            num_chunk_rows - len(chunk),
+                            idx * reader.chunksize,
+                            idx * reader.chunksize + num_chunk_rows))
                 chunk['timestamp'] = chunk['datetime'].dt.strftime(
                     '%s%f').astype(int)
                 chunk['datetime'] = chunk['datetime'].apply(
                     Timestamp.isoformat).astype(str)
             except ValueError:
-                warning_string = (
+                logger.warning(
                     'Rows {0} to {1} skipped due to malformed '
-                    'datetime values ')
-                logger.warning(warning_string.format(
-                    idx * reader.chunksize,
-                    idx * reader.chunksize + chunk.shape[0]))
+                    'datetime values '.format(
+                        idx * reader.chunksize,
+                        idx * reader.chunksize + chunk.shape[0]))
                 continue
             if 'tag' in chunk:
                 chunk['tag'] = chunk['tag'].apply(_parse_tag_field)

--- a/timesketch/lib/utils.py
+++ b/timesketch/lib/utils.py
@@ -176,7 +176,8 @@ def read_and_validate_csv(
                     'Rows {0} to {1} skipped due to malformed '
                     'datetime values ')
                 logger.warning(warning_string.format(
-                    idx * reader.chunksize, chunk.shape[0]))
+                    idx * reader.chunksize, 
+                    idx * reader.chunksize + chunk.shape[0]))
                 continue
             if 'tag' in chunk:
                 chunk['tag'] = chunk['tag'].apply(_parse_tag_field)

--- a/timesketch/lib/utils.py
+++ b/timesketch/lib/utils.py
@@ -165,8 +165,14 @@ def read_and_validate_csv(
 
             # Normalize datetime to ISO 8601 format if it's not the case.
             try:
-                chunk['datetime'] = pandas.to_datetime(chunk['datetime'])
-
+                chunk['datetime'] = pandas.to_datetime(
+                    chunk['datetime'], errors='coerce')
+                chunk.dropna(inplace=True)
+                if len(chunk) < DEFAULT_CHUNK_SIZE:
+                    warning_string = (
+                        '{0} rows dropped due to invalid datetime values')
+                    logger.warning(warning_string.format(
+                        DEFAULT_CHUNK_SIZE - len(chunk)))
                 chunk['timestamp'] = chunk['datetime'].dt.strftime(
                     '%s%f').astype(int)
                 chunk['datetime'] = chunk['datetime'].apply(
@@ -176,7 +182,7 @@ def read_and_validate_csv(
                     'Rows {0} to {1} skipped due to malformed '
                     'datetime values ')
                 logger.warning(warning_string.format(
-                    idx * reader.chunksize, 
+                    idx * reader.chunksize,
                     idx * reader.chunksize + chunk.shape[0]))
                 continue
             if 'tag' in chunk:

--- a/timesketch/lib/utils.py
+++ b/timesketch/lib/utils.py
@@ -167,12 +167,16 @@ def read_and_validate_csv(
             try:
                 chunk['datetime'] = pandas.to_datetime(
                     chunk['datetime'], errors='coerce')
+                num_chunk_rows = chunk.shape[0]
                 chunk.dropna(inplace=True)
-                if len(chunk) < DEFAULT_CHUNK_SIZE:
+                if len(chunk) < num_chunk_rows:
                     warning_string = (
-                        '{0} rows dropped due to invalid datetime values')
+                        '{0} rows dropped from Rows {1} to {2} due to invalid '
+                        'datetime values')
                     logger.warning(warning_string.format(
-                        DEFAULT_CHUNK_SIZE - len(chunk)))
+                        num_chunk_rows - len(chunk),
+                        idx * reader.chunksize,
+                        idx * reader.chunksize + num_chunk_rows))
                 chunk['timestamp'] = chunk['datetime'].dt.strftime(
                     '%s%f').astype(int)
                 chunk['datetime'] = chunk['datetime'].apply(


### PR DESCRIPTION
For the read_and_validate_csv() function in timesketch/lib/utils.py:

* Fixes logger warning for malformed datetime values

From
```
[2021-08-15 12:05:26,978] timesketch.utils/WARNING Rows 0 to 10000 skipped due to malformed datetime values 
[2021-08-15 12:28:27,790] timesketch.utils/WARNING Rows 850000 to 10000 skipped due to malformed datetime values
[2021-08-15 12:55:31,045] timesketch.utils/WARNING Rows 1840000 to 10000 skipped due to malformed datetime values 
[2021-08-15 13:06:30,256] timesketch.utils/WARNING Rows 2240000 to 260 skipped due to malformed datetime values 
```
to
```
[2021-08-15 01:27:28,188] timesketch.utils/WARNING Rows 0 to 10000 skipped due to malformed datetime values 
[2021-08-15 01:48:48,038] timesketch.utils/WARNING Rows 850000 to 860000 skipped due to malformed datetime values
[2021-08-15 02:12:43,431] timesketch.utils/WARNING Rows 1840000 to 1850000 skipped due to malformed datetime values 
[2021-08-15 02:22:14,163] timesketch.utils/WARNING Rows 2240000 to 2240260 skipped due to malformed datetime values 
```

* Adds code to drop rows containing invalid datetime values in chunk (instead of skipping entire chunk)
```
[2021-08-16 12:44:52,772] timesketch.utils/WARNING 1420 rows dropped from Rows 0 to 10000 due to invalid datetime values
[2021-08-16 13:08:11,732] timesketch.utils/WARNING 2 rows dropped from Rows 850000 to 860000 due to invalid datetime values
[2021-08-16 14:07:24,190] timesketch.utils/WARNING 2 rows dropped from Rows 1840000 to 1850000 due to invalid datetime values
[2021-08-16 14:17:39,035] timesketch.utils/WARNING 4 rows dropped from Rows 2240000 to 2240260 due to invalid datetime values
```

**Checks**

- [ ] All tests succeed.
- [ ] Unit tests added.
- [ ] e2e tests added.
- [ ] Documentation updated.

**Closing issues**
#1884 
