### PR TITLE
Update plaso.mappings

### DIFF
--- a/data/plaso.mappings
+++ b/data/plaso.mappings
@@ -79,7 +79,7 @@
       "type": "text",
       "fields": {"keyword": {"type": "keyword"}}
     },
-    "http_response_bytes" {
+    "http_response_bytes": {
       "type": "text",
       "fields": {"keyword": {"type": "keyword"}}
     }

--- a/data/plaso.mappings
+++ b/data/plaso.mappings
@@ -78,6 +78,10 @@
     "version": {
       "type": "text",
       "fields": {"keyword": {"type": "keyword"}}
+    },
+    "http_response_bytes" {
+      "type": "text",
+      "fields": {"keyword": {"type": "keyword"}}
     }
   }
 }


### PR DESCRIPTION
the attribute from the apache log plaso parser sometimes set the `http_response_bytes` to `-` and this doesn't work for the default mapping of `long`. This PR fixes that.

Closes #1935
