### PR TITLE
Fix: Sigma analyzer creates saved search and story even with 0 results

### DIFF
--- a/timesketch/lib/analyzers/sigma_tagger.py
+++ b/timesketch/lib/analyzers/sigma_tagger.py
@@ -110,7 +110,7 @@ class SigmaPlugin(interface.BaseAnalyzer):
         total_tagged_events = sum(tags_applied.values())
         output_strings.append('Applied {0:d} tags'.format(total_tagged_events))
 
-        if sigma_rule_counter > 0:
+        if total_tagged_events > 0:
             self.add_sigma_match_view(sigma_rule_counter)
 
         if len(problem_strings) > 0:


### PR DESCRIPTION
Root cause: Was using the wrong variable to check. It did check how many sigma rules are there instead of the number of events tagged.

closes #1907