### PR TITLE
Read "requester" from the correct location in plaso metadata

### DIFF
--- a/contrib/gcs_importer.py
+++ b/contrib/gcs_importer.py
@@ -168,7 +168,9 @@ def callback(message):
 
     with open(local_metadata_file, "r") as metadata_file:
         metadata = json.load(metadata_file)
-        username = metadata.get("requester")
+        username = metadata.get("globals", {}).get("requester")
+        if not username: 
+            username = metadata.get("requester")  # Backwards compatibility for old Turbinia versions.
         sketch_id_from_metadata = metadata.get("sketch_id")
 
     if not username:


### PR DESCRIPTION
+ What existing problem does this PR solve?

The GCS importer was not reading the "requester" field correctly from plaso metadata.

https://github.com/google/timesketch/issues/2242 


**Checks**

- [x] All tests succeed.
- [] Unit tests added.
- [ ] e2e tests added.
- [ ] Documentation updated.

**Closing issues**

closes #2242 
