### PR TITLE
Fix #2051 Sketch attributes deleted via the API cannot be re-added by an analyzer

### DIFF
--- a/timesketch/lib/analyzers/interface.py
+++ b/timesketch/lib/analyzers/interface.py
@@ -464,7 +464,8 @@ class Sketch(object):
                 data/ontology.yaml.
         """
         # Check first whether the attribute already exists.
-        attribute = Attribute.query.filter_by(name=name).first()
+        attribute = Attribute.query.filter_by(
+          name=name, sketch=self.sql_sketch).first()
 
         if not attribute:
             attribute = Attribute(


### PR DESCRIPTION
Fixes #2051 - Sketch attributes deleted via the API cannot be re-added by an analyzer 

**Checks**

- [ ] All tests succeed.
- [ ] Unit tests added.
- [ ] e2e tests added.
- [ ] Documentation updated.
