### PR TITLE
Change link to upload timeline documentation in UI

### DIFF
--- a/timesketch/frontend/src/views/Timelines.vue
+++ b/timesketch/frontend/src/views/Timelines.vue
@@ -42,7 +42,7 @@ limitations under the License.
                 <br />
                 If you are uploading a CSV or JSONL file make sure to read the
                 <a
-                  href="https://github.com/google/timesketch/blob/master/docs/Users-Guide.md#adding-timelines"
+                  href="https://timesketch.org/guides/user/import-from-json-csv/"
                   rel="noreferrer"
                   target="_blank"
                   >documentation</a


### PR DESCRIPTION
Fixes the link displayed to users to lean more about uploading timelines.

**Closing issues**

closes #2246