### PR TITLE
[Sigma] Adding fs:bodyfile:entry to keep up with plaso output

### DIFF
--- a/data/sigma_config.yaml
+++ b/data/sigma_config.yaml
@@ -100,6 +100,7 @@ logsources:
         - "fs:stat"
         - "fs:mactime:line"
         - "filesystem:santa:entry"
+        - "fs:bodyfile:entry"
   sysmon:
     service: sysmon
     conditions:


### PR DESCRIPTION
To be prepared for: https://github.com/log2timeline/plaso/pull/4132

We adding another option to be checked if one uses filesystem as type. That should make the data mapping compatible with both the legacy and the new format that plaso will prepare compatible.