### PR TITLE
Reduce load time for the CLI client

### DIFF
--- a/cli_client/python/timesketch_cli_client/cli.py
+++ b/cli_client/python/timesketch_cli_client/cli.py
@@ -20,7 +20,7 @@ from requests.exceptions import ConnectionError as RequestConnectionError
 
 from timesketch_cli_client.commands import analyze
 from timesketch_cli_client.commands import config
-from timesketch_cli_client.commands import importer
+from timesketch_cli_client.commands import upload
 from timesketch_cli_client.commands import search
 from timesketch_cli_client.commands import sketch as sketch_command
 from timesketch_cli_client.commands import timelines
@@ -163,7 +163,7 @@ cli.add_command(search.search_group)
 cli.add_command(search.saved_searches_group)
 cli.add_command(analyze.analysis_group)
 cli.add_command(sketch_command.sketch_group)
-cli.add_command(importer.importer)
+cli.add_command(upload.upload)
 cli.add_command(version.version)
 
 

--- a/cli_client/python/timesketch_cli_client/cli.py
+++ b/cli_client/python/timesketch_cli_client/cli.py
@@ -26,9 +26,9 @@ from timesketch_cli_client.commands import importer
 from timesketch_cli_client.commands import search
 from timesketch_cli_client.commands import sketch as sketch_command
 from timesketch_cli_client.commands import timelines
+from timesketch_cli_client.commands import version
 
 from .definitions import DEFAULT_OUTPUT_FORMAT
-from .version import get_version
 
 
 class TimesketchCli(object):
@@ -108,7 +108,6 @@ class TimesketchCli(object):
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
-@click.version_option(version=get_version(), prog_name="Timesketch CLI")
 @click.option("--sketch", type=int, default=None, help="Sketch to work in.")
 @click.pass_context
 def cli(ctx, sketch):
@@ -136,6 +135,7 @@ cli.add_command(search.saved_searches_group)
 cli.add_command(analyze.analysis_group)
 cli.add_command(sketch_command.sketch_group)
 cli.add_command(importer.importer)
+cli.add_command(version.version)
 
 
 # pylint: disable=no-value-for-parameter

--- a/cli_client/python/timesketch_cli_client/commands/analyze.py
+++ b/cli_client/python/timesketch_cli_client/commands/analyze.py
@@ -17,8 +17,6 @@ import time
 
 import click
 
-from timesketch_api_client import error
-
 
 @click.group("analyze")
 def analysis_group():
@@ -49,6 +47,8 @@ def run_analyzer(ctx, analyzer_name, timeline_id):
         analyzer_name: Name of the analyzer to run.
         timeline_id: Timeline ID of the timeline to analyze.
     """
+    from timesketch_api_client import error
+
     sketch = ctx.obj.sketch
     timelines = []
     if timeline_id == "all":

--- a/cli_client/python/timesketch_cli_client/commands/config.py
+++ b/cli_client/python/timesketch_cli_client/commands/config.py
@@ -17,8 +17,6 @@ import sys
 
 import click
 
-from timesketch_cli_client.definitions import SUPPORTED_OUTPUT_FORMATS
-
 
 @click.group("config")
 def config_group():
@@ -34,12 +32,7 @@ def set_group():
 @click.argument("sketch_id")
 @click.pass_context
 def set_sketch(ctx, sketch_id):
-    """Set the active sketch.
-
-    Args:
-        ctx: Click CLI context object.
-        sketch_id: ID of the sketch to save to config.
-    """
+    """Set the active sketch."""
     ctx.obj.config_assistant.set_config("sketch", sketch_id)
     ctx.obj.config_assistant.save_config()
 
@@ -48,12 +41,9 @@ def set_sketch(ctx, sketch_id):
 @click.argument("output_format")
 @click.pass_context
 def set_output_format(ctx, output_format):
-    """Set the output format.
+    """Set the output format."""
+    from timesketch_cli_client.definitions import SUPPORTED_OUTPUT_FORMATS
 
-    Args:
-        ctx: Click CLI context object.
-        output_format: Format to use for output text.
-    """
     if output_format not in SUPPORTED_OUTPUT_FORMATS:
         supported_formats = " ".join(SUPPORTED_OUTPUT_FORMATS)
         click.echo(f"Unsupported format. Choose between {supported_formats}")

--- a/cli_client/python/timesketch_cli_client/commands/importer.py
+++ b/cli_client/python/timesketch_cli_client/commands/importer.py
@@ -17,7 +17,6 @@ import sys
 import time
 
 import click
-from timesketch_import_client import importer as import_client
 
 
 @click.command("import")
@@ -26,14 +25,9 @@ from timesketch_import_client import importer as import_client
 @click.argument("file_path", type=click.Path(exists=True))
 @click.pass_context
 def importer(ctx, name, timeout, file_path):
-    """Import timeline.
+    """Import timeline."""
+    from timesketch_import_client import importer as import_client
 
-    Args:
-        ctx: Click CLI context object.
-        name: Name of the timeline to create.
-        timeout: Seconds to wait for indexing.
-        file_path: File path to the file to import.
-    """
     sketch = ctx.obj.sketch
     if not name:
         name = click.format_filename(file_path, shorten=True)

--- a/cli_client/python/timesketch_cli_client/commands/search.py
+++ b/cli_client/python/timesketch_cli_client/commands/search.py
@@ -17,9 +17,6 @@ import json
 import sys
 
 import click
-from tabulate import tabulate
-
-from timesketch_api_client import search
 
 
 def format_output(search_obj, output_format, show_headers):
@@ -33,6 +30,7 @@ def format_output(search_obj, output_format, show_headers):
     Returns:
         Search results in the requested output format.
     """
+    from tabulate import tabulate
     dataframe = search_obj.to_pandas()
 
     # Label is being set regardless of return_fields. Remove if it is not in
@@ -72,7 +70,8 @@ def describe_query(search_obj):
 
 @click.command("search")
 @click.option(
-    "--query", "-q", default="*", help="Search query in OpenSearch query string format"
+    "--query", "-q", help="Search query in OpenSearch query string format",
+    required=True
 )
 @click.option(
     "--time", "times", multiple=True, help="Datetime filter (e.g. 2020-01-01T12:00)"
@@ -126,6 +125,8 @@ def search_group(
     describe,
 ):
     """Search and explore."""
+    from timesketch_api_client import search
+
     sketch = ctx.obj.sketch
     output_format = ctx.obj.output_format
     search_obj = search.Search(sketch=sketch)

--- a/cli_client/python/timesketch_cli_client/commands/search.py
+++ b/cli_client/python/timesketch_cli_client/commands/search.py
@@ -210,7 +210,7 @@ def search_group(
 
 @click.group("saved-searches")
 def saved_searches_group():
-    """Managed saved searches."""
+    """Manage saved searches."""
 
 
 @saved_searches_group.command("list")

--- a/cli_client/python/timesketch_cli_client/commands/search.py
+++ b/cli_client/python/timesketch_cli_client/commands/search.py
@@ -31,6 +31,7 @@ def format_output(search_obj, output_format, show_headers):
         Search results in the requested output format.
     """
     from tabulate import tabulate
+
     dataframe = search_obj.to_pandas()
 
     # Label is being set regardless of return_fields. Remove if it is not in
@@ -70,8 +71,10 @@ def describe_query(search_obj):
 
 @click.command("search")
 @click.option(
-    "--query", "-q", help="Search query in OpenSearch query string format",
-    required=True
+    "--query",
+    "-q",
+    help="Search query in OpenSearch query string format",
+    required=True,
 )
 @click.option(
     "--time", "times", multiple=True, help="Datetime filter (e.g. 2020-01-01T12:00)"

--- a/cli_client/python/timesketch_cli_client/commands/sketch.py
+++ b/cli_client/python/timesketch_cli_client/commands/sketch.py
@@ -25,7 +25,7 @@ def sketch_group():
 @click.pass_context
 def list_sketches(ctx):
     """List all sketches."""
-    api_client = ctx.obj.api
+    api_client = ctx.obj.api_client
     for sketch in api_client.list_sketches():
         click.echo(f"{sketch.id} {sketch.name}")
 
@@ -48,7 +48,7 @@ def describe_sketch(ctx):
 @click.pass_context
 def create_sketch(ctx, name, description):
     """Create a new sketch."""
-    api_client = ctx.obj.api
+    api_client = ctx.obj.api_client
     if not description:
         description = name
     sketch = api_client.create_sketch(name=name, description=description)

--- a/cli_client/python/timesketch_cli_client/commands/upload.py
+++ b/cli_client/python/timesketch_cli_client/commands/upload.py
@@ -19,13 +19,13 @@ import time
 import click
 
 
-@click.command("import")
+@click.command("upload")
 @click.option("--name", help="Name of the timeline.")
 @click.option("--timeout", type=int, default=600, help="Seconds to wait for indexing.")
 @click.argument("file_path", type=click.Path(exists=True))
 @click.pass_context
-def importer(ctx, name, timeout, file_path):
-    """Import timeline."""
+def upload(ctx, name, timeout, file_path):
+    """Upload a timeline to the server."""
     from timesketch_import_client import importer as import_client
 
     sketch = ctx.obj.sketch
@@ -72,4 +72,4 @@ def importer(ctx, name, timeout, file_path):
         retry_count += 1
         time.sleep(sleep_time_seconds)
 
-    click.echo(f"Timeline imported: {timeline.name}")
+    click.echo(f"Timeline uploaded: {timeline.name}")

--- a/cli_client/python/timesketch_cli_client/commands/version.py
+++ b/cli_client/python/timesketch_cli_client/commands/version.py
@@ -17,7 +17,8 @@ import click
 
 from ..version import get_version
 
+
 @click.command("version")
 def version():
-    """Version."""
-    click.echo(f'Timesketch CLI version {get_version()}')
+    """Tool version."""
+    click.echo(f"Timesketch CLI version {get_version()}")

--- a/cli_client/python/timesketch_cli_client/commands/version.py
+++ b/cli_client/python/timesketch_cli_client/commands/version.py
@@ -20,5 +20,5 @@ from ..version import get_version
 
 @click.command("version")
 def version():
-    """Tool version."""
+    """Get the version of this tool."""
     click.echo(f"Timesketch CLI version {get_version()}")

--- a/cli_client/python/timesketch_cli_client/commands/version.py
+++ b/cli_client/python/timesketch_cli_client/commands/version.py
@@ -1,0 +1,23 @@
+# Copyright 2022 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Commands for importing timelines."""
+
+import click
+
+from ..version import get_version
+
+@click.command("version")
+def version():
+    """Version."""
+    click.echo(f'Timesketch CLI version {get_version()}')

--- a/cli_client/python/timesketch_cli_client/version.py
+++ b/cli_client/python/timesketch_cli_client/version.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Version information for the Timesketch CLI client."""
 
-__version__ = "20220411"
+__version__ = "20220414"
 
 
 def get_version():


### PR DESCRIPTION
This PR refactors how we do imports in the CLI client. The current implementation  has some slow imports (the API client with cloud dependencies etc). The way Click works is it imports all commands at startup.

By moving the imports in the commands to inline with the function we lazy import when needed. This speeds up the UI significantly.

I also refactored the state object, moving initializing the API client and config assistant to properties instead, with the ability to cache the objects (for commands that access them multiple times).

These changes reduced time to load the tool from ~1.4s -> ~0.2s. Making the tool much snappier to use.

* Further more, some cleanup of help messages, and the renaming of `import` to `upload` to make it more intuitive.