### PR TITLE
Switch to OpenSearch for e2e tests

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -10,6 +10,6 @@ jobs:
       - name: Set up infrastructure with docker-compose
         run: docker-compose -f docker/e2e/docker-compose.yml up -d
         env:
-          ELASTICSEARCH_VERSION: 7.9.3
+          OPENSEARCH_VERSION: 1.2.2
       - name: Run e2e tests
         run: docker-compose -f docker/e2e/docker-compose.yml exec -T timesketch python3 /usr/local/src/timesketch/end_to_end_tests/tools/run_in_container.py

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,35 +13,43 @@ jobs:
         python-version: [3.7, 3.8]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        pip install astroid==2.4.0
-        pip install pylint==2.6.0
-        pip install -r test_requirements.txt
-        pip install -r requirements.txt
-        pip install -e .
-        pip install -e api_client/python
-        pip install -e importer_client/python
-    - name: Run pylint
-      run: |
-        git config pull.rebase false && git fetch -p origin master
-        for FILE in `git --no-pager diff origin/master --name-only | grep \.py$`; do echo "Running pylint against ${FILE}"; pylint --rcfile=.pylintrc ${FILE}; done
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install astroid==2.4.0
+          pip install pylint==2.6.0
+          pip install -r test_requirements.txt
+          pip install -r requirements.txt
+          pip install -e .
+          pip install -e api_client/python
+          pip install -e importer_client/python
+      - name: Run pylint
+        run: |
+          git config pull.rebase false && git fetch -p origin master
+          for FILE in `git --no-pager diff origin/master --name-only | grep \.py$`; do echo "Running pylint against ${FILE}"; pylint --rcfile=.pylintrc ${FILE}; done
 
   eslint:
     runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: ./timesketch/frontend
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+        node-version: ["12"]
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: yarn add eslint@5.16.0
-    - name: Run eslint
-      run: |
-        git config pull.rebase false && git fetch -p origin master
-        for FILE in `git --no-pager diff origin/master --name-only --diff-filter=ACMR | grep -e \.vue$ -e \.js$ | grep -v dist\/js | sed s/'^timesketch\/frontend\/'/''/`; do echo "Running eslint against ${FILE}"; yarn run eslint ${FILE}; done
+      - uses: actions/checkout@v2
+      - name: Set up Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: yarn add eslint@5.16.0
+      - name: Run eslint
+        run: |
+          git config pull.rebase false && git fetch -p origin master
+          for FILE in `git --no-pager diff origin/master --name-only --diff-filter=ACMR | grep -e \.vue$ -e \.js$ | grep -v dist\/js | sed s/'^timesketch\/frontend\/'/''/`; do echo "Running eslint against ${FILE}"; yarn run eslint ${FILE}; done

--- a/docker/e2e/docker-compose.yml
+++ b/docker/e2e/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   timesketch:
     environment:
@@ -6,7 +6,7 @@ services:
       - POSTGRES_PASSWORD=password
       - POSTGRES_ADDRESS=postgres
       - POSTGRES_PORT=5432
-      - ELASTIC_ADDRESS=elasticsearch
+      - ELASTIC_ADDRESS=opensearch
       - ELASTIC_PORT=9200
       - REDIS_ADDRESS=redis
       - REDIS_PORT=6379
@@ -18,25 +18,33 @@ services:
     ports:
       - "80:80"
     links:
-      - elasticsearch
+      - opensearch
       - postgres
       - redis
     restart: always
     volumes:
       - ../../:/usr/local/src/timesketch/
 
-  elasticsearch:
+  opensearch:
+    container_name: opensearch
+    image: opensearchproject/opensearch:${OPENSEARCH_VERSION}
+    restart: always
     environment:
       - TAKE_FILE_OWNERSHIP=1
       - discovery.type=single-node
-    # uncomment the following lines to control JVM memory utilization
-    # in smaller deployments with minimal resources
-    #  - ES_JAVA_OPTS= -Xms1g -Xmx1g # 1G min/1G max
-    image: elasticsearch:${ELASTICSEARCH_VERSION}
+      - bootstrap.memory_lock=true
+      - "DISABLE_INSTALL_DEMO_CONFIG=true"
+      - "DISABLE_SECURITY_PLUGIN=true" # TODO: Enable when we have migrated the python client to Opensearch as well.
     ports:
       - "9200:9200"
       - "9300:9300"
-    restart: always
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
 
   postgres:
     image: postgres

--- a/docker/e2e/docker-compose.yml
+++ b/docker/e2e/docker-compose.yml
@@ -26,13 +26,11 @@ services:
       - ../../:/usr/local/src/timesketch/
 
   opensearch:
-    container_name: opensearch
     image: opensearchproject/opensearch:${OPENSEARCH_VERSION}
     restart: always
     environment:
       - TAKE_FILE_OWNERSHIP=1
       - discovery.type=single-node
-      - bootstrap.memory_lock=true
       - "DISABLE_INSTALL_DEMO_CONFIG=true"
       - "DISABLE_SECURITY_PLUGIN=true" # TODO: Enable when we have migrated the python client to Opensearch as well.
     ports:

--- a/end_to_end_tests/interface.py
+++ b/end_to_end_tests/interface.py
@@ -31,7 +31,7 @@ from timesketch_import_client import importer
 # Default values based on Docker config.
 TEST_DATA_DIR = '/usr/local/src/timesketch/end_to_end_tests/test_data'
 HOST_URI = 'http://127.0.0.1'
-ELASTIC_HOST = 'elasticsearch'
+ELASTIC_HOST = 'opensearch'
 ELASTIC_PORT = 9200
 ELASTIC_MAPPINGS_FILE = '/etc/timesketch/plaso.mappings'
 USERNAME = 'test'

--- a/end_to_end_tests/tools/run_end_to_end_tests.sh
+++ b/end_to_end_tests/tools/run_end_to_end_tests.sh
@@ -9,7 +9,7 @@ set -e
 DEFAULT_ELASTICSEARCH_VERSION=7.9.3
 
 # Set Elasticsearch version to run
-[ -z "$ELASTICSEARCH_VERSION" ] && export ELASTICSEARCH_VERSION=$DEFAULT_ELASTICSEARCH_VERSION
+[ -z "$OPENSEARCH_VERSION" ] && export OPENSEARCH_VERSION=$DEFAULT_ELASTICSEARCH_VERSION
 
 # Container ID for the web server
 export CONTAINER_ID="$(sudo -E docker container list -f name=e2e_timesketch -q)"

--- a/end_to_end_tests/tools/run_end_to_end_tests.sh
+++ b/end_to_end_tests/tools/run_end_to_end_tests.sh
@@ -17,7 +17,7 @@ export CONTAINER_ID="$(sudo -E docker container list -f name=e2e_timesketch -q)"
 # Start containers if necessary
 if [ -z "$CONTAINER_ID" ]; then
   sudo -E docker-compose -f ./docker/e2e/docker-compose.yml up -d
-  /bin/sleep 120  # Wait for all containers to be available
+  /bin/sleep 180  # Wait for all containers to be available
   export CONTAINER_ID="$(sudo -E docker container list -f name=e2e_timesketch -q)"
 fi
 

--- a/end_to_end_tests/tools/run_end_to_end_tests.sh
+++ b/end_to_end_tests/tools/run_end_to_end_tests.sh
@@ -17,7 +17,7 @@ export CONTAINER_ID="$(sudo -E docker container list -f name=e2e_timesketch -q)"
 # Start containers if necessary
 if [ -z "$CONTAINER_ID" ]; then
   sudo -E docker-compose -f ./docker/e2e/docker-compose.yml up -d
-  /bin/sleep 180  # Wait for all containers to be available
+  /bin/sleep 120  # Wait for all containers to be available
   export CONTAINER_ID="$(sudo -E docker container list -f name=e2e_timesketch -q)"
 fi
 

--- a/end_to_end_tests/tools/run_end_to_end_tests.sh
+++ b/end_to_end_tests/tools/run_end_to_end_tests.sh
@@ -6,10 +6,10 @@
 set -e
 
 # Defaults
-DEFAULT_ELASTICSEARCH_VERSION=7.9.3
+DEFAULT_OPENSEARCH_VERSION=1.2.2
 
-# Set Elasticsearch version to run
-[ -z "$OPENSEARCH_VERSION" ] && export OPENSEARCH_VERSION=$DEFAULT_ELASTICSEARCH_VERSION
+# Set OpenSearch version to run
+[ -z "$OPENSEARCH_VERSION" ] && export OPENSEARCH_VERSION=$DEFAULT_OPENSEARCH_VERSION
 
 # Container ID for the web server
 export CONTAINER_ID="$(sudo -E docker container list -f name=e2e_timesketch -q)"


### PR DESCRIPTION
This PR changes the search backend to use OpenSearch instead of Elasticsearch.