### PR TITLE
UI 2255

### DIFF
--- a/docker/dev/restart.sh
+++ b/docker/dev/restart.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export CONTAINER_ID="$(docker container list -f name=timesketch-dev -q)"
+docker exec -d $CONTAINER_ID celery -A timesketch.lib.tasks worker --loglevel info
+docker exec -d $CONTAINER_ID gunicorn --reload -b 0.0.0.0:5000 --log-file - --timeout 600 -c /usr/local/src/timesketch/data/gunicorn_config.py timesketch.wsgi:application

--- a/docker/dev/restart.sh
+++ b/docker/dev/restart.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-export CONTAINER_ID="$(docker container list -f name=timesketch-dev -q)"
-docker exec -d $CONTAINER_ID celery -A timesketch.lib.tasks worker --loglevel info
-docker exec -d $CONTAINER_ID gunicorn --reload -b 0.0.0.0:5000 --log-file - --timeout 600 -c /usr/local/src/timesketch/data/gunicorn_config.py timesketch.wsgi:application

--- a/timesketch/frontend/src/components/Timelines/TimelineListItem.vue
+++ b/timesketch/frontend/src/components/Timelines/TimelineListItem.vue
@@ -381,8 +381,10 @@ export default {
       ApiClient.getSketchTimeline(this.sketch.id, this.timeline.id)
         .then(response => {
           this.timelineStatus = response.data.objects[0].status[0].status
-          if (this.timelineStatus !== 'ready') {
+          if (this.timelineStatus !== 'ready' && this.timelineStatus !== 'fail') {
             this.autoRefresh = true
+          }else{
+            this.autoRefresh = false
           }
           this.$store.dispatch('updateSketch', this.$store.state.sketch.id)
         })
@@ -423,8 +425,10 @@ export default {
       hex: this.timeline.color,
     }
     this.timelineStatus = this.timeline.status[0].status
-    if (this.timelineStatus !== 'ready') {
+    if (this.timelineStatus !== 'ready' && this.timelineStatus !== 'fail') {
       this.autoRefresh = true
+    }else{
+      this.autoRefresh = false
     }
   },
   beforeDestroy() {
@@ -437,7 +441,9 @@ export default {
         this.t = setInterval(
           function() {
             this.fetchData()
-            if (this.timelineStatus === 'ready') {
+            console.log("hi")
+            console.log(this.timelineStatus)
+            if (this.timelineStatus === 'ready' || this.timelineStatus === 'fail') {
               this.autoRefresh = false
             }
           }.bind(this),

--- a/timesketch/frontend/src/components/Timelines/TimelineListItem.vue
+++ b/timesketch/frontend/src/components/Timelines/TimelineListItem.vue
@@ -441,8 +441,6 @@ export default {
         this.t = setInterval(
           function() {
             this.fetchData()
-            console.log("hi")
-            console.log(this.timelineStatus)
             if (this.timelineStatus === 'ready' || this.timelineStatus === 'fail') {
               this.autoRefresh = false
             }

--- a/timesketch/lib/tasks.py
+++ b/timesketch/lib/tasks.py
@@ -181,6 +181,10 @@ def _set_timeline_status(timeline_id, status, error_msg=None):
     # Check if there is at least one data source that hasn't failed.
     multiple_sources = any(not x.error_message for x in timeline.datasources)
 
+    if error_msg and status=="fail":
+        timeline.set_status(status)
+        timeline.searchindex.set_status(status)
+
     if multiple_sources:
         timeline_status = timeline.get_status.status.lower()
         if timeline_status != "process" and status != "fail":


### PR DESCRIPTION
**Summary**

+ What existing problem does this PR solve? 
Issue #2255.

+ What new feature is being introduced with this PR?
This PR allows a user to upload a CSV file with bad headers and receive an error from the Server, without continuing performing HTTP requests to retrieve the timeline that it was supposed to be created.

+ Overview of changes to existing functions if required.
If the CSV is not parsed correctly, then the timeline's status associated with the uploaded file is set to "Fail". The client checks for the value of the status: if it assumes the value (i) correct or (ii) fail, then the client will not send any HTTP request to retrieve the timeline.

**Closing issues**

`closes #2255 `