### PR TITLE
geoip attribution

### DIFF
--- a/data/timesketch.conf
+++ b/data/timesketch.conf
@@ -259,6 +259,25 @@ YETI_API_KEY = ''
 # Labels to narrow down indicator selection
 YETI_INDICATOR_LABELS = ['domain']
 
+# GeoIP Analyzer Settings
+#
+# Disclaimer: Please note that the geolocation results obtained from this analyzer
+# are indicative and based upon the accuracy of the configured datasource.
+# This analyzer uses GeoLite2 data created by MaxMind, available from
+# https://maxmind.com.
+
+# The path to a MaxMind GeoIP database
+MAXMIND_DB_PATH = ''
+
+# The Account ID to access a MaxMind GeoIP web service
+MAXMIND_WEB_ACCOUNT_ID = ''
+
+# The license key to access a MaxMind GeoIP web service
+MAXMIND_WEB_LICENSE_KEY = ''
+
+# The host URL of a MaxMind GeoIP web service
+MAXMIND_WEB_HOST = ''
+
 #-------------------------------------------------------------------------------
 # Enable experimental UI features.
 
@@ -292,24 +311,8 @@ SIGMA_RULE_STATUS_CSV = '/etc/timesketch/sigma_rule_status.csv'
 # Max age in seconds for CSRF tokens. Default is 3600. If set to None, the CSRF token is valid for the life of the session.
 # WTF_CSRF_TIME_LIMIT = 7200
 # WTF_CSRF_ENABLED = False # Set this to False for UI-development purposes
-#------
-# GeoIP Analyzer Settings
-#
-# Disclaimer: Please note that the geolocation results obtained from this analyzer
-# are indicative and based upon the accuracy of the configured datasource.
 
-# The path to a MaxMind GeoIP database
-MAXMIND_DB_PATH = ''
-
-# The Account ID to access a MaxMind GeoIP web service
-MAXMIND_WEB_ACCOUNT_ID = ''
-
-# The license key to access a MaxMind GeoIP web service
-MAXMIND_WEB_LICENSE_KEY = ''
-
-# The host URL of a MaxMind GeoIP web service
-MAXMIND_WEB_HOST = ''
-
+#-------------------------------------------------------------------------------
 # Scenarios
 SCENARIOS_PATH = '/etc/timesketch/scenarios/scenarios.yaml'
 FACETS_PATH = '/etc/timesketch/scenarios/facets.yaml'

--- a/timesketch/lib/analyzers/geoip.py
+++ b/timesketch/lib/analyzers/geoip.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This geoip analyzer uses GeoLite2 data created by MaxMind,
+# available from https://maxmind.com
+
 """Sketch analyzer plugin for geolocating IP addresses."""
 
 import os
@@ -345,7 +348,7 @@ class MaxMindDbGeoIPAnalyzer(BaseGeoIpAnalyzer):
     DISPLAY_NAME = "Geolocate IP addresses (MaxMind Database based)"
     DESCRIPTION = (
         "Find the approximate geolocation of an IP address using "
-        + "a MaxMind GeoLite2 database"
+        "a MaxMind GeoLite2 database, available from https://maxmind.com"
     )
 
 
@@ -357,7 +360,7 @@ class MaxMindDbWebIPAnalyzer(BaseGeoIpAnalyzer):
     DISPLAY_NAME = "Geolocate IP addresses (MaxMind Web client based)"
     DESCRIPTION = (
         "Find the approximate geolocation of an IP address using "
-        + "a MaxMind GeoLite2 web client API"
+        "a MaxMind GeoLite2 web client API, available from https://maxmind.com"
     )
 
 


### PR DESCRIPTION
Moving the geoip analyzer config values into the analyzer section of `timesketch.conf` and adding the MaxMind attribution.