### PR TITLE
Minor upload form refactor to prevent upload of empty files

### DIFF
--- a/importer_client/python/tools/timesketch_importer.py
+++ b/importer_client/python/tools/timesketch_importer.py
@@ -75,6 +75,7 @@ def upload_file(
         able to upload the timeline as well as the celery task identification
         for the indexing.
     """
+
     if not my_sketch or not hasattr(my_sketch, "id"):
         return "Sketch needs to be set"
 
@@ -86,6 +87,10 @@ def upload_file(
             ".jsonl (not {0:s})"
         ).format(file_extension.lower())
 
+    if os.path.getsize(file_path) <= 0:
+        return (
+            "File cannot be empty"
+        )
     import_helper = helper.ImportHelper()
     import_helper.add_config_dict(config_dict)
 

--- a/timesketch/api/v1/resources/upload.py
+++ b/timesketch/api/v1/resources/upload.py
@@ -344,6 +344,11 @@ class UploadFileResource(resources.ResourceMixin, Resource):
         file_size = form.get("total_file_size")
         if isinstance(file_size, str) and file_size.isdigit():
             file_size = int(file_size)
+        if file_size <= 0:
+            abort(
+                HTTP_STATUS_CODE_BAD_REQUEST,
+                "Unable to upload file. File is empty"
+            )
         enable_stream = form.get("enable_stream", False)
 
         data_label = form.get("data_label", "")

--- a/timesketch/frontend/src/components/Common/UploadForm.vue
+++ b/timesketch/frontend/src/components/Common/UploadForm.vue
@@ -19,7 +19,7 @@ limitations under the License.
       <div class="field">
         <div class="file has-name">
           <label class="file-label">
-            <input class="file-input" type="file" name="resume" v-on:change="setFileName($event.target.files)" />
+            <input class="file-input" type="file" name="resume" v-on:change="setFile($event.target.files)" />
             <span class="file-cta">
               <span class="file-icon">
                 <i class="fas fa-upload"></i>
@@ -36,17 +36,12 @@ limitations under the License.
         </div>
       </div>
       <div class="field">
-        <span v-if="error">
-          {{ error }}
+        <span v-for="(errorMessage, index) in error" :key="index">
+            {{ errorMessage }}
+            <br/>
         </span>
       </div>
-      <div class="field" v-if="fileName">
-        <label class="label">Name</label>
-        <div class="control">
-          <input v-model="form.name" class="input" type="text" required placeholder="Name your timeline" />
-        </div>
-      </div>
-      <div class="error" v-if="!error">
+      <div class="error" v-if="!error.length">
         <div class="field" v-if="fileName">
           <label class="label">Name</label>
           <div class="control">
@@ -86,7 +81,7 @@ export default {
         file: '',
       },
       fileName: '',
-      error: '',
+      error: [],
       percentCompleted: 0,
     }
   },
@@ -97,9 +92,10 @@ export default {
       this.fileName = ''
     },
     submitForm: function() {
-      if (this.error == 'Please select a file with a valid extension' ) {
-        return;
+      if (!this.validateFile()) {
+        return
       }
+
       let formData = new FormData()
       formData.append('file', this.form.file)
       formData.append('name', this.form.name)
@@ -122,11 +118,26 @@ export default {
           this.clearFormData()
           this.percentCompleted = 0
        })
-       .catch(e => {}) 
+       .catch(e => {})
     },
-    setFileName: function(fileList) {
+    validateFile: function() {
+      this.error = []
+
+      if (this.form.file.size <= 0) {
+        this.error.push('Please select a non empty file')
+      }
+
+      let fileExtension = this.fileName.split('.')[1]
+      let allowedExtensions = ['csv', 'json', 'jsonl', 'plaso']
+      if (!allowedExtensions.includes(fileExtension)) {
+        this.error.push('Please select a file with a valid extension')
+      }
+
+      return this.error.length === 0;
+    },
+    setFile: function(fileList) {
       let fileName = fileList[0].name
-      let fileExtension = fileName.split('.')[1]
+
       this.form.file = fileList[0]
       this.form.name = fileName
         .split('.')
@@ -134,11 +145,7 @@ export default {
         .join('.')
       this.fileName = fileName
 
-      this.error = ''
-      let allowedExtensions = ['csv', 'json', 'jsonl', 'plaso']
-      if (!allowedExtensions.includes(fileExtension)) {
-        this.error = 'Please select a file with a valid extension'
-      }
+      this.validateFile()
     },
   },
 }


### PR DESCRIPTION
This PR includes a minor refactor to `UploadForm.vue` to prevent the upload of empty files.

I've also lifted the validation of the file into its own method to keep the validation in one place, this should hopefully keep the code cleaner and allow for further error cases to be checked more easily. 

- removed duplicate file name field on web upload form
- updated web upload form to prevent upload of empty files
- slight refactor of upload form to allow for the display of multiple errors
- slight refactor of upload form for easier validation without extra bloat
- updated upload api endpoint to prevent empty files from being uploaded
- updated importer cli to prevent empty files from being uploaded

---

## Screenshots
Please find below the updated frontend errors. Multiple validation errors can now be displayed

![empty-file-frontend-validation](https://user-images.githubusercontent.com/9006404/181908041-e653487c-244c-4430-ab2a-798e9a7e09ca.png)
![empty-invalid-extension-frontend-validation](https://user-images.githubusercontent.com/9006404/181908042-bd1adf91-112c-4209-ac4f-3f184e222ef2.png)
![wrong-extension-frontend-validation](https://user-images.githubusercontent.com/9006404/181908043-7a54a9b4-23d5-4eb6-9239-2dadc0e75c7c.png)



**Checks**

- [x] All tests succeed.
- [ ] Unit tests added.
- [ ] e2e tests added.
- [ ] Documentation updated.

**Closing issues**
closes #2196 
closes #2268
