### PR TITLE
JSONL MAPPING HEADERS

### DIFF
--- a/docs/developers/getting-started.md
+++ b/docs/developers/getting-started.md
@@ -130,3 +130,20 @@ To test mkdocs locally, run the following in your container:
 ```
 
 And visit the results / review remarks, warnings or errors from mkdocs.
+
+## Formatting
+
+Before merging a pull request, we expect the code to be formatted in a certain manner. You can use VS Code extensions to make your life easier in formatting your files. For example:
+* [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur) for *Vue* files
+* [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python) and [Black](https://github.com/psf/black) for *Python* files.
+
+### Formatting Python files
+
+We use `black` to format Python files. `black` is the uncompromising Python code formatter. There are two ways to use it:
+1. Manually from the command line: 
+    * Install `black` following the official [black documentation](https://pypi.org/project/black/).
+    * Format your file by running this command: `$ black path/to/python/file`
+2. Automatically from [VS Code](https://dev.to/adamlombard/how-to-use-the-black-python-code-formatter-in-vscode-3lo0):
+    * Download the VS Code extension `Python`.
+    * Navigate to `Code -> Preferences -> Settings` and search for `Python Formatting Provider`. Then, select `black` from the dropdown menu.
+    * Enable the `Format on Save` option to automatically format your files every time you save them.

--- a/timesketch/api/v1/resources/upload.py
+++ b/timesketch/api/v1/resources/upload.py
@@ -289,7 +289,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
         meta["task_id"] = task_id
         return self.to_json(timeline, status_code=HTTP_STATUS_CODE_CREATED, meta=meta)
 
-    def _upload_events(self, events, form, sketch, index_name):
+    def _upload_events(self, events, form, sketch, index_name, headers_mapping=None):
         """Upload a file like object.
 
         Args:
@@ -315,6 +315,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
             form=form,
             data_label=data_label,
             enable_stream=form.get("enable_stream", False),
+            headers_mapping=headers_mapping,
         )
 
     def _upload_file(
@@ -475,6 +476,8 @@ class UploadFileResource(resources.ResourceMixin, Resource):
 
         # headers mapping: map between mandatory headers and new ones
         headers_mapping = json.loads(form.get("headersMapping", "{}")) or None
+        logger.info(headers_mapping)
+
         delimiter = form.get("delimiter", ",")
 
         sketch_id = form.get("sketch_id", None)
@@ -529,5 +532,9 @@ class UploadFileResource(resources.ResourceMixin, Resource):
             )
 
         return self._upload_events(
-            events=events, form=form, sketch=sketch, index_name=index_name
+            events=events,
+            form=form,
+            sketch=sketch,
+            index_name=index_name,
+            headers_mapping=headers_mapping,
         )

--- a/timesketch/frontend/src/components/Common/UploadForm.vue
+++ b/timesketch/frontend/src/components/Common/UploadForm.vue
@@ -41,7 +41,7 @@ limitations under the License.
       </div>
 
       <div class="field">
-        <div v-if="extension === 'csv'">
+        <div v-if="['csv', 'jsonl'].includes(extension)">
           <hr />
 
           <!-- List of button: showHelper, showPreview, addColumnsToPreview -->
@@ -263,17 +263,24 @@ limitations under the License.
             <hr />
           </div>
 
-          <!-- CSV delimiter selection: the program will parse the file according to this choice -->
-          <label class="label">CSV Separator</label>
-          <div class="control" v-for="(v, key) in delimitersList" :key="key">
-            <input
-              type="radio"
-              name="CSVDelimiter"
-              :value="v"
-              v-model="CSVDelimiter"
-              @change="changeCSVDelimiter"
-            />
-            {{ key }} ({{ v }})
+          <!--
+
+            CSV delimiter selection: the program will parse 
+            the file according tothis choice
+          
+          -->
+          <div v-if="extension === 'csv'">
+            <label class="label">CSV Separator</label>
+            <div class="control" v-for="(v, key) in delimitersList" :key="key">
+              <input
+                type="radio"
+                name="CSVDelimiter"
+                :value="v"
+                v-model="CSVDelimiter"
+                @change="changeCSVDelimiter"
+              />
+              {{ key }} ({{ v }})
+            </div>
           </div>
         </div>
       </div>
@@ -378,7 +385,13 @@ export default {
   },
   computed: {
     headers() {
-      return this.headersString.split(this.CSVDelimiter);
+      let headers = [];
+      if (this.extension === "csv") {
+        headers = this.headersString.split(this.CSVDelimiter);
+      } else if (this.extension === "jsonl") {
+        headers = Object.keys(this.headersString);
+      }
+      return headers;
     },
     missingHeaders() {
       return this.mandatoryHeaders.filter(
@@ -386,11 +399,19 @@ export default {
       );
     },
     extension() {
-      return this.fileName.split(".")[1];
+      let extension = this.fileName.split(".")[1];
+      console.log(extension);
+      if (extension) return extension.toLowerCase();
     },
     numberRows() {
-      let n = this.valuesString.indexOf("");
-      return n < 0 ? this.staticNumberRows : n;
+      if (this.extension === "csv") {
+        let n = this.valuesString.indexOf("");
+        return n < 0 ? this.staticNumberRows : n;
+      } else if (this.extension === "jsonl") {
+        return this.valuesString.length;
+      } else {
+        return 0;
+      }
     },
     allHeaders() {
       let setHeaders = new Set(
@@ -409,12 +430,12 @@ export default {
        */
 
       /**
-       * valuesAndHeaders = list of dictionaries. Each entry represent a column in the CSV, i.e.,
+       * valuesAndHeaders = dictionary where
        *  - the key is the header, e.g., "datetime", "file_name"
        *  - the value is an array containing the values of that column
        */
-      let valuesAndHeaders = [];
-      if (this.extension.toLowerCase() === "csv") {
+      let valuesAndHeaders = {};
+      if (this.extension === "csv") {
         let values = this.valuesString.map((x) => x.split(this.CSVDelimiter));
         /**
          * values is an array of array (matrix)
@@ -423,21 +444,28 @@ export default {
          *                | [2022-11-09, file_create, high] |
          *                | [2022-11-09, file_update, low]  |
          */
-
         for (let i = 0; i < this.headers.length; i++) {
           let listValues = [];
           for (let j = 0; j < values.length; j++) {
             listValues.push(values[j][i]); // list values aggregate the information on the columns
           }
-          valuesAndHeaders.push({
-            name: this.headers[i],
-            values: listValues,
-          });
+          valuesAndHeaders[this.headers[i]] = listValues;
+        }
+      } else if (this.extension === "jsonl") {
+        for (let i = 0; i < this.valuesString.length; i++) {
+          for (let header in this.valuesString[i]) {
+            if (header in valuesAndHeaders) {
+              valuesAndHeaders[header].push(this.valuesString[i][header]);
+            } else {
+              valuesAndHeaders[header] = [this.valuesString[i][header]];
+            }
+          }
         }
       } else {
-        console.log("JSONL not supported (yet) for this feature");
+        console.error(
+          this.extension + " extension not supported for this feature"
+        );
       }
-
       let checkedHeaders = this.checkedHeaders;
       return checkedHeaders.sort().map((header) => {
         let color = ""; // CSS property for the displayed column
@@ -445,7 +473,7 @@ export default {
 
         if (this.headers.includes(header)) {
           // case 0: the mandatory header is in the CSV (no mapping required)
-          values = valuesAndHeaders.find((x) => x.name === header).values;
+          values = valuesAndHeaders[header];
           color = this.colors.find((x) => x.name === "blue").value;
         } else {
           // header is missing, need to check to headers mapping
@@ -462,21 +490,17 @@ export default {
             if (extractedMapping.source) {
               if (extractedMapping.source.length === 1) {
                 // case 1
-                values = valuesAndHeaders.find(
-                  (x) => x.name === extractedMapping.source[0]
-                ).values;
+                values = valuesAndHeaders[extractedMapping.source[0]];
               } else {
                 // case 2
-                let listValues = valuesAndHeaders.filter((x) =>
-                  extractedMapping.source.includes(x.name)
-                );
+                let listSources = extractedMapping.source;
                 for (let i = 0; i < this.numberRows; i++) {
-                  // here we build the value that we will display in the message field
                   let concatValue = "";
-                  for (let j = 0; j < listValues.length; j++) {
-                    concatValue += listValues[j].name + ": ";
-                    concatValue += listValues[j].values[i] + " | ";
-                  }
+                  listSources.forEach((source) => {
+                    concatValue += source + ": ";
+                    concatValue +=
+                      JSON.stringify(valuesAndHeaders[source][i]) + " | ";
+                  });
                   values.push(concatValue);
                 }
               }
@@ -609,7 +633,7 @@ export default {
       formData.append("context", this.fileName);
       formData.append("total_file_size", this.form.file.size);
       formData.append("sketch_id", this.$store.state.sketch.id);
-      if (this.extension === "csv") {
+      if (["csv", "jsonl"].includes(this.extension)) {
         let hMapping = JSON.stringify(this.headersMapping);
         formData.append("headersMapping", hMapping);
         formData.append("delimiter", this.CSVDelimiter);
@@ -638,11 +662,14 @@ export default {
       if (this.form.file.size <= 0) {
         this.error.push("Please select a non empty file");
       }
-      let allowedExtensions = ["csv", "json", "jsonl", "plaso"];
+      let allowedExtensions = ["csv", "jsonl", "plaso"];
       if (!allowedExtensions.includes(this.extension)) {
-        this.error.push("Please select a file with a valid extension");
+        this.error.push(
+          "Please select a file with a valid extension: " +
+            allowedExtensions.toString()
+        );
       }
-      if (this.extension === "csv") {
+      if (["csv", "jsonl"].includes(this.extension)) {
         // 1. check if mapping is completed, i.e., if the user set all the mandatory headers
         if (this.headersMapping.length !== this.missingHeaders.length) {
           this.error.push(
@@ -679,6 +706,8 @@ export default {
       /* 3. Manage CSV missing headers */
       if (this.extension === "csv") {
         this.extractCSVHeader();
+      } else if (this.extension === "jsonl") {
+        this.extractJSONLHeader();
       } else {
         this.validateFile();
       }
@@ -701,6 +730,72 @@ export default {
             .split("\n")
             .slice(1, vueJS.staticNumberRows + 1);
           vueJS.validateFile();
+        }
+      };
+    },
+    extractJSONLHeader: function () {
+      let reader = new FileReader();
+      let file = document.getElementById("datafile").files[0];
+      let vueJS = this;
+      reader.readAsText(file.slice(0, 10000));
+      reader.onloadend = function (e) {
+        if (e.target.readyState === FileReader.DONE) {
+          /* 3a. Extract the headers from the CSV */
+          let data = e.target.result;
+
+          // Algorithm to extract the JSON first lines
+
+          // let isText = false;
+          // let separator = '"';
+          // let curlyBrackets = [];
+          // let jsonObj = [];
+
+          // for (let i = 0; i < data.length; i++) {
+          //   let c = data[i];
+          //   if (isText) {
+          //     if (c === separator) isText = false;
+          //     continue;
+          //   } else {
+          //     if (c === "{") {
+          //       curlyBrackets.push(i);
+          //     } else if (c === "}") {
+          //       let index = curlyBrackets.pop();
+          //       if (curlyBrackets.length === 0) {
+          //         jsonObj.push(data.slice(index, i + 1));
+          //         if (jsonObj.length >= vueJS.staticNumberRows) {
+          //           break;
+          //         }
+          //       }
+          //     } else if (c === "'") {
+          //       separator = "'";
+          //       isText = true;
+          //     } else if (c === "'") {
+          //       separator = '"';
+          //       isText = true;
+          //     }
+          //   }
+          // }
+
+          // if (jsonObj.length === 0) {
+          //   vueJS.error.push("Cannot parse JSON FILE");
+          //   return;
+          // }
+
+          // instruction to parse JSONL: https://dbconvert.com/blog/json-lines-data-stream/
+          // according to this documentation, "It doesn’t require custom parsers. Just read a line, parse as JSON, read a line, parse as JSON… and so on."
+
+          let rows = data.split("\n");
+          let i = Math.min(vueJS.staticNumberRows, rows.length);
+          try {
+            vueJS.headersString = JSON.parse(rows[0]);
+            vueJS.valuesString = rows.slice(0, i).map((x) => JSON.parse(x));
+            vueJS.validateFile();
+          } catch (objError) {
+            let error = objError.message;
+            error += ". Your first lines of JSON: ";
+            error += jsonObj;
+            vueJS.error.push(error);
+          }
         }
       };
     },

--- a/timesketch/lib/tasks.py
+++ b/timesketch/lib/tasks.py
@@ -285,7 +285,13 @@ def build_index_pipeline(
         )
     else:
         index_task = index_task_class.s(
-            file_path, events, timeline_name, index_name, file_extension, timeline_id
+            file_path,
+            events,
+            timeline_name,
+            index_name,
+            file_extension,
+            timeline_id,
+            headers_mapping,
         )
 
     # TODO: Check if a scenario is set or an investigative question

--- a/timesketch/lib/tasks.py
+++ b/timesketch/lib/tasks.py
@@ -271,7 +271,7 @@ def build_index_pipeline(
     sketch_analyzer_chain = None
     searchindex = SearchIndex.query.filter_by(index_name=index_name).first()
 
-    if file_extension == "csv":
+    if file_extension == "csv" or file_extension == "jsonl":
         # passing the extra argument: headers_mapping
         index_task = index_task_class.s(
             file_path,
@@ -285,13 +285,7 @@ def build_index_pipeline(
         )
     else:
         index_task = index_task_class.s(
-            file_path,
-            events,
-            timeline_name,
-            index_name,
-            file_extension,
-            timeline_id,
-            headers_mapping,
+            file_path, events, timeline_name, index_name, file_extension, timeline_id
         )
 
     # TODO: Check if a scenario is set or an investigative question

--- a/timesketch/lib/utils.py
+++ b/timesketch/lib/utils.py
@@ -188,7 +188,7 @@ def check_mapping_errors(headers, headers_mapping):
                         f"Value specified in the headers mapping not found in the CSV\n"
                         f"Headers mapping: {', '.join(mapping['source'])}\n"
                         f"Sources column/s: {source}\n"
-                        f"CSV columns: {', '.join(headers)}"
+                        f"All Headers: {', '.join(headers)}"
                     )
 
             # Update the headers list that we will substitute/rename
@@ -214,7 +214,7 @@ def check_mapping_errors(headers, headers_mapping):
         )
 
 
-def rename_headers(chunk, headers_mapping):
+def rename_csv_headers(chunk, headers_mapping):
     """ "Rename the headers of the dataframe
 
     Args:
@@ -285,7 +285,7 @@ def read_and_validate_csv(
         for idx, chunk in enumerate(reader):
             if headers_mapping:
                 # rename colunms according to the mapping
-                chunk = rename_headers(chunk, headers_mapping)
+                chunk = rename_csv_headers(chunk, headers_mapping)
 
             skipped_rows = chunk[chunk["datetime"].isnull()]
             if not skipped_rows.empty:
@@ -377,13 +377,74 @@ def read_and_validate_redline(file_handle):
         yield row_to_yield
 
 
-def read_and_validate_jsonl(file_handle, **kwargs):  # pylint: disable=unused-argument
+def rename_jsonl_headers(linedict, headers_mapping, lineno):
+    """Rename the headers of the dictionary
+
+    Args:
+        linedict: dictionary to be modified
+        headers_mapping: list of dicts containing:
+                         (i) target header we want to insert [key=target],
+                         (ii) sources header we want to rename/combine [key=source],
+                         (iii) def. value if we add a new column [key=default_value]
+        lineno: line of the JSONL file
+
+    Returns: the dictionary with renamed headers
+
+
+    """
+    headers_mapping.sort(
+        key=lambda x: len(x["source"]) if x["source"] else 0, reverse=True
+    )
+    ld_keys = linedict.keys()
+
+    # sanity check of the headers_mapping
+    check_mapping_errors(ld_keys, headers_mapping)
+
+    for mapping in headers_mapping:
+        if mapping["target"] not in ld_keys:
+            if mapping["source"]:
+                # mapping["source"] is not None
+                if len(mapping["source"]) == 1:
+                    # 1. rename header
+                    if mapping["source"][0] in ld_keys:
+                        linedict[mapping["target"]] = linedict.pop(mapping["source"][0])
+                    else:
+                        raise RuntimeError(
+                            f"Source mapping {mapping['source'][0]} not found in JSON\n"
+                            f"JSON line:\n{linedict}\n"
+                            f"Line no: {lineno}"
+                        )
+                else:
+                    # 2. combine headers
+                    linedict[mapping["target"]] = ""
+                    for source in mapping["source"]:
+                        if source in ld_keys:
+                            linedict[mapping["target"]] += f"{source} : "
+                            linedict[mapping["target"]] += f"{linedict[source]} |"
+                        else:
+                            raise RuntimeError(
+                                f"Source mapping {source} not found in JSON\n"
+                                f"JSON line:\n{linedict}\n"
+                                f"Line no: {lineno}"
+                            )
+            else:
+                # 3. create new entry with the default value
+                linedict[mapping["target"]] = mapping["default_value"]
+    return linedict
+
+
+def read_and_validate_jsonl(
+    file_handle, delimiter=None, headers_mapping=None
+):  # pylint: disable=unused-argument
     """Generator for reading a JSONL (json lines) file.
 
     Args:
         file_handle: a file-like object containing the CSV content.
-        **kwargs: headers_mapping and delimiter are passed to
-                  this function but they are currently not used here
+        delimiter: not used in this function
+        headers_mapping: list of dicts containing:
+                         (i) target header we want to insert [key=target],
+                         (ii) sources header we want to rename/combine [key=source],
+                         (iii) def. value if we add a new column [key=default_value]
 
     Raises:
         RuntimeError: if there are missing fields.
@@ -400,6 +461,8 @@ def read_and_validate_jsonl(file_handle, **kwargs):  # pylint: disable=unused-ar
         try:
             linedict = json.loads(line)
             ld_keys = linedict.keys()
+            if headers_mapping:
+                linedict = rename_jsonl_headers(linedict, headers_mapping, lineno)
             if "datetime" not in ld_keys and "timestamp" in ld_keys:
                 epoch = int(str(linedict["timestamp"])[:10])
                 dt = datetime.datetime.fromtimestamp(epoch)
@@ -409,6 +472,13 @@ def read_and_validate_jsonl(file_handle, **kwargs):  # pylint: disable=unused-ar
                     linedict["timestamp"] = int(
                         parser.parse(linedict["datetime"]).timestamp() * 1000000
                     )
+                except TypeError as e:
+                    logger.error(
+                        "Unable to parse timestamp, skipping line "
+                        "{0:d}".format(lineno),
+                        exc_info=True,
+                    )
+                    continue
                 except parser.ParserError:
                     logger.error(
                         "Unable to parse timestamp, skipping line "
@@ -420,9 +490,9 @@ def read_and_validate_jsonl(file_handle, **kwargs):  # pylint: disable=unused-ar
             missing_fields = [x for x in mandatory_fields if x not in linedict]
             if missing_fields:
                 raise RuntimeError(
-                    "Missing field(s) at line {0:n}: {1:s}".format(
-                        lineno, ",".join(missing_fields)
-                    )
+                    f"Missing field(s) at line {lineno}: {','.join(missing_fields)}\n"
+                    f"Line: {linedict}\n"
+                    f"Mapping: {headers_mapping}"
                 )
 
             if "tag" in linedict:

--- a/timesketch/lib/utils_test.py
+++ b/timesketch/lib/utils_test.py
@@ -67,7 +67,7 @@ class TestUtils(BaseTest):
         for row in data_generator:
             self.assertRegex(row["datetime"], ISO8601_REGEX)
 
-    def test_invalid_headers_mapping(self):
+    def test_invalid_CSV_headers_mapping(self):
         """Test for invalid headers mapping"""
         current_headers = ["DT", "message", "TD"]
 
@@ -103,7 +103,7 @@ class TestUtils(BaseTest):
             # Call next to work around lazy generators.
             next(check_mapping_errors(current_headers, invalid_mapping_3))
 
-    def test_valid_headers_mapping(self):
+    def test_valid_CSV_headers_mapping(self):
         """Test for valid headers mapping"""
         current_headers = ["DT", "message", "TD"]
 
@@ -153,3 +153,11 @@ class TestUtils(BaseTest):
         with self.assertRaises(RuntimeError):
             # Call next to work around lazy generators.
             next(_validate_csv_fields(mandatory_fields, df_02))
+
+
+def test_valid_JSONL_headers_mapping(self):
+    ...
+
+
+def test_invalid_JSONL_headers_mapping(self):
+    ...


### PR DESCRIPTION
# JSONL MAPPING HEADERS

`closes #2284`

This PR closes the issue #2284 and it  extends the PR #2261 and #2287 regarding the headers mapping feature.

## Main contribution and accomplishment

This PR allows a user to use the headers mapping feature also for JSONL file.

Currently a JSONL file that does not have the required headers, i.e., `message`, `datetime` and `timestamp_desc`, can not be imported into Timesketch.

With this feature we overcome this limitation by introducing the headers mapping functionality. In particolar, a user can now map an existing field in the JSONL with a missing required header.

### How are the headers extracted from the JSONL?

It is easier to extract the headers of a CSV because we can assume that they are on the first line. However, a JSONL file is a different structure where each row corresponds to a dictionary. For this reason, each row could have different headers.

```
{"time" : "2022-11-11", "fileData" : {"path": "/home/luke/Desktop", "filename": "helloBR8", "size" : "22"}}

{"time" : "2022-11-12", "fileData" : {"path": "/home/luke/Desktop", "filename": "na", "size" : "22"}, "logsource" : "sysmon", "" }
```

We can observe that the second line of the example contain a new field that is: "logsource"

**What can't we say?**

All headers are present in the first line of the file. How can we overcome these limitations? Making assumptions and *failing safe* (see below).

**What can we assume?** 

* [Each entry of a JSONL terminates with a new line](https://dbconvert.com/blog/json-lines-data-stream/). To this end, parsing a JSONL doesn’t require custom parsers. Just read a line, parse as JSON, read a line, parse as JSON… and so on.
* We assume that all the headers are in the first line of the JSONL. When we perform the mapping on the server-side, we check first if the `target` field (e.g., `datetime`) is already in the JSONL line. If so, there is no need for mapping. Otherwise, we proceed with the mapping: if any of the fields specified in the `source` value is missing in the JSONL line, we throw a Runtime exception.

```
ld_keys = jsonl_line.keys()
for mapping in headers_mapping:
    if mapping["target"] not in ld_keys:
        # proceed with the mapping
        if mapping["source"]:
            for source in mapping["source"]:
                if source in ld_keys:
                    # proceed with the mapping
                else:
                    # throw a Runtime Error
        else:
            # create the new column with a default value
    else:
        continue
```

## Frontend major modifications:

Wrt the previous request, we did not modify the structure of the HTML.

We added the following methods:

* `extractJSONLHeader()` that extracts the first 
lines of the JSONL file and converts them into JSON objects.

We added around the code of `UploadForm.vue` the various conditions to display the headers mapping functionality (previously displayed only for `CSV` files).

## Backend major modifications:

We added the function `rename_jsonl_headers(linedict, headers_mapping, lineno)` in the file `timesketch/lib/utils.py` to map the missing headers according to the headers mapping

## CHECKS
- [x] All tests succeed.
- [x] Unit tests added 
    - 2 test to verify the new function `rename_jsonl_headers(linedict, headers_mapping, lineno)` in the file `timesketch/lib/utils.py`
- [x] Documentation updated: see `import-from-json-csv.md` file.

## Final note on JSON file

This PR does not take into consideration importing JSON files. A JSON file has a similar structure of a JSONL but tricky to be considered by Timesketch compared to a JSONL.

In fact, a JSONL file is a flat structure. On the contrary, a JSON file has a hierarchy structure, for example:

```
{
    "event-01" : {data-01},
    "event-02" : {data-02},
    ...
    "event-N" : {data-N},
}
```
Even if the structure is not too deep, we need to extract the values from `event-i`. After careful consideration, extracting this information from a JSON file seems not worthy because the structure of the file could change and not be processed by the headers mapping (e.g., `data-i` could be in a deeper layer of the JSON object).