### PR TITLE
Bring back disappearing codebase

### DIFF
--- a/timesketch/frontend/src/views/Intelligence.vue
+++ b/timesketch/frontend/src/views/Intelligence.vue
@@ -313,6 +313,11 @@ export default {
       if (this.tagMetadata[tag]) {
         return _.extend(tagInfo, this.tagMetadata[tag])
       } else {
+        for (var regex in this.tagMetadata['regexes']) {
+          if (tag.match(regex)) {
+            return _.extend(tagInfo, this.tagMetadata['regexes'][regex])
+          }
+        }
         return _.extend(tagInfo, this.tagMetadata.default)
       }
     },


### PR DESCRIPTION
ad0082bd027b093e65abf6bfd0b9b66e7b7b1af3 made the coloriaztion regex feature disappear.