### PR TITLE
Change default value of use rule in Sigma analyzer

### DIFF
--- a/timesketch/lib/analyzers/sigma_tagger.py
+++ b/timesketch/lib/analyzers/sigma_tagger.py
@@ -33,7 +33,7 @@ class SigmaPlugin(interface.BaseAnalyzer):
         super().__init__(index_name, sketch_id, timeline_id=timeline_id)
 
     def run_sigma_rule(
-        self, query, rule_name, tag_list=None, status_good=True):
+        self, query, rule_name, tag_list=None, status_good=False):
         """Runs a sigma rule and applies the appropriate tags.
 
         Args:


### PR DESCRIPTION
Current behaviour:
If a file is not found in the Sigma status file, the rule is considered good and Tags will be applied.

Future behaviour:
If a file is not found in the status page, it is considered not good, thus Tags are not applied.