### PR TITLE
Feature: Add new IOCs from the UI

### DIFF
--- a/timesketch/api/v1/resources_test.py
+++ b/timesketch/api/v1/resources_test.py
@@ -590,6 +590,7 @@ class IntelligenceResourceTest(BaseTest):
             "legit": {"class": "success", "weight": 10},
             "malware": {"class": "danger", "weight": 100},
             "suspicious": {"class": "warning", "weight": 50},
+            'regexes': {'^GROUPNAME': {'class': 'danger', 'weight': 100}},
         }
         self.login()
         response = self.client.get("/api/v1/intelligence/tagmetadata/")

--- a/timesketch/frontend/src/components/Common/ExplorePreview.vue
+++ b/timesketch/frontend/src/components/Common/ExplorePreview.vue
@@ -14,14 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <template>
-  <span v-if="previewData.length" @mouseenter="delayDisplay(true, 0)" @mouseleave="delayDisplay(false, 500)">
+  <!-- Floating -->
+  <span
+    v-if="previewData.length && !displayInline"
+    @mouseenter="delayDisplay(true, 0)"
+    @mouseleave="delayDisplay(false, 500)"
+  >
     <b-tag rounded type="is-success is-light">
       <span class="icon is-medium"><i class="fas fa-eye" aria-hidden="true"></i></span>
       {{ previewData.length }}
     </b-tag>
-    <div class="preview-box" v-show="isOpen">
+    <div class="preview-box-floating" v-show="isOpen">
       <div class="preview-title">
-        Previewing results for <code>{{ searchQuery['q'] }}</code>
+        Previewing results for <code>{{ searchQuery }}</code>
       </div>
       <event-list
         :eventList="previewData"
@@ -32,6 +37,21 @@ limitations under the License.
       ></event-list>
     </div>
   </span>
+
+  <!-- Inline -->
+  <span v-else-if="displayInline">
+    Live preview: {{ previewData.length || 'No' }} matching events.
+    <event-list
+      v-if="previewData.length"
+      :eventList="previewData"
+      order="asc"
+      :displayOptions="{ showEmojis: false, showMillis: false, showTags: true }"
+      :selectedFields="[{ field: 'message', type: 'text' }]"
+      :searchNode="previewSearchNode"
+    ></event-list>
+  </span>
+
+  <!-- No results -->
   <b-tag v-else rounded type="is-light" style="opacity: 0.5">
     <span class="icon is-medium"><i class="fas fa-eye-slash" aria-hidden="true"></i></span>0
   </b-tag>
@@ -40,10 +60,14 @@ limitations under the License.
 <script>
 import ApiClient from '../../utils/RestApiClient'
 import EventList from '../Explore/EventList'
+import _ from 'lodash'
 
 export default {
   components: { EventList },
-  props: ['searchQuery'],
+  props: {
+    searchQuery: [String],
+    displayInline: { type: Boolean, default: false },
+  },
   data() {
     return {
       previewData: [],
@@ -83,15 +107,15 @@ export default {
     this.refreshPreview()
   },
   watch: {
-    searchQuery: function (newQuery) {
+    searchQuery: _.debounce(function (newQuery) {
       this.refreshPreview(newQuery)
-    },
+    }, 300),
   },
 }
 </script>
 
 <style scoped lang="scss">
-.preview-box {
+.preview-box-floating {
   z-index: 100;
   position: absolute;
   background: var(--background-color);

--- a/timesketch/frontend/src/components/Common/ExplorePreview.vue
+++ b/timesketch/frontend/src/components/Common/ExplorePreview.vue
@@ -121,7 +121,7 @@ export default {
   background: var(--background-color);
   width: 60%;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
-  height: 50%;
+  height: auto;
   overflow: scroll;
 }
 

--- a/timesketch/frontend/src/components/Common/TsIocCompose.vue
+++ b/timesketch/frontend/src/components/Common/TsIocCompose.vue
@@ -1,0 +1,95 @@
+<template>
+  <div>
+    <section class="box">
+      <h1 class="subtitle">Compose IOC</h1>
+      <b-field label-position="on-border">
+        <b-input custom-class="ioc-input" type="textarea" v-model="composeIoc.ioc"></b-input>
+      </b-field>
+      <b-field grouped>
+        <b-field>
+          <b-select placeholder="IOC type" v-model="composeIoc.type" label="IOC type" label-position="on-border">
+            <option v-for="option in IOCTypes" :value="option.type" :key="option.type">
+              {{ option.type }}
+            </option>
+          </b-select>
+        </b-field>
+        <b-field>
+          <b-taginput
+            v-model="composeIoc.tags"
+            ellipsis
+            icon="label"
+            placeholder="Add a tag"
+            aria-close-label="Delete this tag"
+          >
+          </b-taginput>
+        </b-field>
+        <b-field grouped expanded position="is-right">
+          <p class="control">
+            <b-button type="is-primary" @click="saveIoc">Save</b-button>
+          </p>
+          <p class="control">
+            <b-button @click="$parent.close()">Cancel</b-button>
+          </p>
+        </b-field>
+      </b-field>
+      <b-field label="External reference (URI)">
+        <b-input v-model="composeIoc.externalURI"></b-input>
+      </b-field>
+    </section>
+  </div>
+</template>
+
+<script>
+import _ from 'lodash'
+import ApiClient from '@/utils/RestApiClient'
+import { IOCTypes } from '@/utils/tagMetadata'
+import ExplorePreview from '@/components/Common/ExplorePreview'
+
+export default {
+  components: { ExplorePreview },
+  props: ['value'],
+  data() {
+    return {
+      composeIoc: JSON.parse(JSON.stringify(this.value)),
+      IOCTypes: IOCTypes,
+    }
+  },
+  methods: {
+    saveIoc() {
+      this.$parent.close()
+      this.$emit('input', this.composeIoc)
+    },
+  },
+  computed: {
+    sketch() {
+      return this.$store.state.sketch
+    },
+    meta() {
+      return this.$store.state.meta
+    },
+  },
+}
+</script>
+
+<style lang="scss">
+.ioc-input {
+  font-family: monospace;
+}
+
+.delete-ioc {
+  cursor: pointer;
+  color: #da1039;
+}
+
+.fa-question-circle {
+  margin-left: 0.6em;
+  opacity: 0.5;
+}
+
+.new-ioc i {
+  margin-right: 0.5em;
+}
+.new-ioc {
+  margin-left: 0.5em;
+}
+</style>

--- a/timesketch/frontend/src/components/Common/TsIocCompose.vue
+++ b/timesketch/frontend/src/components/Common/TsIocCompose.vue
@@ -45,8 +45,6 @@
 </template>
 
 <script>
-import _ from 'lodash'
-import ApiClient from '@/utils/RestApiClient'
 import { IOCTypes } from '@/utils/tagMetadata'
 import ExplorePreview from '@/components/Common/ExplorePreview'
 

--- a/timesketch/frontend/src/components/Common/TsIocCompose.vue
+++ b/timesketch/frontend/src/components/Common/TsIocCompose.vue
@@ -35,6 +35,11 @@
       <b-field label="External reference (URI)">
         <b-input v-model="composeIoc.externalURI"></b-input>
       </b-field>
+      <explore-preview
+        style="margin-left: 10px"
+        :searchQuery="generateOpenSearchQuery(composeIoc.ioc)['q']"
+        :display-inline="true"
+      ></explore-preview>
     </section>
   </div>
 </template>
@@ -58,6 +63,18 @@ export default {
     saveIoc() {
       this.$parent.close()
       this.$emit('input', this.composeIoc)
+    },
+    generateOpenSearchQuery(value, field) {
+      if (value === undefined) {
+        return { q: '' }
+      }
+      let query = `"${value}"`
+      // Escape special OpenSearch characters: \, [space]
+      query = query.replace(/[\\\s]/g, '\\$&')
+      if (field !== undefined) {
+        query = `${field}:${query}`
+      }
+      return { q: query }
     },
   },
   computed: {


### PR DESCRIPTION
Fixes #2253

* Moved the `Edit IOC` modal to a new component: `TsIocCompose.vue`
* Added a feature to be able to inline `ExplorePreview` if we don't need the "compact" (icon + hover) feature.

New add button:

![image](https://user-images.githubusercontent.com/1257972/180230347-ff007415-98f8-4d07-bc73-11a5513f805a.png)

Live preview while typing IOC:

![image](https://user-images.githubusercontent.com/1257972/180230466-7a48c8bc-f18c-43c4-82f5-9b53b94d91e8.png)
