### PR TITLE
Added a new BigQuery Matcher Analyzer plugin and related documentation.

### DIFF
--- a/data/bigquery_matcher.yaml
+++ b/data/bigquery_matcher.yaml
@@ -1,0 +1,24 @@
+#
+# Configuration file for the BigQuery matcher analyzer plugin.
+# 
+# You can configure several matchers. They should look like this:
+#
+# matcher_name:
+#     event_field_name: sha256_hash
+#     bq_project: 'project_name'
+#     bq_query: 'SELECT DISTINCT hash FROM project.dataset.tablename WHERE hash IN UNNEST(@sha256_hash)'
+#     tags: ['bigquery-sha256-match']
+#     emojis: ['SKULL']
+#
+# The fields are used as follows:
+#     * matcher_name: Name for the matcher entry.
+#     * event_field_name: Field name in a Timesketch event that you want to match against.
+#     * bq_project: Google Cloud Project you want to run the BigQuery job under.
+#     * bq_query: Query that is used to match Timesketch events. Results from this query 
+#       will be tagged. Match the "IN UNNEST(@sha256_hash)" part to your event_field_name.
+#       This example would tag any Timesketch events which have a "sha256_hash" field that
+#       has a matching row in BigQuery in the "hash" column.
+#     * tags: Tags to apply for matching Timesketch events.
+#     * emojis: Emojis to add for matching Timesketch events.
+# 
+

--- a/docker/dev/build/docker-entrypoint.sh
+++ b/docker/dev/build/docker-entrypoint.sh
@@ -15,6 +15,7 @@ if [ "$1" = 'timesketch' ]; then
   cp /usr/local/src/timesketch/data/generic.mappings /etc/timesketch/
   cp /usr/local/src/timesketch/data/ontology.yaml /etc/timesketch/
   cp /usr/local/src/timesketch/data/data_finder.yaml /etc/timesketch/
+  cp /usr/local/src/timesketch/data/bigquery_matcher.yaml /etc/timesketch/
   ln -s /usr/local/src/timesketch/data/sigma_config.yaml /etc/timesketch/sigma_config.yaml
   ln -s /usr/local/src/timesketch/data/sigma_blocklist.csv /etc/timesketch/sigma_blocklist.csv
   ln -s /usr/local/src/timesketch/data/sigma /etc/timesketch/

--- a/docker/e2e/Dockerfile
+++ b/docker/e2e/Dockerfile
@@ -44,6 +44,7 @@ RUN cp /tmp/timesketch/data/generic.mappings /etc/timesketch/
 RUN cp /tmp/timesketch/data/sigma_config.yaml /etc/timesketch/
 RUN cp /tmp/timesketch/data/sigma_blocklist.csv /etc/timesketch/
 RUN cp /tmp/timesketch/data/data_finder.yaml /etc/timesketch/
+RUN cp /tmp/timesketch/data/bigquery_matcher.yaml /etc/timesketch/
 RUN cp -r /tmp/timesketch/data/sigma /etc/timesketch/sigma
 RUN chmod -R go+r /etc/timesketch
 

--- a/docs/guides/user/basic-concepts.md
+++ b/docs/guides/user/basic-concepts.md
@@ -153,6 +153,25 @@ The browser time frame analyzer discovers browser events that occurred outside o
 
 The analyzer determines the activity hours by finding the frequency of browsing events per hour, and then discovering the longest block of most active hours before proceeding with flagging all events outside of that time period. This information can be used by other analyzers or by manually looking for other activity within the inactive time period to find unusual actions.
 
+#### BigQuery Matcher Analyzer
+
+The BigQuery Matcher allows tagging events that match indicators in a BigQuery table.
+
+An example could be tagging events that have a `sha256_hash` field that matches indicators stored in a BigQuery table. You can configure this by adding the following matcher into `bigquery_matcher.yaml`:
+
+```
+sha256_matcher:
+    event_field_name: sha256_hash
+    bq_project: 'my_google_project'
+    bq_query: 'SELECT DISTINCT hash FROM project.dataset.table_with_hashes WHERE hash IN UNNEST(@sha256_hash)'
+    tags: ['bigquery-sha256-match']
+    emojis: ['SKULL']
+```
+
+Any Timesketch event that has a `sha256_hash` field that matches the `hash` column value in the BigQuery table `table_with_hashes` will be tagged with `bigquery-sha256-match` and a skull emoji is added to the event.
+
+Note that Timesketch must be able to authenticate to BigQuery and have access to the tables. You can read more about setting up authentication in the relevant [Google Cloud documentation](https://cloud.google.com/docs/authentication/production).
+
 #### Chain analyzer
 
 Sketch analyzer for chained events

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,8 @@ flask_restful==0.3.7
 flask_script==2.0.6
 flask_sqlalchemy==2.4.1
 flask_wtf==0.14.2
-google-auth==1.7.0
-google_auth_oauthlib==0.4.1
+google-auth==2.5.0
+google_auth_oauthlib==0.4.6
 gunicorn==19.10.0  # Note: Last version to support py2
 numpy==1.19.0
 oauthlib==3.1.0
@@ -36,3 +36,4 @@ prometheus-client==0.9.0
 prometheus-flask-exporter==0.18.1
 decorator==5.0.5
 geoip2==4.2.0
+google-cloud-bigquery==2.32.0

--- a/timesketch/lib/analyzers/__init__.py
+++ b/timesketch/lib/analyzers/__init__.py
@@ -15,6 +15,7 @@
 
 # Register all analyzers here by importing them.
 from timesketch.lib.analyzers import account_finder
+from timesketch.lib.analyzers import bigquery_matcher
 from timesketch.lib.analyzers import browser_search
 from timesketch.lib.analyzers import browser_timeframe
 from timesketch.lib.analyzers import chain

--- a/timesketch/lib/analyzers/bigquery_matcher.py
+++ b/timesketch/lib/analyzers/bigquery_matcher.py
@@ -1,0 +1,124 @@
+"""Index analyzer plugin for matching against data in BigQuery tables."""
+from __future__ import unicode_literals
+
+import itertools
+import logging
+
+from google.cloud import bigquery
+from google.auth import exceptions as google_auth_exceptions
+
+from timesketch.lib import emojis
+from timesketch.lib.analyzers import interface
+from timesketch.lib.analyzers import manager
+
+logger = logging.getLogger('timesketch.analyzers.bigquery_matcher')
+
+
+class BigQueryMatcherPlugin(interface.BaseAnalyzer):
+    """Analyzer for matching events to BigQuery data."""
+
+    NAME = 'bigquery_matcher'
+    DISPLAY_NAME = 'BigQuery matcher'
+    DESCRIPTION = 'Match pre-defined event fields to data in BigQuery tables'
+
+    _BQ_BATCH_SIZE = 10000  # Number of entries per BQ query
+
+    def __init__(self, index_name, sketch_id, timeline_id=None, **kwargs):
+        """Initialize the BQ Matcher Analyzer.
+
+        Args:
+            index_name: OpenSearch index name
+            sketch_id: Sketch ID
+            timeline_id: The ID of the timeline
+        """
+        self.index_name = index_name
+        self._matcher_name = kwargs.get('matcher_name')
+        self._matcher_config = kwargs.get('matcher_config')
+        super().__init__(index_name, sketch_id, timeline_id=timeline_id)
+
+    @staticmethod
+    def get_kwargs():
+        """Get kwargs for the analyzer.
+
+        Returns:
+            List of matchers.
+        """
+        bq_config = interface.get_yaml_config('bigquery_matcher.yaml')
+        if not bq_config:
+            logger.error('BigQuery Matcher could not load configuration file.')
+            return []
+
+        matcher_kwargs = [{
+            'matcher_name': matcher_name,
+            'matcher_config': matcher_config
+        } for matcher_name, matcher_config in bq_config.items()]
+        return matcher_kwargs
+
+    def run(self):
+        """Entry point for the analyzer.
+
+        Returns:
+            String with summary of the analyzer result.
+        """
+        if self._matcher_name is None or self._matcher_config is None:
+            return 'Configuration file is not valid for this analyzer.'
+        return self.matcher(self._matcher_name, self._matcher_config)
+
+    def bigquery_match(self, bq_client, bq_query, event_field_name, values):
+        """Run a BigQuery query for rows with matching event_field_name values.
+
+        Returns:
+            BigQuery query job.
+        """
+        job_config = bigquery.QueryJobConfig(query_parameters=[
+            bigquery.ArrayQueryParameter(event_field_name, "STRING", values),
+        ])
+        return bq_client.query(bq_query, job_config=job_config)
+
+    def matcher(self, name, config):
+        """Entry point for the analyzer.
+
+        Returns:
+            String with summary of the analyzer result.
+        """
+        event_field_name = config.get('event_field_name')
+        bq_query = config.get('bq_query')
+        bq_project = config.get('bq_project')
+        tags = config.get('tags')
+        emoji_names = config.get('emojis')
+        emojis_to_add = [emojis.get_emoji(x) for x in emoji_names]
+
+        es_query = ('{"query": { "bool": { "should": [ '
+                    '{ "exists" : { "field" : "' + event_field_name +
+                    '" }} ] } } }')
+        events_stream = self.event_stream(
+            query_dsl=es_query,
+            return_fields=[event_field_name],
+        )
+
+        events = {}
+        for event in events_stream:
+            field = event.source.get(event_field_name)
+            events.setdefault(field, []).append(event)
+
+        try:
+            bq_client = bigquery.Client(project=bq_project)
+        except (google_auth_exceptions.DefaultCredentialsError) as exception:
+            return 'Could not authenticate to BigQuery: {0!s}'.format(exception)
+
+        num_matches = 0
+        for i in range(0, len(events), self._BQ_BATCH_SIZE):
+            batch = list(itertools.islice(events, i, i + self._BQ_BATCH_SIZE))
+            query_job = self.bigquery_match(bq_client, bq_query,
+                                            event_field_name, batch)
+            for row in query_job:
+                for event in events[row[0]]:
+                    event.add_tags(tags)
+                    event.add_emojis(emojis_to_add)
+                    event.commit()
+                    num_matches += 1
+        return ('{0:d} events found for matcher [{1:s}]').format(
+            num_matches, name)
+
+
+manager.AnalysisManager.register_analyzer(BigQueryMatcherPlugin)

--- a/timesketch/lib/analyzers/bigquery_matcher_test.py
+++ b/timesketch/lib/analyzers/bigquery_matcher_test.py
@@ -1,0 +1,94 @@
+"""Tests for BigQueryMatcher Plugin."""
+from __future__ import unicode_literals
+
+import copy
+import mock
+
+from timesketch.lib.testlib import MockDataStore
+
+from timesketch.lib.emojis import EMOJI_MAP
+from timesketch.lib.analyzers import bigquery_matcher
+from timesketch.lib.testlib import BaseTest
+
+
+class TestBigQueryMatcherPlugin(BaseTest):
+    """Tests the functionality of the analyzer."""
+
+    _TEST_EMOJI = 'SKULL'
+    _TEST_TAG = 'test-tag'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.test_index = 'test_index'
+
+    def setUp(self):
+        """Set up the tests."""
+        super().setUp()
+        self.config = {}
+        self.config['event_field_name'] = 'field_name'
+        self.config['bq_query'] = 'test_query'
+        self.config['bq_project'] = 'test_project'
+        self.config['tags'] = [self._TEST_TAG]
+        self.config['emojis'] = [self._TEST_EMOJI]
+
+    @mock.patch('timesketch.lib.analyzers.interface.OpenSearchDataStore',
+                MockDataStore)
+    @mock.patch('google.cloud.bigquery.Client')
+    def test_match_single_entry(self, mock_bq):
+        """Test that an entry is tagged correctly if it matches a row in BQ."""
+        analyzer = bigquery_matcher.BigQueryMatcherPlugin(
+            sketch_id=1, index_name=self.test_index)
+
+        analyzer.datastore.client = mock.Mock()
+        datastore = analyzer.datastore
+        test_value = '12345'
+        mock_bq().query.return_value = [[test_value]]
+        _add_event_to_datastore(datastore, 0, {'field_name': test_value})
+
+        analyzer.matcher('test_name', self.config)
+        self.assertEqual(EMOJI_MAP[self._TEST_EMOJI].code,
+                         analyzer.emoji_events['0']['emojis'][0])
+        self.assertEqual(self._TEST_TAG, analyzer.tagged_events['0']['tags'][0])
+
+    @mock.patch('timesketch.lib.analyzers.interface.OpenSearchDataStore',
+                MockDataStore)
+    @mock.patch('google.cloud.bigquery.Client')
+    def test_no_match_single_entry(self, mock_bq):
+        """Test that an entry is not tagged if it has no match in BQ."""
+        analyzer = bigquery_matcher.BigQueryMatcherPlugin(
+            sketch_id=1, index_name=self.test_index)
+
+        analyzer.datastore.client = mock.Mock()
+        datastore = analyzer.datastore
+        mock_bq().query.return_value = []
+        _add_event_to_datastore(datastore, 0, {'field_name': 'not-in-bigquery'})
+
+        analyzer.matcher('test_name', self.config)
+        self.assertFalse(analyzer.emoji_events)
+        self.assertFalse(analyzer.tagged_events)
+
+    @mock.patch('timesketch.lib.analyzers.interface.OpenSearchDataStore',
+                MockDataStore)
+    @mock.patch('google.cloud.bigquery.Client')
+    def test_query_batching(self, mock_bq):
+        """Test that queries are batched correctly."""
+        analyzer = bigquery_matcher.BigQueryMatcherPlugin(
+            sketch_id=1, index_name=self.test_index)
+
+        analyzer.datastore.client = mock.Mock()
+        datastore = analyzer.datastore
+        mock_bq().query.return_value = []
+        # Need to access protected members for testing purposes.
+        # pylint: disable=protected-access
+        for i in range(analyzer._BQ_BATCH_SIZE + 1):
+            _add_event_to_datastore(datastore, i, {'field_name': str(i)})
+
+        analyzer.matcher('test_name', self.config)
+        self.assertEqual(mock_bq().query.call_count, 2)
+
+
+def _add_event_to_datastore(datastore, event_id, attributes_dict):
+    event = copy.deepcopy(MockDataStore.event_dict)
+    event['_source'].update(attributes_dict)
+    datastore.import_event('test_index', 'test_event', event['_source'],
+                           str(event_id))


### PR DESCRIPTION
https://github.com/google/timesketch/issues/2130

+ What existing problem does this PR solve?

It allows matching Timesketch event metadata against indicators stored in a BigQuery table.

+ What new feature is being introduced with this PR?

A new BigQuery Analyzer plugin.

+ Overview of changes to existing functions if required.

The PR adds a single analyzer plugin, along with tests.

**Checks**

- [X] All tests succeed.
- [X] Unit tests added.
- [ ] e2e tests added.
- [X ] Documentation updated.

I didn't add e2e tests, as it looked tricky to test with BQ in the current e2e test setup? Happy to do so if you give me a tip how.
