### PR TITLE
Migrate to OpenSearch for dev environment

### DIFF
--- a/docker/dev/build/Dockerfile
+++ b/docker/dev/build/Dockerfile
@@ -28,11 +28,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     plaso-tools \
   && rm -rf /var/lib/apt/lists/*
 
-# Install NodeJS and Yarn for frontend development
+# Install NodeJS for frontend development
+RUN curl -sL https://deb.nodesource.com/setup_12.x -o nodesource_setup.sh
+RUN bash nodesource_setup.sh
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    nodejs \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install Yarn for frontend development
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    nodejs \
     yarn \
   && rm -rf /var/lib/apt/lists/*
 

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   timesketch:
     container_name: timesketch-dev
@@ -9,7 +9,7 @@ services:
       - 127.0.0.1:5001:5001
       - 127.0.0.1:8080:8080
     links:
-      - elasticsearch
+      - opensearch
       - postgres
       - redis
       - notebook
@@ -18,7 +18,7 @@ services:
       - POSTGRES_PASSWORD=password
       - POSTGRES_ADDRESS=postgres
       - POSTGRES_PORT=5432
-      - ELASTIC_ADDRESS=elasticsearch
+      - ELASTIC_ADDRESS=opensearch
       - ELASTIC_PORT=9200
       - REDIS_ADDRESS=redis
       - REDIS_PORT=6379
@@ -31,19 +31,25 @@ services:
     volumes:
       - ../../:/usr/local/src/timesketch/
 
-  elasticsearch:
-    container_name: elasticsearch
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
+  opensearch:
+    container_name: opensearch
+    image: opensearchproject/opensearch:latest
     restart: always
     environment:
       - discovery.type=single-node
       - bootstrap.memory_lock=true
       - network.host=0.0.0.0
-      - "ES_JAVA_OPTS=-Xms2g -Xmx2g"
+      - "OPENSEARCH_JAVA_OPTS=-Xms2g -Xmx2g"
+      - "DISABLE_INSTALL_DEMO_CONFIG=true"
+      - "DISABLE_SECURITY_PLUGIN=true" # TODO: Enable when we have migrated the python client to Opensearch as well.
+
     ulimits:
       memlock:
         soft: -1
         hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
 
   postgres:
     container_name: postgres
@@ -65,11 +71,10 @@ services:
       - 127.0.0.1:8844:8844
     restart: on-failure
     links:
-      - elasticsearch
+      - opensearch
     volumes:
       - ../../:/usr/local/src/timesketch/:ro
       - /tmp/:/usr/local/src/picadata/
-
   prometheus:
     container_name: prometheus
     image: prom/prometheus:v2.24.1
@@ -78,15 +83,6 @@ services:
     ports:
       - 127.0.0.1:9090:9090
     command: --config.file=/etc/prometheus/prometheus.yml
-
-  es-metrics-exporter:
-    container_name: es-metrics-exporter
-    image: justwatch/elasticsearch_exporter:1.1.0
-    command: --es.uri=http://elasticsearch:9200 --es.all
-    restart: always
-    links:
-      - elasticsearch
-
   grafana:
     container_name: grafana
     image: "grafana/grafana:latest"

--- a/docker/dev/prometheus/prometheus.yml
+++ b/docker/dev/prometheus/prometheus.yml
@@ -1,13 +1,8 @@
 global:
-    scrape_interval: 10s
-    external_labels:
-        monitor: 'timesketch'
+  scrape_interval: 10s
+  external_labels:
+    monitor: "timesketch"
 scrape_configs:
-    - job_name: 'es-metrics-exporter'
-      static_configs:
-      - targets: ['es-metrics-exporter:9114']
-  
-    - job_name: 'timesketch'
-      static_configs:
-      - targets: ['timesketch:8080']          
-
+  - job_name: "timesketch"
+    static_configs:
+      - targets: ["timesketch:8080"]


### PR DESCRIPTION
This PR replaces the unmaintained Elasticsearch OSS version 7.10.2 with the latest OpenSearch for the development environment.