### PR TITLE
XML Viewer for xml_string in (mostly) WINEVTX timelines

### DIFF
--- a/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
@@ -28,7 +28,28 @@ limitations under the License.
               </thead>
               <tbody>
                 <tr v-for="(value, key) in fullEventFiltered" :key="key">
-                  <td>{{ key }}</td>
+                  <td>
+                    {{ key }}
+                    <v-dialog v-if="key.includes('xml')" v-model="formatXMLString" width="1000">
+                      <template v-slot:activator="{ on, attrs }">
+                        <v-btn
+                          icon
+                          x-small
+                          style="cursor: pointer"
+                          v-bind="attrs"
+                          v-on="on"
+                          @click="formatXMLString = true"
+                        >
+                          <v-icon>mdi-xml</v-icon>
+                        </v-btn>
+                      </template>
+                      <ts-format-xml-string
+                        app
+                        @cancel="formatXMLString = false"
+                        :xmlString="value"
+                      ></ts-format-xml-string>
+                    </v-dialog>
+                  </td>
                   <td>{{ value }}</td>
                 </tr>
               </tbody>
@@ -117,8 +138,12 @@ limitations under the License.
 <script>
 import ApiClient from '../../utils/RestApiClient'
 import EventBus from '../../main'
+import TsFormatXmlString from './FormatXMLString.vue'
 
 export default {
+  components: {
+    TsFormatXmlString,
+  },
   props: ['event'],
   data() {
     return {
@@ -126,6 +151,7 @@ export default {
       comment: '',
       comments: [],
       selectedComment: null,
+      formatXMLString: false,
     }
   },
   computed: {

--- a/timesketch/frontend-ng/src/components/Explore/FormatXMLString.vue
+++ b/timesketch/frontend-ng/src/components/Explore/FormatXMLString.vue
@@ -1,0 +1,109 @@
+<!--
+Copyright 2021 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<template>
+  <v-card width="1000" style="overflow: initial">
+    <v-container class="px-8">
+      <div v-if="error">
+        <v-alert border="right" colored-border type="error" elevation="2"> {{ error }} </v-alert>
+      </div>
+      <div v-else>
+        <v-alert border="top" colored-border type="info" elevation="2">
+          XML String parsing... not 100% reliable
+        </v-alert>
+      </div>
+      <v-alert colored-border :color="'success'" border="left" elevation="1">
+        <ul style="list-style-type: none">
+          <li v-for="item in items" :key="item.id" :style="item.margin">
+            <strong>{{ item.name }} </strong> <i style="color: #808080">{{ item.attributes }} </i>:
+            <code v-if="item.value.trim().length > 0">{{ item.value }}</code>
+          </li>
+        </ul>
+      </v-alert>
+
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn text color="primary" @click="clearAndCancel"> Cancel </v-btn>
+      </v-card-actions>
+    </v-container>
+  </v-card>
+</template>
+
+<script>
+export default {
+  props: ['xmlString'],
+  data() {
+    return {
+      error: null,
+      jsonString: null,
+      items: [],
+      count: 0,
+    }
+  },
+  mounted() {
+    let parser = new DOMParser()
+    let xmlDoc = parser.parseFromString(this.xmlString, 'text/xml')
+    let errorNode = xmlDoc.querySelector('parsererror')
+    if (errorNode) {
+      this.error = 'Document cannot be format correclty'
+    } else {
+      this.error = ''
+      this.xmlToJson(xmlDoc.childNodes[0], 0)
+      this.items.sort((a, b) => (a.id > b.id ? 1 : b.id > a.id ? -1 : 0))
+    }
+  },
+  methods: {
+    clearAndCancel: function () {
+      this.$emit('cancel')
+    },
+
+    xmlToJson: function (node, margin) {
+      let marginString = 'margin-left: ' + margin + '%'
+      this.count++
+      let id = this.count
+      let value = ''
+      if (node.data && node.data.trim().length === 0) {
+        return null
+      }
+      let name = node.tagName
+      let attributes = [...node.attributes]
+      let attributesArray = []
+      for (let i = 0; i < attributes.length; i++) {
+        attributesArray.push(attributes[i].name + ' : ' + attributes[i].value)
+      }
+      let attributesString = ''
+      if (attributesArray.length > 0) attributesString = '( ' + attributesArray.join(' - ') + ' )'
+
+      if (!node.hasChildNodes()) {
+        this.items.push({ id: id, name: name, margin: marginString, value: value, attributes: attributesString })
+        return
+      }
+
+      let nodes = node.childNodes
+      let firstChild = nodes[0]
+      if (firstChild.data && firstChild.data.trim().length > 0) {
+        value = firstChild.data
+      } else {
+        for (let i = 0; i < nodes.length; i++) {
+          this.xmlToJson(nodes[i], margin + 3)
+        }
+      }
+      this.items.push({ id: id, name: name, margin: marginString, value: value, attributes: attributesString })
+    },
+  },
+}
+</script>
+
+<style scoped lang="scss"></style>


### PR DESCRIPTION
# XML Viewer for xml_string attribute

Plaso can parse WINEVTX logs. It creates an attribute `xml_string` that is the "dump" of the log itself. The next figure shows how it is represented in Timesketch.

![image](https://user-images.githubusercontent.com/108743205/189892726-db63d4d6-9385-4b63-a760-26a1cd3b7b46.png)


This valuable information might be hard to interpret since it is written in a compat format. With this PR we aim to create an *icon* to visualize better this attribute.

## Frontend files modified:
1. `EventDetail.vue`: added the icon (`</>`) for the attribute `xml_string`

![Screenshot 2022-09-13 1 42 24 PM](https://user-images.githubusercontent.com/108743205/189892463-aa30bc1a-bbf6-47e0-9502-aab76433bbf4.png)

2. [NEW!] `FormatXMLString.vue`: new component to display the XML string. It receives as input (~ property) the xml_string of the event's attribute `xml_string`. It outputs a formatted version of `xml_string`

![image](https://user-images.githubusercontent.com/108743205/189892572-df0e14ea-7372-4945-a147-1e9b6e7f41f9.png)


### Areas of improvements
We add the xml button to view the XML only when the attribute in the timeline event is equal to `xml_string`. This assumption works fine for the majority of the winevtx file parsed with Plaso. We could add the same button for whatever attribute that contains some XML.