### PR TITLE
re-adding console.error(error.response.data)

### DIFF
--- a/timesketch/frontend-ng/src/utils/RestApiClient.js
+++ b/timesketch/frontend-ng/src/utils/RestApiClient.js
@@ -53,6 +53,8 @@ RestApiClient.interceptors.response.use(
         },
       })
     } else {
+      // TODO: Consider removing that if a global Error handling is established
+      console.error(error.response.data)
       Snackbar.open({
         message: error.response.data.message,
         type: 'is-white',


### PR DESCRIPTION
In the past, a general consol.error was used for the REST API client in JS, that was not yet ported over.

This PR is re-adding that

**Checks**

- [ ] All tests succeed.
- [ ] Unit tests added.
- [ ] e2e tests added.
- [ ] Documentation updated.
