### PR TITLE
Fix for broken Pip package (upstream)

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
+        # Pin pip to pip==21.3.1 due to upstream bug in pip.
+        # TODO: Revisit and remove this when fixed upstream.
         run: |
           pip install astroid==2.4.0
           pip install pylint==2.6.0

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -19,9 +19,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        # Pin pip to pip==21.3.1 due to upstream bug in pip.
+        # Pin pip to pip==22.0.3 due to upstream bug in pip.
         # TODO: Revisit and remove this when fixed upstream.
         run: |
+          pip install -U pip==22.0.3
           pip install astroid==2.4.0
           pip install pylint==2.6.0
           pip install -r test_requirements.txt


### PR DESCRIPTION
Related to upstream bug: https://github.com/pypa/pip/issues/10851
We need at least pip 22.0.3 that have a fix for this.