### PR TITLE
Search history tree generation

### DIFF
--- a/timesketch/api/v1/resources/explore.py
+++ b/timesketch/api/v1/resources/explore.py
@@ -513,8 +513,8 @@ class SearchHistoryTreeResource(resources.ResourceMixin, Resource):
             .first()
         )
 
-        # Traverse (in reverse) the history tree 10 steps from the last node. Reason is
-        # to not build an unesessary big grapth.
+        # Traverse (in reverse) the history tree 10 steps from the last node in order to
+        # not build an unesessary big graph.
         root_node = last_node
         for _ in range(self.HISTORY_NODE_LIMIT):
             if not root_node.parent:

--- a/timesketch/api/v1/resources/explore.py
+++ b/timesketch/api/v1/resources/explore.py
@@ -28,7 +28,6 @@ from flask_restful import Resource
 from flask_restful import reqparse
 from flask_login import login_required
 from flask_login import current_user
-from sqlalchemy.orm import aliased
 
 from timesketch.api.v1 import export
 from timesketch.api.v1 import resources


### PR DESCRIPTION
The History tree used a naive approach to find a reasonable root node to generate the tree from. In some edge cases, the last node was not present in the tree and the UI failed to render the history.

This PR changes so we always start from the last node, and then traverse backwards in the tree 10 nodes. After that generate the full sub tree with all children etc.