### PR TITLE
Update docker images and CI tests to Ubuntu 22.04

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -4,12 +4,12 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   PyPi:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up infrastructure with docker-compose
         run: docker-compose -f docker/e2e/docker-compose.yml up -d
         env:
-          OPENSEARCH_VERSION: 1.2.2
+          OPENSEARCH_VERSION: 1.3.2
       - name: Run e2e tests
         run: docker-compose -f docker/e2e/docker-compose.yml exec -T timesketch python3 /usr/local/src/timesketch/end_to_end_tests/tools/run_in_container.py

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -4,7 +4,10 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   PyPi:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04]
     steps:
       - uses: actions/checkout@v2
       - name: Set up infrastructure with docker-compose

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   PyLint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
@@ -36,7 +36,7 @@ jobs:
           for FILE in `git --no-pager diff origin/master --name-only --diff-filter=ACMR | grep \.py$`; do echo "Running pylint against ${FILE}"; pylint --rcfile=.pylintrc ${FILE}; done
 
   ESLint-frontend:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: ./timesketch/frontend

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -22,9 +22,6 @@ jobs:
         # Pin pip to pip==22.0.3 due to upstream bug in pip.
         # TODO: Revisit and remove this when fixed upstream.
         run: |
-          pip install -U pip==22.0.3
-          pip install astroid==2.4.0
-          pip install pylint==2.6.0
           pip install -r test_requirements.txt
           pip install -r requirements.txt
           pip install -e .

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        python-version: [3.8, 3.10.7]
+        python-version: ['3.8', '3.10']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        python-version: [3.7, 3.8, 3.10.7]
+        python-version: [3.7, 3.8, 3.10.6]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        python-version: [3.7, 3.8, 3.10.7]
+        python-version: [3.8, 3.10.7]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   PyLint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
@@ -36,7 +36,7 @@ jobs:
           for FILE in `git --no-pager diff origin/master --name-only --diff-filter=ACMR | grep \.py$`; do echo "Running pylint against ${FILE}"; pylint --rcfile=.pylintrc ${FILE}; done
 
   ESLint-frontend:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ./timesketch/frontend
@@ -58,7 +58,7 @@ jobs:
           for FILE in `git --no-pager diff origin/master --name-only --diff-filter=ACMR | grep -e \.vue$ -e \.js$ | grep -v dist\/js | grep ^timesketch\/frontend\/ | sed s/'^timesketch\/frontend\/'/''/`; do echo "Running eslint against ${FILE}"; yarn run eslint ${FILE}; done
 
   ESLint-frontend-ng:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ./timesketch/frontend-ng

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        python-version: [3.7, 3.8, 3.10]
+        python-version: [3.7, 3.8, 3.10.7]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        python-version: [3.7, 3.8, 3.10.6]
+        python-version: [3.7, 3.8, 3.10.7]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -6,11 +6,11 @@ on:
 
 jobs:
   PyLint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        os: [ubuntu-20.04]
-        python-version: [3.7, 3.8]
+        os: [ubuntu-20.04, ubuntu-22.04]
+        python-version: [3.7, 3.8, 3.10]
 
     steps:
       - uses: actions/checkout@v2
@@ -36,14 +36,14 @@ jobs:
           for FILE in `git --no-pager diff origin/master --name-only --diff-filter=ACMR | grep \.py$`; do echo "Running pylint against ${FILE}"; pylint --rcfile=.pylintrc ${FILE}; done
 
   ESLint-frontend:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ./timesketch/frontend
     strategy:
       matrix:
-        os: [ubuntu-20.04]
-        node-version: ["12"]
+        os: [ubuntu-20.04, ubuntu-22.04]
+        node-version: ["14"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Node ${{ matrix.node-version }}
@@ -64,8 +64,8 @@ jobs:
         working-directory: ./timesketch/frontend-ng
     strategy:
       matrix:
-        os: [ubuntu-20.04]
-        node-version: ["12"]
+        os: [ubuntu-20.04, ubuntu-22.04]
+        node-version: ["14"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Node ${{ matrix.node-version }}

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   PyLint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
@@ -19,8 +19,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        # Pin pip to pip==22.0.3 due to upstream bug in pip.
-        # TODO: Revisit and remove this when fixed upstream.
         run: |
           pip install -r test_requirements.txt
           pip install -r requirements.txt
@@ -33,7 +31,7 @@ jobs:
           for FILE in `git --no-pager diff origin/master --name-only --diff-filter=ACMR | grep \.py$`; do echo "Running pylint against ${FILE}"; pylint --rcfile=.pylintrc ${FILE}; done
 
   ESLint-frontend:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./timesketch/frontend
@@ -55,7 +53,7 @@ jobs:
           for FILE in `git --no-pager diff origin/master --name-only --diff-filter=ACMR | grep -e \.vue$ -e \.js$ | grep -v dist\/js | grep ^timesketch\/frontend\/ | sed s/'^timesketch\/frontend\/'/''/`; do echo "Running eslint against ${FILE}"; yarn run eslint ${FILE}; done
 
   ESLint-frontend-ng:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./timesketch/frontend-ng

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        python-version: [3.7, 3.8, 3.10.6]
+        python-version: [3.7, 3.8, 3.10.7]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        python-version: [3.7, 3.8, 3.10.6]
+        python-version: [3.7, 3.8, 3.10.7]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   # Backend tests (Python/Flask)
   Python:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
@@ -29,7 +29,7 @@ jobs:
 
   # Frontend tests (VueJS)
   VueJS:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: timesketch/frontend

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        python-version: [3.8, 3.10.7]
+        python-version: ['3.8', '3.10']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,6 +29,7 @@ jobs:
 
   # Test the PPA build packages
   PPA:
+    if: ${{ false }}  # disable until PPA packages has been fixed.
     runs-on: ubuntu-22.04
     strategy:
       matrix:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,8 +5,8 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
-  # Test with PyPi installed packages
-  PyPi:
+  # Backend tests (Python/Flask)
+  Python:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -26,51 +26,6 @@ jobs:
       - name: Run unit tests
         run: |
           pipenv run python run_tests.py
-
-  # Test the PPA build packages
-  PPA:
-    if: ${{ false }}  # disable until PPA packages has been fixed.
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
-        python-version: [3.8, 3.10.7]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          # TODO: Remove when alembic and Flask has been upgraded.
-          sudo pip3 install importlib_resources
-          sudo add-apt-repository ppa:gift/dev
-          sudo apt-get update
-          sudo apt-get -y install python3-distutils pylint
-          sudo apt-get -y install python3-coverage python3-distutils \
-              python3-mock python3-nose python3-pbr python3-setuptools
-          sudo apt-get -y install python3-flask-testing python3-prometheus-flask-exporter \
-              python3-alembic python3-altair python3-amqp python3-aniso8601 \
-              python3-asn1crypto python3-attr python3-bcrypt python3-billiard python3-blinker \
-              python3-bs4 python3-celery python3-certifi python3-cffi python3-chardet \
-              python3-ciso8601 python3-click python3-cryptography python3-datasketch \
-              python3-dateutil python3-editor python3-opensearch python3-entrypoints \
-              python3-flask python3-flask-bcrypt python3-flask-login python3-flask-migrate \
-              python3-flask-restful python3-flask-script python3-flask-sqlalchemy \
-              python3-flaskext.wtf python3-google-auth python3-google-auth-oauthlib \
-              python3-gunicorn python3-idna python3-itsdangerous python3-jinja2 \
-              python3-jsonschema python3-jwt python3-kombu python3-mako python3-importlib-metadata \
-              python3-markdown python3-markupsafe python3-neo4jrestclient python3-numpy \
-              python3-oauthlib python3-pandas python3-parameterized python3-pycparser \
-              python3-pyrsistent python3-redis python3-requests python3-requests-oauthlib \
-              python3-sigmatools python3-six python3-sqlalchemy python3-tabulate python3-toolz \
-              python3-tz python3-urllib3 python3-vine python3-werkzeug python3-wtforms\
-              python3-xlrd python3-xmltodict python3-yaml python3-zipp python3-networkx python3-geoip2
-          sudo ln -s /usr/bin/nosetests3 /usr/bin/nosetests
-      - name: Run unit tests
-        run: |
-          python run_tests.py
 
   # Frontend tests (VueJS)
   VueJS:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,11 +7,11 @@ on:
 jobs:
   # Test with PyPi installed packages
   PyPi:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        os: [ubuntu-20.04]
-        python-version: [3.7, 3.8]
+        os: [ubuntu-20.04, ubuntu-22.04]
+        python-version: [3.7, 3.8, 3.10]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -29,11 +29,11 @@ jobs:
 
   # Test the PPA build packages
   PPA:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        os: [ubuntu-20.04]
-        python-version: [3.7, 3.8]
+        os: [ubuntu-20.04, ubuntu-22.04]
+        python-version: [3.7, 3.8, 3.10]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -73,14 +73,14 @@ jobs:
 
   # Frontend tests (VueJS)
   VueJS:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: timesketch/frontend
     strategy:
       matrix:
-        os: [ubuntu-20.04]
-        node-version: ["12"]
+        os: [ubuntu-20.04, ubuntu-22.04]
+        node-version: ["14"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Node ${{ matrix.node-version }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        python-version: [3.7, 3.8, 3.10.7]
+        python-version: [3.7, 3.8, 3.10.6]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        python-version: [3.7, 3.8, 3.10.7]
+        python-version: [3.7, 3.8, 3.10.6]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   # Test with PyPi installed packages
   PyPi:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
@@ -30,7 +30,7 @@ jobs:
   # Test the PPA build packages
   PPA:
     if: ${{ false }}  # disable until PPA packages has been fixed.
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   # Test with PyPi installed packages
   PyPi:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
@@ -30,7 +30,7 @@ jobs:
   # Test the PPA build packages
   PPA:
     if: ${{ false }}  # disable until PPA packages has been fixed.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        python-version: [3.7, 3.8, 3.10.7]
+        python-version: [3.8, 3.10.7]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        python-version: [3.7, 3.8, 3.10.7]
+        python-version: [3.8, 3.10.7]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        python-version: [3.7, 3.8, 3.10]
+        python-version: [3.7, 3.8, 3.10.7]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        python-version: [3.7, 3.8, 3.10]
+        python-version: [3.7, 3.8, 3.10.7]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/docker/dev/build/Dockerfile
+++ b/docker/dev/build/Dockerfile
@@ -1,5 +1,5 @@
-# Use the official Docker Hub Ubuntu 20.04 base image
-FROM ubuntu:20.04
+# Use the official Docker Hub Ubuntu base image
+FROM ubuntu:22.04
 
 ARG PPA_TRACK=stable
 
@@ -29,20 +29,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 # Install NodeJS for frontend development
-RUN curl -sL https://deb.nodesource.com/setup_12.x -o nodesource_setup.sh
+RUN curl -sL https://deb.nodesource.com/setup_14.x -o nodesource_setup.sh
 RUN bash nodesource_setup.sh
 RUN apt-get update && apt-get install -y --no-install-recommends \
     nodejs \
   && rm -rf /var/lib/apt/lists/*
 
 # Install Yarn for frontend development
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    yarn \
-  && rm -rf /var/lib/apt/lists/*
+RUN npm install --global yarn
 
-# Install test dependencies for Timesketch
+# Install dependencies for Timesketch
 COPY ./requirements.txt /timesketch-requirements.txt
 RUN pip3 install -r /timesketch-requirements.txt
 

--- a/docker/e2e/Dockerfile
+++ b/docker/e2e/Dockerfile
@@ -1,5 +1,5 @@
-# Use the official Docker Hub Ubuntu 20.04 base image
-FROM ubuntu:20.04
+# Use the official Docker Hub Ubuntu base image
+FROM ubuntu:22.04
 
 ARG PPA_TRACK=stable
 
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   python3-wheel \
   python3-setuptools \
   python3-psycopg2 \
+  gpg-agent \
   git \
   wget \
   && rm -rf /var/lib/apt/lists/*
@@ -22,10 +23,6 @@ RUN add-apt-repository -y ppa:gift/$PPA_TRACK
 RUN apt-get update && apt-get install -y --no-install-recommends \
   plaso-tools \
   && rm -rf /var/lib/apt/lists/*
-
-# Install Timesketch from master to get the latest code
-#RUN wget https://raw.githubusercontent.com/google/timesketch/master/requirements.txt
-#RUN pip3 install -r requirements.txt
 
 # Install timesketch from the current branch (In the context of CI platform)
 ADD . /tmp/timesketch

--- a/docker/release/build/Dockerfile-latest
+++ b/docker/release/build/Dockerfile-latest
@@ -1,5 +1,5 @@
-# Use the official Docker Hub Ubuntu 20.04 base image
-FROM ubuntu:20.04
+# Use the official Docker Hub Ubuntu base image
+FROM ubuntu:22.04
 
 ARG PPA_TRACK=stable
 
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-wheel \
     python3-setuptools \
     python3-psycopg2 \
+    gpg-agent \
     wget \
   && rm -rf /var/lib/apt/lists/*
 

--- a/docker/release/build/Dockerfile-release
+++ b/docker/release/build/Dockerfile-release
@@ -1,12 +1,12 @@
-# Use the official Docker Hub Ubuntu 20.04 base image
-FROM ubuntu:20.04
+# Use the official Docker Hub Ubuntu base image
+FROM ubuntu:22.04
 
 ARG PPA_TRACK=stable
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -y update
-RUN apt-get -y install apt-transport-https apt-utils
+RUN apt-get -y install apt-transport-https apt-utils gpg-agent
 RUN apt-get -y install libterm-readline-gnu-perl software-properties-common
 RUN add-apt-repository -y ppa:gift/$PPA_TRACK
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 alembic==1.3.2
 altair==4.1.0
-celery==4.4.0
+celery==5.2.2
 cryptography==3.3.2
 datasketch==1.5.0
 opensearch-py==1.0.0
@@ -14,13 +14,13 @@ flask_wtf==1.0.0
 google-auth==1.7.0
 google_auth_oauthlib==0.4.1
 gunicorn==19.10.0  # Note: Last version to support py2
-numpy==1.21.0
+numpy==1.23.4
 oauthlib==3.1.0
-pandas==1.1.3
+pandas==1.5.0
 PyJWT==1.7.1
 python_dateutil==2.8.1
 PyYAML==5.4.1
-redis==3.3.11
+redis==3.5.3
 requests==2.25.1
 sigmatools==0.19.1 ; python_version > '3.4'
 six==1.12.0
@@ -28,7 +28,7 @@ SQLAlchemy==1.3.12
 Werkzeug==2.0.3
 WTForms==2.2.1
 xlrd==1.2.0
-tabulate==0.8.6
+tabulate==0.9.0
 markdown==3.2.2
 networkx==2.5
 prometheus-client==0.9.0

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,72 +1,17 @@
 #!/usr/bin/env python
-"""Main entry point for running tests and linters."""
-from __future__ import print_function
-from __future__ import unicode_literals
-
+"""Main entry point for running tests."""
 import subprocess
-import argparse
 
 
-def run_python_tests(coverage=False):
-    try:
-        if coverage:
-            subprocess.check_call(
-                (
-                    "nosetests --with-coverage"
-                    " --cover-package=timesketch_api_client,"
-                    "timesketch_import_client,timesketch"
-                    " api_client/python/ timesketch/"
-                    " cli_client/python/"
-                ),
-                shell=True,
-            )
-        else:
-            subprocess.check_call(
-                [
-                    "nosetests",
-                    "-x",
-                    "-s",
-                    "timesketch/",
-                    "api_client/python/",
-                    "importer_client/python",
-                    "cli_client/python/",
-                ]
-            )
-    finally:
-        subprocess.check_call(["rm", "-f", ".coverage"])
-
-
-def run_python(args):
-    if not args.no_tests:
-        run_python_tests(coverage=args.coverage)
-
-
-def parse_cli_args(args=None):
-    """Parse command-line arguments to this script.
-
-    Args:
-        args: List of cli arguments not including program name
-
-    Returns:
-        Instance of argparse.Namespace with the following boolean attributes:
-        py, js, selenium, full, no_tests, coverage
-
-    Raises:
-        SystemExit if arguments are invalid or --help is present.
-    """
-    p = argparse.ArgumentParser(description="Run Python unit tests and linters.")
-    p.add_argument(
-        "--no-tests", action="store_true", help="Skip tests, run only linters."
+def run_python_tests():
+    subprocess.check_call(
+        "pytest timesketch/ api_client/",
+        shell=True,
     )
-    p.add_argument(
-        "--coverage", action="store_true", help="Print code coverage report."
-    )
-    return p.parse_args(args)
 
 
 def main():
-    args = parse_cli_args()
-    run_python(args)
+    run_python_tests()
 
 
 main()

--- a/run_tests.py
+++ b/run_tests.py
@@ -5,7 +5,7 @@ import subprocess
 
 def run_python_tests():
     subprocess.check_call(
-        "pytest timesketch/ api_client/",
+        "python3 -m pytest timesketch/ api_client/",
         shell=True,
     )
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,3 +5,5 @@ pbr >= 4.2.0
 beautifulsoup4 >= 4.8.2
 coverage >= 5.0.2
 httmock >= 1.3.0
+pylint==2.6.0
+astroid==2.4.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,6 @@
 Flask-Testing >= 0.6.2
 mock >= 2.0.0
-nose >= 1.3.7
+pytest==7.1.3
 pbr >= 4.2.0
 beautifulsoup4 >= 4.8.2
 coverage >= 5.0.2

--- a/timesketch/lib/analyzers/safebrowsing.py
+++ b/timesketch/lib/analyzers/safebrowsing.py
@@ -5,10 +5,10 @@ import fnmatch
 import logging
 import re
 
-import pkg_resources
 import requests
 from flask import current_app
 
+from timesketch.version import get_version as get_timesketch_version
 from timesketch.lib.analyzers import interface
 from timesketch.lib.analyzers import manager
 
@@ -67,7 +67,7 @@ class SafeBrowsingSketchPlugin(interface.BaseAnalyzer):
 
         self._google_client_version = current_app.config.get(
             "SAFEBROWSING_CLIENT_VERSION",
-            pkg_resources.get_distribution("timesketch").version,
+            get_timesketch_version(),
         )
 
     def _is_url_allowlisted(self, url, allowlist):


### PR DESCRIPTION
This PR updates our Docker images and CI tests to use Ubuntu 22.04. We still suport 20.04, but with the caveat that 20.04 won't have Plaso versions > 20220724.

* Changed Ubuntu base version to 22.04 on all Docker images, and made it the default.
* Added 22.04 to the OS matrix in GH actions to run all tests on that version
* Cleaned up actions and removed legacy workarounds
* Temporarily removed PPA tests as this process need to be updated. This work is tracked in #2373  
* Migrated away from `nosetests` -> `pytest` - nosetest has been deprecated and don't work on Python 3.10, hence can't run on our CI infrastructure.
* Use ubuntu-latest as our host OS on GH actions.
* Bumped celery, pandas, numpy and redis to new versions supporting Python 3.10