### PR TITLE
2022 12 02 tscl sketch info

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,51 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+alembic = "==1.3.2"
+altair = "==4.1.0"
+celery = "==4.4.0"
+cryptography = "==3.3.2"
+datasketch = "==1.5.0"
+elasticsearch = "==7.5.1"
+google-auth = "==1.7.0"
+google-auth-oauthlib = "==0.4.1"
+gunicorn = "==19.10.0"
+numpy = "==1.19.0"
+oauthlib = "==3.1.0"
+pandas = "==1.1.3"
+python-dateutil = "==2.8.1"
+redis = "==3.3.11"
+requests = "==2.25.1"
+sigmatools = "==0.19.1"
+six = "==1.12.0"
+xlrd = "==1.2.0"
+tabulate = "==0.8.6"
+networkx = "==2.5"
+prometheus-client = "==0.9.0"
+prometheus-flask-exporter = "==0.18.1"
+decorator = "==5.0.5"
+geoip2 = "==4.2.0"
+Flask = "==1.1.1"
+Flask-Bcrypt = "==0.7.1"
+Flask-Login = "==0.4.1"
+Flask-Migrate = "==2.5.2"
+Flask-RESTful = "==0.3.7"
+Flask-Script = "==2.0.6"
+Flask-SQLAlchemy = "==2.4.1"
+Flask-WTF = "==0.14.2"
+PyJWT = "==1.7.1"
+PyYAML = "==5.4.1"
+SQLAlchemy = "==1.3.12"
+Werkzeug = "==0.16.0"
+WTForms = "==2.2.1"
+Markdown = "==3.2.2"
+prettytable = "==3.5.0"
+
+
+[dev-packages]
+
+[requires]
+python_version = "3.9"

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,4 @@ prometheus-client==0.9.0
 prometheus-flask-exporter==0.18.1
 decorator==5.0.5
 geoip2==4.2.0
+prettytable==3.5.0

--- a/timesketch/tsctl.py
+++ b/timesketch/tsctl.py
@@ -21,6 +21,7 @@ import yaml
 import click
 from flask.cli import FlaskGroup
 from sqlalchemy.exc import IntegrityError
+from prettytable import PrettyTable
 
 from timesketch import version
 from timesketch.app import create_app
@@ -442,3 +443,62 @@ def export_sigma_rules(path):
             fw.write(rule.rule_yaml.encode("utf-8"))
         n = n + 1
     print(f"{n} Sigma rules exported")
+
+@cli.command(name="sketch-info")
+@click.argument("sketch_id")
+def sketch_info(sketch_id):
+    """Give information about a sketch."""
+    sketch = Sketch.query.filter_by(id=sketch_id).first()
+    if not sketch:
+        print("Sketch does not exist.")
+    else:
+        print(f"Sketch {sketch_id} Name: ({sketch.name})")
+
+        table = PrettyTable()
+        table.field_names = [
+            "searchindex_id",
+            "index_name",
+            "created_at",
+            "user_id",
+            "description",
+        ]
+
+        for t in sketch.active_timelines:
+            table.add_row(
+                [
+                    t.searchindex_id,
+                    t.searchindex.index_name,
+                    t.created_at,
+                    t.user_id,
+                    t.description,
+                ]
+            )
+
+        print(f"active_timelines:\n{table}")
+
+        print(f"Shared with:")
+        print(f"\tUsers:")
+        for user in sketch.collaborators:
+            print(f"\t\t{user.id}: {user.username}")
+        print(f"\tGroups:")
+        for group in sketch.groups:
+            print(f"\t\t{group.display_name}")
+        sketch_labels = [label.label for label in sketch.labels]
+        print(f"Sketch Status: {sketch.get_status.status}")
+        print(f"Sketch is public: {bool(sketch.is_public)}")
+        sketch_labels = ([label.label for label in sketch.labels],)
+        print(f"Sketch Labels: {sketch_labels}")
+
+        status_table = PrettyTable()
+        status_table.field_names = [
+            "id",
+            "status",
+            "created_at",
+            "user_id",
+        ]
+        for status in sketch.status:
+            status_table.add_row(
+                [status.id, status.status, status.created_at, status.user_id]
+            )
+        print(f"Status:\n{status_table}")
+


### PR DESCRIPTION
In various debugging sessions, it might be useful to directly get information about a sketch without using the API but on the system itself.

This PR adds a new argument to tsctl that can do this.

**Checks**

- [ ] All tests succeed.
- [ ] Unit tests added.
- [ ] e2e tests added.
- [ ] Documentation updated.
