### PR TITLE
Update SearchTemplates.vue to check if no searchTemplates are on a system

### DIFF
--- a/timesketch/frontend-ng/src/components/LeftPanel/SearchTemplates.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/SearchTemplates.vue
@@ -80,6 +80,9 @@ export default {
     ApiClient.getSearchTemplates()
       .then((response) => {
         this.searchtemplates = response.data.objects[0]
+        if (typeof(this.searchtemplates) == 'undefined') {
+          this.searchtemplates = []
+        }
       })
       .catch((e) => {})
   },

--- a/timesketch/frontend-ng/src/components/LeftPanel/SearchTemplates.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/SearchTemplates.vue
@@ -80,7 +80,7 @@ export default {
     ApiClient.getSearchTemplates()
       .then((response) => {
         this.searchtemplates = response.data.objects[0]
-        if (typeof(this.searchtemplates) == 'undefined') {
+        if (typeof(this.searchtemplates) === 'undefined') {
           this.searchtemplates = []
         }
       })


### PR DESCRIPTION
Fixes: https://github.com/google/timesketch/issues/2395
Currently if no SearchTemplates are installed on a system, the check for lengths in the UI does fail because the API returns undefined.

This fix addresses that.

**Checks**

- [x] All tests succeed.
- [x] Unit tests added.
- [x] e2e tests added.
- [x] Documentation updated.

**Closing issues**

closes #2395