### PR TITLE
Add incompatible Sigma rules to the blocklist

### DIFF
--- a/contrib/deploy_timesketch.ps1
+++ b/contrib/deploy_timesketch.ps1
@@ -69,6 +69,7 @@ Write-Host "* Fetching configuration files.."
 (Invoke-webrequest -URI $GITHUB_BASE_URL/data/generic.mappings).Content | out-file timesketch\etc\timesketch\generic.mappings -encoding UTF8NoBOM
 (Invoke-webrequest -URI $GITHUB_BASE_URL/data/features.yaml).Content | out-file timesketch\etc\timesketch\features.yaml -encoding UTF8NoBOM
 (Invoke-webrequest -URI $GITHUB_BASE_URL/data/sigma_config.yaml).Content | out-file timesketch\etc\timesketch\sigma_config.yaml -encoding UTF8NoBOM
+(Invoke-webrequest -URI $GITHUB_BASE_URL/data/sigma_blacklist.csv).Content | out-file timesketch\etc\timesketch\sigma_blocklist.csv -encoding UTF8NoBOM
 (Invoke-webrequest -URI $GITHUB_BASE_URL/data/sigma/rules/lnx_susp_zmap.yml).Content | out-file timesketch\etc\timesketch\sigma\rules\lnx_susp_zmap.yml -encoding UTF8NoBOM
 (Invoke-webrequest -URI $GITHUB_BASE_URL/contrib/nginx.conf).Content | out-file timesketch\etc\nginx.conf -encoding UTF8NoBOM
 Write-Host "OK"

--- a/contrib/deploy_timesketch.sh
+++ b/contrib/deploy_timesketch.sh
@@ -83,6 +83,7 @@ curl -s $GITHUB_BASE_URL/data/plaso.mappings > timesketch/etc/timesketch/plaso.m
 curl -s $GITHUB_BASE_URL/data/generic.mappings > timesketch/etc/timesketch/generic.mappings
 curl -s $GITHUB_BASE_URL/data/features.yaml > timesketch/etc/timesketch/features.yaml
 curl -s $GITHUB_BASE_URL/data/sigma_config.yaml > timesketch/etc/timesketch/sigma_config.yaml
+curl -s $GITHUB_BASE_URL/data/sigma_blocklist.csv > timesketch/etc/timesketch/sigma_blocklist.csv
 curl -s $GITHUB_BASE_URL/data/sigma/rules/lnx_susp_zmap.yml > timesketch/etc/timesketch/sigma/rules/lnx_susp_zmap.yml
 curl -s $GITHUB_BASE_URL/contrib/nginx.conf > timesketch/etc/nginx.conf
 echo "OK"

--- a/data/sigma_blocklist.csv
+++ b/data/sigma_blocklist.csv
@@ -180,3 +180,32 @@ rules/windows/file_event/sysmon_susp_desktop_ini.yml,good,9ac87754adb88a8ac14969
 rules/windows/file_event/sysmon_startup_folder_file_write.yml,bad,no good sample found 9ac87754adb88a8ac14969bb4adaed043f783d7264d0846365ca0cf4b7f80ffb,2021-10-26,2aa0a6b4-a865-495b-ab51-c28249537b75
 rules/windows/process_creation/sysmon_always_install_elevated_windows_installer.yml,bad,no good sample found e5874027b483a6bcac952f302eedcadb59f858e9d7cc1f89b08102c8dbc69160,2021-10-26,cd951fdc-4b2f-47f5-ba99-a33bf61e3770
 rules/windows/process_creation/win_susp_svchost.yml,good,cc565bd2909f2889f8369939c3b932030f4dddba3b52ec17a2b4961144b05aa6,2021-10-26,01d2e2a1-5f09-44f7-9fc1-24faa7479b6d
+tools/config/generic/,bad,Sigma internal tools with yaml files in them,2021-11-19,
+/rules-unsupported/,bad,Sigma internal folder name,2021-11-19,
+sigma/tests/,bad,Sigma internal folder name,2021-11-19,
+sigma/tools/config/,bad,Sigma internal folder name,2021-11-19,
+.github/,bad,Github folder name in case Sigma project is clones,2021-11-19,
+sigma-schema.rx.yml,bad,Sigma internal filename,2021-11-19,
+/_config.yml,bad,Sigma internal filename,2021-11-19,
+sigma/rules/windows/dns_query/dns_query_possible_dns_rebinding.yml,bad,NotImplementedError,2021-11-19,
+sigma/rules/windows/builtin/win_susp_failed_remote_logons_single_source.yml,bad,NotImplementedError,2021-11-19,add2ef8d-dc91-4002-9e7e-f2702369f53a
+sigma/rules/windows/builtin/win_susp_failed_logons_single_source_kerberos3.yml,bad,NotImplementedError,2021-11-19,bc93dfe6-8242-411e-a2dd-d16fa0cc8564
+sigma/rules/windows/builtin/win_susp_failed_logons_single_source_ntlm2.yml,bad,NotImplementedError,2021-11-19,56d62ef8-3462-4890-9859-7b41e541f8d5
+sigma/rules/windows/builtin/win_susp_failed_logons_explicit_credentials.yml,bad,NotImplementedError,2021-11-19,196a29c2-e378-48d8-ba07-8a9e61f7fab9
+sigma/rules/windows/builtin/win_susp_failed_logons_single_source_ntlm.yml,bad,NotImplementedError,2021-11-19,f88bab7f-b1f4-41bb-bdb1-4b8af35b0470
+sigma/rules/windows/builtin/win_susp_failed_logons_single_source_kerberos2.yml,bad,NotImplementedError,2021-11-19,4b6fe998-b69c-46d8-901b-13677c9fb663
+sigma/rules/windows/builtin/win_susp_failed_logons_single_source2.yml,bad,NotImplementedError,2021-11-19,6309ffc4-8fa2-47cf-96b8-a2f72e58e538
+sigma/rules/windows/builtin/win_susp_multiple_files_renamed_or_deleted.yml,bad,NotImplementedError,2021-11-19,97919310-06a7-482c-9639-92b67ed63cf8
+sigma/rules/windows/builtin/win_susp_failed_logons_single_process.yml,bad,NotImplementedError,2021-11-19,fe563ab6-ded4-4916-b49f-a3a8445fe280
+sigma/rules/windows/builtin/win_susp_failed_logons_single_source_kerberos.yml,bad,NotImplementedError,2021-11-19,5d1d946e-32e6-4d9a-a0dc-0ac022c7eb98
+sigma/rules/windows/powershell/powershell_script/powershell_cl_invocation_lolscript_count.yml,bad,NotImplementedError,2021-11-19,f588e69b-0750-46bb-8f87-0e9320d57536
+sigma/rules/windows/powershell/powershell_script/powershell_cl_mutexverifiers_lolscript_count.yml,bad,NotImplementedError,2021-11-19,6609c444-9670-4eab-9636-fe4755a851ce
+sigma/rules/linux/modsecurity/modsec_mulitple_blocks.yml,bad,NotImplementedError,2021-11-19,a06eea10-d932-4aa6-8ba9-186df72c8d23
+sigma/rules/linux/builtin/lnx_shell_priv_esc_prep.yml,bad,NotImplementedError,2021-11-19,444ade84-c362-4260-b1f3-e45e20e1a905
+sigma/rules/linux/other/lnx_susp_failed_logons_single_source.yml,bad,NotImplementedError,2021-11-19,fc947f8e-ea81-4b14-9a7b-13f888f94e18
+sigma/rules/linux/auditd/lnx_auditd_cve_2021_3156_sudo_buffer_overflow.yml,bad,NotImplementedError,2021-11-19,5ee37487-4eb8-4ac2-9be1-d7d14cdc559f
+sigma/rules/linux/auditd/lnx_auditd_cve_2021_3156_sudo_buffer_overflow_brutforce.yml,bad,NotImplementedError,2021-11-19,b9748c98-9ea7-4fdb-80b6-29bed6ba71d2
+sigma/rules/cloud/aws/aws_macic_evasion.yml,bad,NotImplementedError,2021-11-19,91f6a16c-ef71-437a-99ac-0b070e3ad221
+sigma/rules/cloud/aws/aws_lambda_function_created_or_invoked.yml,bad,NotImplementedError,2021-11-19,d914951b-52c8-485f-875e-86abab710c0b
+sigma/rules/cloud/aws/aws_ec2_download_userdata.yml,bad,NotImplementedError,2021-11-19,26ff4080-194e-47e7-9889-ef7602efed0c
+sigma/rules/cloud/aws/aws_enum_listing.yml,bad,NotImplementedError,2021-11-19,e9c14b23-47e2-4a8b-8a63-d36618e33d70

--- a/data/timesketch.conf
+++ b/data/timesketch.conf
@@ -251,6 +251,7 @@ EXTERNAL_HOST_URL = 'https://localhost'
 SIGMA_RULES_FOLDERS = ['/etc/timesketch/sigma/rules/']
 SIGMA_CONFIG = '/etc/timesketch/sigma_config.yaml'
 SIGMA_TAG_DELAY = 5
+SIGMA_BLOCKLIST_CSV = '/etc/timesketch/sigma_blocklist.csv'
 
 #-------------------------------------------------------------------------------
 # Flask Settings

--- a/docker/dev/build/docker-entrypoint.sh
+++ b/docker/dev/build/docker-entrypoint.sh
@@ -16,6 +16,7 @@ if [ "$1" = 'timesketch' ]; then
   cp /usr/local/src/timesketch/data/ontology.yaml /etc/timesketch/
   cp /usr/local/src/timesketch/data/data_finder.yaml /etc/timesketch/
   ln -s /usr/local/src/timesketch/data/sigma_config.yaml /etc/timesketch/sigma_config.yaml
+  ln -s /usr/local/src/timesketch/data/sigma_blocklist.csv /etc/timesketch/sigma_blocklist.csv
   ln -s /usr/local/src/timesketch/data/sigma /etc/timesketch/
 
 

--- a/docker/e2e/Dockerfile
+++ b/docker/e2e/Dockerfile
@@ -42,6 +42,7 @@ RUN cp /tmp/timesketch/data/features.yaml /etc/timesketch/
 RUN cp /tmp/timesketch/data/plaso.mappings /etc/timesketch/
 RUN cp /tmp/timesketch/data/generic.mappings /etc/timesketch/
 RUN cp /tmp/timesketch/data/sigma_config.yaml /etc/timesketch/
+RUN cp /tmp/timesketch/data/sigma_blocklist.csv /etc/timesketch/
 RUN cp /tmp/timesketch/data/data_finder.yaml /etc/timesketch/
 RUN cp -r /tmp/timesketch/data/sigma /etc/timesketch/sigma
 RUN chmod -R go+r /etc/timesketch

--- a/docs/guides/user/sigma.md
+++ b/docs/guides/user/sigma.md
@@ -63,6 +63,24 @@ The rules then will be under
 timesketch/data/sigma
 ```
 
+### Sigma Rules Blocklist file
+
+The `data/sigma_blocklist.csv` is the central point where Timesketch tries to maintain which rules are considered good or bad. By default each rule is considered good, but it is good practice to add them in that file if they are tested.
+
+Each method that reads Sigma rules from the a folder is checking, if part of the full path of a rule is mentioned in the `data/sigma_blocklist.csv` file.
+
+For examle a file at `/etc/timesketch/data/sigma/rules-unsupported/foo/bar.yml` would not be parsed as a line in `data/sigma_blocklist.csv` mentions:
+
+```
+/rules-unsupported/,bad,Sigma internal folder name,2021-11-19,
+```
+
+The header for that file are:
+
+```
+path,bad,reason,last_ckecked,rule_id
+```
+
 ### Sigma Rules
 
 The windows rules are stored in
@@ -87,6 +105,7 @@ There are multiple sigma related config variables in ```timesketch.conf```.
 SIGMA_RULES_FOLDERS = ['/etc/timesketch/sigma/rules/']
 SIGMA_CONFIG = '/etc/timesketch/sigma_config.yaml'
 SIGMA_TAG_DELAY = 5
+SIGMA_BLOCKLIST_CSV = '/etc/timesketch/sigma_blocklist.csv'
 ```
 
 The ```SIGMA_RULES_FOLDERS``` points to the folder(s) where Sigma rules are stored. The folder is the local folder of the Timesketch server (celery worker and webserver). For a distributed system, mounting network shares is possible.

--- a/docs/guides/user/sigma.md
+++ b/docs/guides/user/sigma.md
@@ -67,7 +67,7 @@ timesketch/data/sigma
 
 The `data/sigma_blocklist.csv` is where Timesketch maintains a list of incompatible rules. By default each rule is considered compatible, but it is good practice to add them in this file if they are tested and verified to not be compatible.
 
-Each method that reads Sigma rules from the a folder is checking, if part of the full path of a rule is mentioned in the `data/sigma_blocklist.csv` file.
+Each method that reads Sigma rules from the a folder is checking if part of the full path of a rule is mentioned in the `data/sigma_blocklist.csv` file.
 
 For examle a file at `/etc/timesketch/data/sigma/rules-unsupported/foo/bar.yml` would not be parsed as a line in `data/sigma_blocklist.csv` mentions:
 

--- a/docs/guides/user/sigma.md
+++ b/docs/guides/user/sigma.md
@@ -65,7 +65,7 @@ timesketch/data/sigma
 
 ### Sigma Rules Blocklist file
 
-The `data/sigma_blocklist.csv` is the central point where Timesketch tries to maintain which rules are considered good or bad. By default each rule is considered good, but it is good practice to add them in that file if they are tested.
+The `data/sigma_blocklist.csv` is where Timesketch maintains a list of incompatible rules. By default each rule is considered compatible, but it is good practice to add them in this file if they are tested and verified to not be compatible.
 
 Each method that reads Sigma rules from the a folder is checking, if part of the full path of a rule is mentioned in the `data/sigma_blocklist.csv` file.
 

--- a/timesketch/api/v1/resources/sigma.py
+++ b/timesketch/api/v1/resources/sigma.py
@@ -49,12 +49,12 @@ class SigmaListResource(resources.ResourceMixin, Resource):
         try:
             sigma_rules = ts_sigma_lib.get_all_sigma_rules()
 
-        except ValueError:
+        except ValueError as e:
             logger.error('OS Error, unable to get the path to the Sigma rules',
                          exc_info=True)
             abort(
                 HTTP_STATUS_CODE_NOT_FOUND,
-                'OS Error, unable to get the path to the Sigma rules')
+                f'Value Error, {e}')
         # TODO: idea for meta: add a list of folders that have been parsed
         meta = {'current_user': current_user.username,
                 'rules_count': len(sigma_rules)}
@@ -78,12 +78,12 @@ class SigmaResource(resources.ResourceMixin, Resource):
         try:
             sigma_rules = ts_sigma_lib.get_all_sigma_rules()
 
-        except ValueError:
+        except ValueError as e:
             logger.error('OS Error, unable to get the path to the Sigma rules',
                          exc_info=True)
             abort(
                 HTTP_STATUS_CODE_NOT_FOUND,
-                'OS Error, unable to get the path to the Sigma rules')
+                f'ValueError {e}')
         for rule in sigma_rules:
             if rule is not None:
                 if rule_uuid == rule.get('id'):

--- a/timesketch/lib/sigma_util.py
+++ b/timesketch/lib/sigma_util.py
@@ -17,6 +17,7 @@ import os
 import codecs
 import csv
 import logging
+from datetime import datetime
 import yaml
 import pandas as pd
 
@@ -29,7 +30,6 @@ from sigma.parser import collection as sigma_collection
 from sigma.parser import exceptions as sigma_exceptions
 from sigma.config.exceptions import SigmaConfigParseError
 
-from datetime import datetime
 
 logger = logging.getLogger('timesketch.lib.sigma')
 
@@ -232,7 +232,7 @@ def get_sigma_rule(filepath, sigma_config=None):
                 'Error generating rule in file {0:s}: {1!s}'
                 .format(abs_path, exception))
             add_problematic_rule(filepath, doc.get('id'),
-                                 'NotImplementedError - Something in the rule is not implemented for Timesketch')
+                                 'Parts of the rule not implemented in TS')
             return None
 
         except sigma_exceptions.SigmaParseError as exception:
@@ -378,7 +378,6 @@ def add_problematic_rule(filepath, rule_uuid=None, reason=None):
     with open(blocklist_file_path, 'a') as f:
         writer = csv.writer(f)
         writer.writerow(fields)
-        f.close
 
 
 def get_sigma_rule_by_text(rule_text, sigma_config=None):

--- a/timesketch/lib/sigma_util.py
+++ b/timesketch/lib/sigma_util.py
@@ -141,12 +141,8 @@ def get_sigma_rules(rule_folder, sigma_config=None):
                     continue
 
                 rule_file_path = os.path.join(dirpath, rule_filename)
-                block_because_csv = False
 
                 if any(x in rule_file_path for x in ignore_list):
-                    block_because_csv = True
-
-                if block_because_csv:
                     continue
 
                 parsed_rule = get_sigma_rule(rule_file_path, sigma_config)

--- a/timesketch/lib/sigma_util.py
+++ b/timesketch/lib/sigma_util.py
@@ -331,7 +331,7 @@ def get_sigma_blocklist_path(blocklist_path=None):
     """
     logger.error(blocklist_path)
 
-    if blocklist_path is None or blocklist_path == '':
+    if not blocklist_path or blocklist_path == '':
         blocklist_path = current_app.config.get(
             'SIGMA_BLOCKLIST_CSV', './data/sigma_blocklist.csv')
     if not blocklist_path:

--- a/timesketch/lib/sigma_util.py
+++ b/timesketch/lib/sigma_util.py
@@ -15,10 +15,10 @@
 
 import os
 import codecs
+import csv
 import logging
 import yaml
 import pandas as pd
-import csv
 
 from flask import current_app
 
@@ -28,6 +28,8 @@ from sigma.backends import elasticsearch as sigma_es
 from sigma.parser import collection as sigma_collection
 from sigma.parser import exceptions as sigma_exceptions
 from sigma.config.exceptions import SigmaConfigParseError
+
+from datetime import datetime
 
 logger = logging.getLogger('timesketch.lib.sigma')
 
@@ -357,7 +359,6 @@ def add_problematic_rule(filepath, rule_uuid=None, reason=None):
         reason: optional reason why file is moved
     """
     blocklist_file_path = get_sigma_blocklist_path()
-    from datetime import datetime
 
     # we only want to store the relative paths in the blocklist file
 
@@ -373,7 +374,6 @@ def add_problematic_rule(filepath, rule_uuid=None, reason=None):
     # path,bad,reason,last_ckecked,rule_id
     fields = [file_relpath, 'bad', reason,
               datetime.now().strftime('%Y-%m-%d'), rule_uuid]
-    logging.error(f'Adding following rule to ignore list {fields}')
 
     with open(blocklist_file_path, 'a') as f:
         writer = csv.writer(f)

--- a/timesketch/lib/sigma_util_test.py
+++ b/timesketch/lib/sigma_util_test.py
@@ -79,6 +79,11 @@ class TestSigmaUtilLib(BaseTest):
         self.assertRaises(ValueError, sigma_util.get_sigma_config_file, '/foo')
         self.assertIsNotNone(sigma_util.get_sigma_config_file())
 
+    def test_get_blocklist_file(self):
+        """Test getting sigma config file"""
+        self.assertRaises(ValueError, sigma_util.get_sigma_blocklist, '/foo')
+        self.assertIsNotNone(sigma_util.get_sigma_config_file())
+
     def test_get_sigma_rule(self):
         """Test getting sigma rule from file"""
 


### PR DESCRIPTION
From time to time, people try to copy the whole Sigma repository into Timesketch and it will cause side effects and frustration.

With this PR two things will happen:

a) Rules / folders that are known not good and are mentioned in the `sigma_blocklist.csv` will now be ignored when returing rules over the API.

b) if a new rules is added to the Filesystem and is causing problems, it will add a line to the `sigma_blocklist.csv` and therefor ignore it for future iterations.

**Checks**

- [x] All tests succeed.
- [x] Unit tests added.
- [x] e2e tests added.
- [x] Documentation updated.

**Closing issues**
closes #2037 
