### PR TITLE
Microseconds since epoch for JSONL input data

### DIFF
--- a/timesketch/lib/utils.py
+++ b/timesketch/lib/utils.py
@@ -258,7 +258,8 @@ def read_and_validate_jsonl(file_handle):
                 linedict['datetime'] = dt.isoformat()
             if 'timestamp' not in ld_keys and 'datetime' in ld_keys:
                 try:
-                    linedict['timestamp'] = parser.parse(linedict['datetime'])
+                    linedict['timestamp'] = int(parser.parse(
+                        linedict['datetime']).timestamp() * 1000000)
                 except parser.ParserError:
                     logger.error(
                         'Unable to parse timestamp, skipping line '


### PR DESCRIPTION
This PR fixes the case where the input data (when importing) is jsonl, and the `timestamp` field is missing. There was a bug where the calculated timestamp was in datetime format instead of microseconds since the epoch.

**Closing issues**
Closes #1869
