### PR TITLE
Properly split file extension

### DIFF
--- a/timesketch/frontend/src/components/Common/UploadForm.vue
+++ b/timesketch/frontend/src/components/Common/UploadForm.vue
@@ -123,7 +123,7 @@ export default {
     },
     setFileName: function(fileList) {
       let fileName = fileList[0].name
-      let fileExtension = fileName.split('.')[1]
+      let fileExtension = fileName.split('.')[-1]
       this.form.file = fileList[0]
       this.form.name = fileName
         .split('.')


### PR DESCRIPTION
TLDR: This PR fixes a small bug in the way that the fileExtension is grabbed. Current implementation will not grab the real file extension if there are multiple '.' in the filename. Since this is a minor bug fix I didn't creatte a problem but if you'd like I can still do thatt.

Error in code on line 126 where the file extension is grabbed. Currently splitting and grabbing [1] will only grab you the first item after the file name. This may not always be the extension. Plaso currently outputs the .plaso file as filename.something.something2.somethin3.plaso. To properly grab the file extension and prevent issues when uploading due to unknown file extension it should be grabbing the last item in the split [-1] which would always be the real extension.

IE:
let fileExtension = fileName.split('.')[-1]

**Checks**

- [ ] All tests succeed.
- [ ] Unit tests added.
- [ ] e2e tests added.
- [ ] Documentation updated.

**Closing issues**

closes #1951