### PR TITLE
make it clear to which ID the timeline is uploaded

### DIFF
--- a/importer_client/python/tools/timesketch_importer.py
+++ b/importer_client/python/tools/timesketch_importer.py
@@ -484,7 +484,7 @@ def main(args=None):
             continue
 
         print('[DONE]')
-        print(f'Timeline uploaded to ID: {timeline.id}.')
+        print(f'Timeline uploaded to Timeline Id: {timeline.id}.')
 
         task_state = 'Unknown'
         task_list = ts_client.check_celery_status(task_id)


### PR DESCRIPTION
Small improvement of the import client to make sure the user knows what ID is meant in the putput