### PR TITLE
bugfix 2097

### DIFF
--- a/contrib/deploy_timesketch.sh
+++ b/contrib/deploy_timesketch.sh
@@ -93,8 +93,8 @@ echo -n "* Edit configuration files.."
 sed -i 's#SECRET_KEY = \x27\x3CKEY_GOES_HERE\x3E\x27#SECRET_KEY = \x27'$SECRET_KEY'\x27#' timesketch/etc/timesketch/timesketch.conf
 
 # Set up the Elastic connection
-sed -i 's#^ELASTIC_HOST = \x27127.0.0.1\x27#ELASTIC_HOST = \x27'$OPENSEARCH_ADDRESS'\x27#' timesketch/etc/timesketch/timesketch.conf
-sed -i 's#^ELASTIC_PORT = 9200#ELASTIC_PORT = '$OPENSEARCH_PORT'#' timesketch/etc/timesketch/timesketch.conf
+sed -i 's#^OPENSEARCH_HOST = \x27127.0.0.1\x27#OPNSEARCH_HOST = \x27'$OPENSEARCH_ADDRESS'\x27#' timesketch/etc/timesketch/timesketch.conf
+sed -i 's#^OPENSEARCH_PORT = 9200#OPENSEARCH_PORT = '$OPENSEARCH_PORT'#' timesketch/etc/timesketch/timesketch.conf
 
 # Set up the Redis connection
 sed -i 's#^UPLOAD_ENABLED = False#UPLOAD_ENABLED = True#' timesketch/etc/timesketch/timesketch.conf


### PR DESCRIPTION
See Issue #2097 

deploy_timesketch.sh contanins:

..
 79 # Fetch default Timesketch config files
 80 curl -s $GITHUB_BASE_URL/data/timesketch.conf > timesketch/etc/timesketch/timesketch.conf
...
 95 # Set up the Elastic connection
 96 sed -i 's#^**ELASTIC_HOST** = \x27127.0.0.1\x27#**ELASTIC_HOST** = \x27'$OPENSEARCH_ADDRESS'\x27#' timesketch/etc/timesketch/timesketch.conf
 97 sed -i 's#^**ELASTIC_PORT** = 9200#**ELASTIC_PORT** = '$OPENSEARCH_PORT'#' timesketch/etc/timesketch/timesketch.conf

It is looking for the variable named ELASTIC_HOST. But in the current sample file /data/timesketch.conf which is copied at first with curl there is no such variable. 
The variable there is 

...
 29 OPENSEARCH_HOST = '127.0.0.1'
 30 OPENSEARCH_PORT = 9200
...

I altered the contrib/deploy_timesketch.sh so the fresh etc/timesketch/timesketch.conf now is created with the correct variable value.