### PR TITLE
Context lookup part 2 - front-end API client

### DIFF
--- a/timesketch/frontend-ng/src/store.js
+++ b/timesketch/frontend-ng/src/store.js
@@ -42,7 +42,8 @@ const defaultState = (currentUser) => {
       color: "",
       message: "",
       timeout: -1
-    }
+    },
+    contextLinkConf: {},
   }
 }
 
@@ -108,6 +109,9 @@ export default new Vuex.Store({
         let currentUser = response.data.objects[0].username
         Object.assign(state, defaultState(currentUser))
       })
+    },
+    SET_CONTEXT_LINKS(state, payload) {
+      Vue.set(state, 'contextLinkConf', payload)
     },
   },
   actions: {
@@ -217,6 +221,13 @@ export default new Vuex.Store({
         message: snackbar.message,
         timeout: snackbar.timeout
       });
-    }
+    },
+    updateContextLinks(context) {
+      ApiClient.getContextLinkConfig()
+        .then((response) => {
+          context.commit('SET_CONTEXT_LINKS', response.data)
+      })
+      .catch((e) => { })
+    },
   },
 })

--- a/timesketch/frontend-ng/src/utils/RestApiClient.js
+++ b/timesketch/frontend-ng/src/utils/RestApiClient.js
@@ -391,4 +391,7 @@ export default {
     let formData = { status: status }
     return RestApiClient.post('/sketches/' + sketchId + '/scenarios/' + scenarioId + '/status/', formData)
   },
+  getContextLinkConfig() {
+    return RestApiClient.get('/contextlinks/')
+  },
 }

--- a/timesketch/frontend-ng/src/views/Sketch.vue
+++ b/timesketch/frontend-ng/src/views/Sketch.vue
@@ -265,6 +265,7 @@ export default {
       this.$store.dispatch('updateScenarios', this.sketchId)
       this.$store.dispatch('updateScenarioTemplates', this.sketchId)
       this.$store.dispatch('updateSigmaList', this.sketchId)
+      this.$store.dispatch('updateContextLinks', this.sketchId)
     })
   },
   updated() {

--- a/timesketch/frontend-ng/src/views/Sketch.vue
+++ b/timesketch/frontend-ng/src/views/Sketch.vue
@@ -265,7 +265,7 @@ export default {
       this.$store.dispatch('updateScenarios', this.sketchId)
       this.$store.dispatch('updateScenarioTemplates', this.sketchId)
       this.$store.dispatch('updateSigmaList', this.sketchId)
-      this.$store.dispatch('updateContextLinks', this.sketchId)
+      this.$store.dispatch('updateContextLinks')
     })
   },
   updated() {


### PR DESCRIPTION
**This PR is part two of working on issue #2439 to create a context lookup for event fields.**

This PR includes:

- Adding a method to the front-end API client to get the context link configuration data.
- Adding the context link configuration data to the vue store.
- Loading the data together with the sketch view.