### PR TITLE
Pinning the opensearch container to version 1.3.2. to fix #2195

### DIFF
--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -33,7 +33,7 @@ services:
 
   opensearch:
     container_name: opensearch
-    image: opensearchproject/opensearch:latest
+    image: opensearchproject/opensearch:1.3.2
     restart: always
     environment:
       - discovery.type=single-node


### PR DESCRIPTION
The `docker/dev/docker-compose.yml` file does use the `image: opensearchproject/opensearch:latest` container. Opensearch was recently (~14 days ago) [updated to version 2.0.0](https://hub.docker.com/r/opensearchproject/opensearch/tags). Using this latest version of opensearch does break multiple things in timesketch, e.g. issue #2195 or some analyzers.

This PR will pin the opensearch version in the `docker/dev/docker-compose.yml` file to the last working version of `1.3.2`.

**Checks**

- [X] All tests succeed.
- [ ] ~~Unit tests added.~~
- [ ] ~~e2e tests added.~~
- [ ] ~~Documentation updated.~~

**Closing issues**
`closes #2195`
