### PR TITLE
More efficient IOC searching

### DIFF
--- a/timesketch/frontend/src/components/Common/TsIOCMenu.vue
+++ b/timesketch/frontend/src/components/Common/TsIOCMenu.vue
@@ -65,10 +65,12 @@ export default {
   data() {
     return {
       IOCTypes: [
+        { regex: /^(\/[\S]+)+$/, type: 'fs_path' },
+        { regex: /^([-\w]+\.)+[a-z]{2,}$/, type: 'hostname' },
         { regex: /^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/g, type: 'ip' },
-        { regex: /^[0-9a-f]{64}$/gi, type: 'hash_sha256' },
-        { regex: /^[0-9a-f]{40}$/gi, type: 'hash_sha1' },
-        { regex: /^[0-9a-f]{32}$/gi, type: 'hash_md5' },
+        { regex: /^[0-9a-f]{64}$/i, type: 'hash_sha256' },
+        { regex: /^[0-9a-f]{40}$/i, type: 'hash_sha1' },
+        { regex: /^[0-9a-f]{32}$/i, type: 'hash_md5' },
         // Match any "other" selection
         { regex: /./g, type: 'other' },
       ],

--- a/timesketch/frontend/src/components/Common/TsIOCMenu.vue
+++ b/timesketch/frontend/src/components/Common/TsIOCMenu.vue
@@ -65,8 +65,8 @@ export default {
   data() {
     return {
       IOCTypes: [
-        { regex: /^(\/[\S]+)+$/, type: 'fs_path' },
-        { regex: /^([-\w]+\.)+[a-z]{2,}$/, type: 'hostname' },
+        { regex: /^(\/[\S]+)+$/i, type: 'fs_path' },
+        { regex: /^([-\w]+\.)+[a-z]{2,}$/i, type: 'hostname' },
         { regex: /^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/g, type: 'ip' },
         { regex: /^[0-9a-f]{64}$/i, type: 'hash_sha256' },
         { regex: /^[0-9a-f]{40}$/i, type: 'hash_sha1' },

--- a/timesketch/frontend/src/components/Explore/EventListRowDetail.vue
+++ b/timesketch/frontend/src/components/Explore/EventListRowDetail.vue
@@ -86,8 +86,8 @@ export default {
       TsIOCMenu,
       regexSelection: '',
       regexes: [
-        { type: 'fs_path', regex: /(\/[\S]+)+/, match_fields: 'message' },
-        { type: 'hostname', regex: /([-\w]+\.)+[a-z]{2,}/, match_fields: 'hostname' },
+        { type: 'fs_path', regex: /(\/[\S]+)+/i, match_fields: 'message' },
+        { type: 'hostname', regex: /([-\w]+\.)+[a-z]{2,}/i, match_fields: 'hostname' },
         { type: 'ip', regex: /((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/g, match_fields: 'message' },
         { type: 'hash_md5', regex: /[0-9a-f]{32}/i, match_fields: 'message' },
         { type: 'hash_sha1', regex: /[0-9a-f]{40}/i, match_fields: 'message' },

--- a/timesketch/frontend/src/components/Explore/EventListRowDetail.vue
+++ b/timesketch/frontend/src/components/Explore/EventListRowDetail.vue
@@ -59,12 +59,14 @@ limitations under the License.
             ><i class="fas fa-copy"></i
           ></span>
           <text-highlight
+            v-if="getRegexes(key).length > 0"
             @addChip="$emit('addChip', $event)"
             :highlightComponent="TsIOCMenu"
-            :queries="Object.values(regexes)"
+            :queries="getRegexes(key)"
             :attributeKey="key"
             >{{ item }}</text-highlight
           >
+          <span v-else>{{item}}</span>
         </td>
       </tr>
     </tbody>
@@ -82,13 +84,13 @@ export default {
   data() {
     return {
       TsIOCMenu,
-      regexes: {
-        ip: /((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/g,
-        hash_md5: /[0-9a-f]{32}/gi,
-        hash_sha1: /[0-9a-f]{40}/gi,
-        hash_sha256: /[0-9a-f]{64}/gi,
-        selection: '',
-      },
+      regexSelection: '',
+      regexes: [
+        { type: 'ip', regex: /((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/g, match_fields: 'message' },
+        { type: 'hash_md5', regex: /[0-9a-f]{32}/i, match_fields: 'message' },
+        { type: 'hash_sha1', regex: /[0-9a-f]{40}/i, match_fields: 'message' },
+        { type: 'hash_sha256', regex: /[0-9a-f]{64}/i, match_fields: 'message' },
+      ],
       c_key: -1,
       fullEvent: {},
     }
@@ -135,10 +137,18 @@ export default {
         return
       }
       const text = window.getSelection().toString()
-      this.regexes.selection = text
-      if (this.regexes.selection !== '') {
-      }
+      this.regexSelection = text
     },
+    getRegexes(key) {
+      if (this.regexSelection !== '') {
+        return this.regexSelection
+      }
+      let regexes = Object.values(this.regexes.filter(r=> r.match_fields === key || r.match_fields === '*').map(r => r.regex))
+      if (this.regexSelection !== '') {
+        regexes.push(this.regexSelection)
+      }
+      return regexes
+    }
   },
   created: function() {
     this.getEvent()

--- a/timesketch/frontend/src/components/Explore/EventListRowDetail.vue
+++ b/timesketch/frontend/src/components/Explore/EventListRowDetail.vue
@@ -86,12 +86,12 @@ export default {
       TsIOCMenu,
       regexSelection: '',
       regexes: [
-        { type: 'fs_path', regex: /(\/[\S]+)+/i, match_fields: 'message' },
-        { type: 'hostname', regex: /([-\w]+\.)+[a-z]{2,}/i, match_fields: 'hostname' },
-        { type: 'ip', regex: /((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/g, match_fields: 'message' },
-        { type: 'hash_md5', regex: /[0-9a-f]{32}/i, match_fields: 'message' },
-        { type: 'hash_sha1', regex: /[0-9a-f]{40}/i, match_fields: 'message' },
-        { type: 'hash_sha256', regex: /[0-9a-f]{64}/i, match_fields: 'message' },
+        { type: 'fs_path', regex: /(\/[\S]+)+/i, match_field: 'message' },
+        { type: 'hostname', regex: /([-\w]+\.)+[a-z]{2,}/i, match_field: 'hostname' },
+        { type: 'ip', regex: /((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/g, match_field: 'message' },
+        { type: 'hash_md5', regex: /[0-9a-f]{32}/i, match_field: 'message' },
+        { type: 'hash_sha1', regex: /[0-9a-f]{40}/i, match_field: 'message' },
+        { type: 'hash_sha256', regex: /[0-9a-f]{64}/i, match_field: 'message' },
       ],
       c_key: -1,
       fullEvent: {},
@@ -145,7 +145,7 @@ export default {
       if (this.regexSelection !== '') {
         return this.regexSelection
       }
-      let regexes = Object.values(this.regexes.filter(r=> r.match_fields === key || r.match_fields === '*').map(r => r.regex))
+      let regexes = Object.values(this.regexes.filter(r=> r.match_field === key || r.match_field === '*').map(r => r.regex))
       if (this.regexSelection !== '') {
         regexes.push(this.regexSelection)
       }

--- a/timesketch/frontend/src/components/Explore/EventListRowDetail.vue
+++ b/timesketch/frontend/src/components/Explore/EventListRowDetail.vue
@@ -86,6 +86,8 @@ export default {
       TsIOCMenu,
       regexSelection: '',
       regexes: [
+        { type: 'fs_path', regex: /(\/[\S]+)+/, match_fields: 'message' },
+        { type: 'hostname', regex: /([-\w]+\.)+[a-z]{2,}/, match_fields: 'hostname' },
         { type: 'ip', regex: /((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/g, match_fields: 'message' },
         { type: 'hash_md5', regex: /[0-9a-f]{32}/i, match_fields: 'message' },
         { type: 'hash_sha1', regex: /[0-9a-f]{40}/i, match_fields: 'message' },

--- a/timesketch/frontend/tests/unit/iocmenu.spec.js
+++ b/timesketch/frontend/tests/unit/iocmenu.spec.js
@@ -24,6 +24,16 @@ const testIOCs = [
     {text: '11a3e229084349bc25d97e29393ced1d', type: 'hash_md5'},
     {text: '0011a3e229084349bc25d97e29393ced1d', type: 'other'},
     {text: 'ZZa3e229084349bc25d97e29393ced1d', type: 'other'},
+
+    {text: '/tmp/tmpcl4mrm0w/4370B0F43479C318.body', type: 'fs_path'},
+    {text: '/tmp/tmpcl4mrm0w/4370B0F43 479C318.body', type: 'other'},
+
+    {text: 'tomchop.me', type: 'hostname'},
+    {text: 'subdomain.tomchop.me', type: 'hostname'},
+    {text: 'sub-domain99.tomchop.me', type: 'hostname'},
+    {text: 'sub.tomc-hop.me', type: 'hostname'},
+    {text: 'tomchop.m-e', type: 'other'},
+
 ]
 
 describe('TsIOCMenu.vue', () => {

--- a/timesketch/frontend/tests/unit/iocmenu.spec.js
+++ b/timesketch/frontend/tests/unit/iocmenu.spec.js
@@ -45,7 +45,7 @@ describe('TsIOCMenu.vue', () => {
   it('IOC type is correctly derived from text selection', () => {
     const wrapper = shallowMount(TsIOCMenu, {})
     for (let testIoc of testIOCs) {
-        expect(wrapper.vm.getIOC(testIoc.text).type).to.equal(testIoc.type, testIoc.text)
+        expect(wrapper.vm.getIOC(testIoc.text).type).to.equal(testIoc.type, 'Mismatch on ' + testIoc.text)
     }
   })
 })

--- a/timesketch/frontend/tests/unit/iocmenu.spec.js
+++ b/timesketch/frontend/tests/unit/iocmenu.spec.js
@@ -30,7 +30,7 @@ describe('TsIOCMenu.vue', () => {
   it('IOC type is correctly derived from text selection', () => {
     const wrapper = shallowMount(TsIOCMenu, {})
     for (let testIoc of testIOCs) {
-        expect(wrapper.vm.getIOC(testIoc.text).type).to.equal(testIoc.type)
+        expect(wrapper.vm.getIOC(testIoc.text).type).to.equal(testIoc.type, testIoc.text)
     }
   })
 })

--- a/timesketch/frontend/tests/unit/iocmenu.spec.js
+++ b/timesketch/frontend/tests/unit/iocmenu.spec.js
@@ -10,25 +10,30 @@ const testIOCs = [
     {text: '127.0.0.01', type: 'other'},
     {text: '266.0.0.1', type: 'other'},
 
-    // Test hash parsing with wrong length (prepend 00) and non-hex chars (ZZ)
+    // Test hash parsing with uppercase, wrong length (prepend 00) and non-hex chars (ZZ)
     {text: '819f04e5706f509de5a6b833d3f561369156820b4240c7c26577b223e59aae97', type: 'hash_sha256'},
+    {text: '819F04E5706F509DE5A6B833D3F561369156820B4240C7C26577B223E59AAE97', type: 'hash_sha256'},
     {text: '00819f04e5706f509de5a6b833d3f561369156820b4240c7c26577b223e59aae97', type: 'other'},
     {text: 'ZZ9f04e5706f509de5a6b833d3f561369156820b4240c7c26577b223e59aae97', type: 'other'},
 
     // sha1
     {text: 'e6e8ea7465f12e4d3b5a067a4c4dc698436b3478', type: 'hash_sha1'},
+    {text: 'E6E8EA7465F12E4D3B5A067A4C4DC698436B3478', type: 'hash_sha1'},
     {text: '00e6e8ea7465f12e4d3b5a067a4c4dc698436b3478', type: 'other'},
     {text: 'ZZe8ea7465f12e4d3b5a067a4c4dc698436b3478', type: 'other'},
 
     // md5
     {text: '11a3e229084349bc25d97e29393ced1d', type: 'hash_md5'},
+    {text: '11A3E229084349BC25D97E29393CED1D', type: 'hash_md5'},
     {text: '0011a3e229084349bc25d97e29393ced1d', type: 'other'},
     {text: 'ZZa3e229084349bc25d97e29393ced1d', type: 'other'},
 
     {text: '/tmp/tmpcl4mrm0w/4370B0F43479C318.body', type: 'fs_path'},
+    {text: '/TMP/TMPCL4MRM0W/4370B0F43479C318.BODY', type: 'fs_path'},
     {text: '/tmp/tmpcl4mrm0w/4370B0F43 479C318.body', type: 'other'},
 
     {text: 'tomchop.me', type: 'hostname'},
+    {text: 'TOMCHOP.ME', type: 'hostname'},
     {text: 'subdomain.tomchop.me', type: 'hostname'},
     {text: 'sub-domain99.tomchop.me', type: 'hostname'},
     {text: 'sub.tomc-hop.me', type: 'hostname'},


### PR DESCRIPTION

This PR changes the way IOCs are searched for in event details, by introducing a `match_fields` key in the regexes object, that binds the search to only a specific event field (to induce less false positives and to avoid searching in fields that aren't interesting)

Additionally, this PR introduces a few more IOC types:

* `hostname` (only search in the `hostname` field)
* `fs_path` (only search in the `message` field)

All other IOCs are only searched for in the `message` field, reducing the number of TextHighlight components that are rendered in the page with nothing to highlight.