### PR TITLE
fix missing mock in sigma_tagger_test.py

### DIFF
--- a/timesketch/lib/analyzers/sigma_tagger_test.py
+++ b/timesketch/lib/analyzers/sigma_tagger_test.py
@@ -25,7 +25,10 @@ class TestSigmaPlugin(BaseTest):
         _ = sigma_tagger.RulesSigmaPlugin(
             sketch_id=1, index_name=self.test_index
         )
-
+    # Mock the OpenSearch datastore.
+    @mock.patch(
+        "timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore
+    )
     def test_get_kwargs(self):
         analyzer_init = sigma_tagger.RulesSigmaPlugin(
             sketch_id=1, index_name=self.test_index


### PR DESCRIPTION

Fixes #2264  where a an opensearch mock is missing for the function test_get_kwargs 
+ What existing problem does this PR solve? Failed unitest


**Checks**

- [x] All tests succeed.
- [ ] Unit tests added.
- [ ] e2e tests added.
- [ ] Documentation updated.

**Closing issues**
closes #2264

