### PR TITLE
Generate graph for a specific timeline

### DIFF
--- a/timesketch/frontend/src/utils/RestApiClient.js
+++ b/timesketch/frontend/src/utils/RestApiClient.js
@@ -281,15 +281,19 @@ export default {
   getLoggedInUser() {
     return RestApiClient.get('/users/me/')
   },
-  generateGraphFromPlugin(sketchId, graphPlugin, currentIndices, refresh) {
+  generateGraphFromPlugin(sketchId, graphPlugin, currentIndices, timelineIds, refresh) {
     let formData = {
       plugin: graphPlugin,
       config: {
         filter: {
           indices: currentIndices,
+          timelineIds: timelineIds,
         },
       },
       refresh: refresh,
+    }
+    if (timelineIds.length) {
+      formData['timeline_ids'] = timelineIds
     }
     return RestApiClient.post('/sketches/' + sketchId + /graph/, formData)
   },
@@ -325,7 +329,7 @@ export default {
     return RestApiClient.get('/sigma/')
   },
   getSigmaResource(ruleUuid) {
-    return RestApiClient.get('/sigma/rule/'+ ruleUuid +'/')
+    return RestApiClient.get('/sigma/rule/' + ruleUuid + '/')
   },
   getSigmaByText(ruleText) {
     let formData = {

--- a/timesketch/lib/graphs/interface.py
+++ b/timesketch/lib/graphs/interface.py
@@ -142,6 +142,7 @@ class BaseGraphElement:
         Returns:
             MD5 hash (str): MD5 hash of the provided label.
         """
+
         id_string = self.attributes.get('id', self.label)
         return hashlib.md5(id_string.encode('utf-8')).hexdigest()
 


### PR DESCRIPTION
This PR add support for per timeline graph generation. There are times where it is desirable to be able to choose which timeline to generate the graph for.

* Add URL parameter support (?timeline=<ID>)
* Dropdown to choose timeline
* Warning to indicate that the cached graph is generated from a single timeline
* Keeps backwards compatibility with old graph caches

![Screenshot 2021-11-12 at 12 18 06](https://user-images.githubusercontent.com/316362/141459045-20a45dba-95e9-4cd3-9685-2ad1c52360e1.png)

We can add support for multiple timelines in the future.

