### PR TITLE
fix(sigma-util): do not fail on bad rules

### DIFF
--- a/timesketch/lib/sigma_util.py
+++ b/timesketch/lib/sigma_util.py
@@ -213,13 +213,13 @@ def get_sigma_rule(filepath, sigma_config=None):
             logger.error(
                 'Error generating rule in file {0:s}: {1!s}'
                 .format(abs_path, exception))
-            raise
+            return None
 
         except sigma_exceptions.SigmaParseError as exception:
             logger.error(
                 'Sigma parsing error generating rule in file {0:s}: {1!s}'
                 .format(abs_path, exception))
-            raise
+            return None
 
         except yaml.parser.ParserError as exception:
             logger.error(


### PR DESCRIPTION
Fix an issue with Sigma integration.

/api/v1/sigma is currently failing with Internal Server Error if a problematic rule exists in the rules directory. This is especially problematic because the official Sigma repository contains problematic rules.

This fix prevents the Sigma integration from failing while still logging problematic rules.

**Checks**

- [ ] All tests succeed.
- [ ] Unit tests added.
- [ ] e2e tests added.
- [ ] Documentation updated.

