### PR TITLE
Adjusted client.py to throw an error if no usable tty is found

### DIFF
--- a/api_client/python/timesketch_api_client/client.py
+++ b/api_client/python/timesketch_api_client/client.py
@@ -247,7 +247,7 @@ class TimesketchApi:
         if run_server:
             _ = flow.run_local_server()
         else:
-            if not sys.stdout.isatty():
+            if not sys.stdout.isatty() or not sys.stdin.isatty():
                 msg = ('You will be asked to paste a token into this session to'
                     'authenticate, but the session doesn\'t have a tty')
                 raise RuntimeError(msg)

--- a/api_client/python/timesketch_api_client/client.py
+++ b/api_client/python/timesketch_api_client/client.py
@@ -16,6 +16,7 @@ from __future__ import unicode_literals
 
 import os
 import logging
+import sys
 
 # pylint: disable=wrong-import-order
 import bs4
@@ -246,6 +247,11 @@ class TimesketchApi:
         if run_server:
             _ = flow.run_local_server()
         else:
+            if not sys.stdout.isatty():
+                msg = ('You will be asked to paste a token into this session to'
+                    'authenticate, but the session doesn\'t have a tty')
+                raise RuntimeError(msg)
+
             auth_url, _ = flow.authorization_url(prompt="select_account")
 
             if skip_open:


### PR DESCRIPTION
As per #2222 - In scenarios where a tty is not available, and a user needs to (re)authenticate, the url is not presented to the user, and they cannot provide the token required. Instead, the client will block on stdin, waiting for the token the user cannot provide.

This PR adds a check that the tty is usable (as in, can present a URL and receive a token via stdin) and if not, provide that information to the user via a runtime error. 

**Closing issues**
Closes #2222