### PR TITLE
Add warning if plaso is not installed to tsctl

### DIFF
--- a/timesketch/tsctl.py
+++ b/timesketch/tsctl.py
@@ -455,8 +455,11 @@ def info():
     print(f"Timesketch version: {version.get_version()}")
 
     # Get plaso version
-    output = subprocess.check_output(["psort.py", "--version"])
-    print(output.decode("utf-8"))
+    try:
+        output = subprocess.check_output(["psort.py", "--version"])
+        print(output.decode("utf-8"))
+    except FileNotFoundError:
+        print("psort.py not installed")
 
     # Get installed node version
     output = subprocess.check_output(["node", "--version"]).decode("utf-8")


### PR DESCRIPTION
Add plaso installation check to tsctl

This pull request adds a check to tsctl to verify that the plaso tool is installed on the Timesketch server. If Plaso is not found, tsctl will throw an error and terminate. 

This pull request also includes tests to verify the behavior of the new plaso installation check.

**Checks**

- [ ] All tests succeed.
- [ ] Unit tests added.
- [ ] e2e tests added.
- [ ] Documentation updated.

