### PR TITLE
Allow OIDC API clients to consume OAuth tokens from several clients

### DIFF
--- a/data/timesketch.conf
+++ b/data/timesketch.conf
@@ -134,7 +134,12 @@ GOOGLE_OIDC_CLIENT_SECRET = None
 # an OAUTH client for "other", or for native applications.
 # https://developers.google.com/identity/protocols/OAuth2ForDevices
 GOOGLE_OIDC_API_CLIENT_ID = None
+# Currently not used, API clients initializes TimesketchApi using CLIENT_ID and CLIENT_SECRET
+# in client code. The server only verifies the CLIENT_ID used is available in
+# GOOGLE_OIDC_API_CLIENT_ID or WHITELISTED_GOOGLE_OIDC_API_CLIENT_IDS.
 GOOGLE_OIDC_API_CLIENT_SECRET = None
+# Comma-seperated list of whitelisted GOOGLE OIDC clients that can authenticate to the APIs
+WHITELISTED_GOOGLE_OIDC_API_CLIENT_IDS = None
 
 # Limit access to a specific Google GSuite domain.
 GOOGLE_OIDC_HOSTED_DOMAIN = None

--- a/data/timesketch.conf
+++ b/data/timesketch.conf
@@ -136,10 +136,10 @@ GOOGLE_OIDC_CLIENT_SECRET = None
 GOOGLE_OIDC_API_CLIENT_ID = None
 # Currently not used, API clients initializes TimesketchApi using CLIENT_ID and CLIENT_SECRET
 # in client code. The server only verifies the CLIENT_ID used is available in
-# GOOGLE_OIDC_API_CLIENT_ID or WHITELISTED_GOOGLE_OIDC_API_CLIENT_IDS.
+# GOOGLE_OIDC_API_CLIENT_ID or ALLOWED_GOOGLE_OIDC_API_CLIENT_IDS.
 GOOGLE_OIDC_API_CLIENT_SECRET = None
-# Comma-seperated list of whitelisted GOOGLE OIDC clients that can authenticate to the APIs
-WHITELISTED_GOOGLE_OIDC_API_CLIENT_IDS = None
+# List of allowed GOOGLE OIDC clients that can authenticate to the APIs
+ALLOWED_GOOGLE_OIDC_API_CLIENT_IDS = []
 
 # Limit access to a specific Google GSuite domain.
 GOOGLE_OIDC_HOSTED_DOMAIN = None

--- a/timesketch/views/auth.py
+++ b/timesketch/views/auth.py
@@ -194,14 +194,11 @@ def validate_api_token():
     if not id_token:
         return abort(HTTP_STATUS_CODE_UNAUTHORIZED, "No ID token supplied.")
 
-    client_ids = []
-    client_ids.append(current_app.config.get("GOOGLE_OIDC_CLIENT_ID"))
-    additional_client_ids = current_app.config.get(
-        "WHITELISTED_GOOGLE_OIDC_API_CLIENT_IDS")
-    if additional_client_ids:
-        client_ids.extend("".join(additional_client_ids.split()).split(","))
-    # Remove None and empty strings.
-    client_ids = [x for x in client_ids if x]
+    client_ids = set()
+    client_ids.add(current_app.config.get("GOOGLE_OIDC_CLIENT_ID"))
+    client_ids.update(current_app.config.get(
+        "ALLOWED_GOOGLE_OIDC_API_CLIENT_IDS"))
+    client_ids = list(client_ids)
     if not client_ids:
         return abort(
             HTTP_STATUS_CODE_BAD_REQUEST,

--- a/timesketch/views/auth.py
+++ b/timesketch/views/auth.py
@@ -199,7 +199,7 @@ def validate_api_token():
     additional_client_ids = current_app.config.get(
         "WHITELISTED_GOOGLE_OIDC_API_CLIENT_IDS")
     if additional_client_ids:
-      client_ids.extend("".join(additional_client_ids.split()).split(","))
+        client_ids.extend("".join(additional_client_ids.split()).split(","))
     # Remove None and empty strings.
     client_ids = [x for x in client_ids if x]
     if not client_ids:
@@ -267,7 +267,7 @@ def validate_api_token():
         )
 
     read_client_id = token_json.get("aud", "")
-    if read_client_id != client_id:
+    if read_client_id not in client_ids:
         return abort(
             HTTP_STATUS_CODE_UNAUTHORIZED,
             "Client ID {0:s} does not match server configuration for "


### PR DESCRIPTION
Allow OIDC API clients to use OAuth tokens issued by several whitelisted clients for the same user account. OAuth-flow and session authorization are done as part of the client code in case of using client API, the client is redirected to login/api_callback which now allows all the OIDC client_ids whitelisted in config.



closes #2208
