### PR TITLE
2033 sigma date unittest

### DIFF
--- a/docs/guides/user/sigma.md
+++ b/docs/guides/user/sigma.md
@@ -162,6 +162,10 @@ You need to remember to copy your rule when you are ready and create a new file 
 When writing Rules specific for Timesketch first and foremost you should the guide from one of the creators of Sigma:
 [How to Write Sigma Rules](https://www.nextron-systems.com/2018/02/10/write-sigma-rules/).
 
+### Date format
+
+When setting the `date` field in your rule, stick to `YYYY/MM/DD`.
+
 #### Number of or
 
 On top of that, it is recommended to avoid a large chain or `or` checks.

--- a/timesketch/lib/sigma_util_test.py
+++ b/timesketch/lib/sigma_util_test.py
@@ -20,8 +20,7 @@ from __future__ import unicode_literals
 from sigma.parser import exceptions as sigma_exceptions
 
 from timesketch.lib.testlib import BaseTest
-import timesketch.lib.sigma_util as sigma_util
-import datetime
+from timesketch.lib import sigma_util
 
 
 MOCK_SIGMA_RULE = """

--- a/timesketch/lib/sigma_util_test.py
+++ b/timesketch/lib/sigma_util_test.py
@@ -17,6 +17,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import datetime
+
 from sigma.parser import exceptions as sigma_exceptions
 
 from timesketch.lib.testlib import BaseTest
@@ -90,10 +92,12 @@ class TestSigmaUtilLib(BaseTest):
             MOCK_SIGMA_RULE_ERROR1,
         )
         self.assertIn("2020/06/26", rule.get("date"))
+        self.assertIsInstance(rule.get("date"), str)
 
         rule = sigma_util.get_sigma_rule_by_text(MOCK_SIGMA_RULE_DATE_ERROR1)
         self.assertIsNotNone(MOCK_SIGMA_RULE_DATE_ERROR1)
         # it is actually: 'date': datetime.date(2022, 1, 10)
+        self.assertIsInstance(rule.get("date"), datetime.date)
         self.assertIsNot("2022-01-10", rule.get("date"))
         self.assertIn("dd23d2323432", rule.get("modified"))
 


### PR DESCRIPTION
The data field in Sigma is parsed but if given a wrong formt (from Sigma perspective) it can behaves strange, therefore some unit tests have been introduced and a documentation section was started. It is not planned at the moment to fix that date parsing on the Timesketch side.

**Checks**

- [x] All tests succeed.
- [x] Unit tests added.
- [x] e2e tests added.
- [x] Documentation updated.

**Closing issues**

closes #2033
