### PR TITLE
Update Spelling Across docs

### DIFF
--- a/docs/guides/admin/upgrade.md
+++ b/docs/guides/admin/upgrade.md
@@ -40,7 +40,7 @@ In case you don't get any response back from the `db current` command you'll nee
 root@<CONTAINER_ID>$ tsctl db history
 ```
 
-Find the lasat revision number you have upgraded the database too, and then issue
+Find the last revision number you have upgraded the database too, and then issue
 
 ```shell
 root@<CONTAINER_ID>$ tsctl db stamp <REVISION_ID>

--- a/docs/guides/user/basic-concepts.md
+++ b/docs/guides/user/basic-concepts.md
@@ -26,7 +26,7 @@ This feature is currently not implemented in the Web UI. But you can add events 
 
 ## Add a comment
 
-You can comment events in your sketch. The comments are safed in your sketch, that means if you add a timeline to multiple sketches, the comments are only shown in the one sketch you made the comments.
+You can comment events in your sketch. The comments are saved in your sketch, that means if you add a timeline to multiple sketches, the comments are only shown in the one sketch you made the comments.
 
 ## Star an event
 
@@ -38,7 +38,7 @@ Views are saved search queries. Those can either be created by the User, by API 
 
 To create a view from the Web Ui, click the _Save as view_ button on the top right of the Search fields in the Explore Tab of a sketch.
 
-## Insights / Aggegations
+## Insights / Aggregations
 
 The _Insights_ functionality in a sketch gives the opportunity to run aggregations on the events in a sketch.
 

--- a/docs/guides/user/cli-client.md
+++ b/docs/guides/user/cli-client.md
@@ -10,7 +10,7 @@ including:
 
 ## Installing
 
-The CLI client is available as a packag on PyPi. To install, simply:
+The CLI client is available as a package on PyPi. To install, simply:
 
 ```
 pip3 install timesketch-cli-client
@@ -19,7 +19,7 @@ pip3 install timesketch-cli-client
 ## Basic usage
 
 The command line program is called `timesketch`. To see the help menu you can
-invoke without ay parameters alternativly issue `timesketch --help`.
+invoke without ay parameters alternatively issue `timesketch --help`.
 
 ```
 $ timesketch
@@ -58,7 +58,7 @@ Commands:
 #### Default sketch
 
 The program need to know what sketch you are working in. You can either specify it
-with the `--sketch` flag on all invocations, or you can configure it globaly:
+with the `--sketch` flag on all invocations, or you can configure it globally:
 
 ```
 timesketch config set sketch <ID of your sketch>

--- a/docs/guides/user/sigma.md
+++ b/docs/guides/user/sigma.md
@@ -175,7 +175,7 @@ This feature can be helpful if you want to test out field mapping.
 
 From the parse result you can copy the `es_query` value and paste it in a new window where you have the explore of a Sketch open.
 
-You need to remember to copy your rule when you are ready and create a new file on your Timesketch server to store the rule and make it available to others. The text from the compose area will be resetted with each reload of the page.
+You need to remember to copy your rule when you are ready and create a new file on your Timesketch server to store the rule and make it available to others. The text from the compose area will be reset with each reload of the page.
 
 ### Best practices
 
@@ -237,7 +237,7 @@ detection:
 That will create two queries:
 ` *value1* or *value2* or *value3* ... or *value10*` and ` *value11* or *value12* or *value13* ... or *value20*`.
 
-The Sigma analyzer is designed to batch and throttle execution of queries which is benefitial for such rule structure.
+The Sigma analyzer is designed to batch and throttle execution of queries which is beneficial for such rule structure.
 
 ### Reduce the haystack
 


### PR DESCRIPTION
Addresses no open issue or bug.

## docs/guides/admin/upgrade.md
line 43: `lasat` -> `last`

## docs/guides/user/basic-concepts.md
line 29: `safed` -> `saved`
line 41: `Aggegations` -> `Aggregations`

## docs/guides/user/cli-client.md
line 13: `packag` -> `package`
line 22: `alternativly` -> `alternatively`
line 61: `globaly` -> `globally`

## docs/guides/user/sigma.md
line 178: `resetted` -> `reset`
line 240: `benefitial` -> `beneficial`
