### PR TITLE
Context lookup part 4 - Documentation

### DIFF
--- a/docs/changelog/2022-12.md
+++ b/docs/changelog/2022-12.md
@@ -9,7 +9,7 @@ Get information about the environment.
 `sketch-info` has been added to the tsctl command line tool to:
 - get information about a specific sketch
 
-Visit [../guides/admin/admin-cli](CLI howto) for more information
+Visit [CLI howto](../guides/admin/admin-cli) for more information
 
 ## tsctl documentation
 
@@ -17,4 +17,10 @@ Updates the tsctl admin command-line interface (CLI) documentation to include th
 
 The updated documentation also includes examples and usage scenarios for each subcommand, to help users understand how to use the tsctl CLI effectively.
 
-Visit [../guides/admin/admin-cli](CLI howto) for more information
+Visit [CLI howto](../guides/admin/admin-cli) for more information
+
+## Context Links
+
+With [#2439](https://github.com/google/timesketch/issues/2439) we introduced context links to the v2 UI. This feature allows linking specific event values to external lookup services for an easy analyst workflow. Now this hash lookup with your favorite CTI platform is just two clicks away.
+
+Check out the [context link documentation](../guides/admin/context-links.md) for more information.

--- a/docs/guides/admin/admin-cli.md
+++ b/docs/guides/admin/admin-cli.md
@@ -532,3 +532,43 @@ All rules deleted
 tsctl provides a subcommand for starting an interactive Python shell with the Timesketch API client pre-initialized. This subcommand is called `shell`, and it allows you to access the Timesketch API and perform various operations using the Python interpreter.
 
 To use the `shell` subcommand, you would run `tsctl shell` followed by the desired options and arguments. For example, to start an interactive Python shell with the Timesketch API client pre-initialized, you could run the following command: `tsctl shell`.
+
+### Context Links Configuration
+
+We can use `tsctl` to test the yaml config file for the context link feature.
+This is especially useful if an entry that is added to the configuration file
+does not show up as a context link in the frontend.
+
+```
+tsctl validate-context-links-conf <PATH TO CONFIG FILE>
+```
+
+The default config can be found at `data/context_links.yaml` .
+
+The output will tell if there is a value not matching the schema requirements:
+
+**No error:** All entries in the configuration file match the schema requirements.
+```
+$ tsctl validate-context-links-conf ./context_links.yaml
+=> OK: "virustotal"
+=> OK: "unfurl"
+=> OK: "mseventid"
+=> OK: "urlhaus"
+```
+
+**With an error:** Here the validator tells us that there is an error with the
+replacement pattern in the `context_link` entry.
+```
+$ tsctl validate-context-links-conf ./context_links.yaml
+=> ERROR: "virustotal" >> 'https://www.virustotal.com/gui/search/<ATTR_VALUE' does not match '<ATTR_VALUE>'
+
+Failed validating 'pattern' in schema['properties']['context_link']:
+    {'pattern': '<ATTR_VALUE>', 'type': 'string'}
+
+On instance['context_link']:
+    'https://www.virustotal.com/gui/search/<ATTR_VALUE'
+
+=> OK: "unfurl"
+=> OK: "mseventid"
+=> OK: "urlhaus"
+```

--- a/docs/guides/admin/context-links.md
+++ b/docs/guides/admin/context-links.md
@@ -1,0 +1,139 @@
+# Context Links
+
+This feature was introduced as part of [#2439](https://github.com/google/timesketch/issues/2439) and allows linking of specific event attributes and values to external lookup services for an easy analyst workflow.
+
+## Demo
+
+![TS_ContextLinks_RedirectWarn](https://user-images.githubusercontent.com/99879757/205897124-00154a89-e58a-4cf0-a89e-ba3b4f3052d8.gif)
+
+## How-To configure
+
+The context link feature is configured in a yaml file that needs to be added to the [timesketch.conf](https://github.com/google/timesketch/blob/master/data/timesketch.conf#L325) file. Add the path to the yaml config file in the `CONTEXT_LINKS_CONFIG_PATH` variable.
+
+Per default the `CONTEXT_LINKS_CONFIG_PATH` entry in `timesketch.conf` points to the [context_links.yaml](https://github.com/google/timesketch/blob/master/data/context_links.yaml) file in the `data` folder. It contains a documentation of available fields and a commented example entry for setting up a hash-lookup with [virustotal](https://www.virustotal.com/).
+
+**Important: You can add a context link only for services that allow a lookup via URL GET parameter.**
+
+### Configuration fields
+
+Each context link consists of the following fields:
+
+```
+context_link_name:
+
+  short_name:       Type: str | The name for the context link.
+                    Will be displayed in the context link submenu.
+
+  match_fields:     Type: list[str] | List of field keys where
+                    this context link should be available. Will
+                    be checked as case insensitive!
+
+  validation_regex: Type: str | OPTIONAL
+                    A regex pattern that needs to be
+                    matched by the field value to to make the
+                    context link available. This can be used to
+                    validate the format of a value (e.g. a hash).
+
+  context_link:     Type: str | The link that will be opened in a
+                    new tab when the context link is clicked.
+                    IMPORTANT: Add the placeholder "<ATTR_VALUE>"
+                    where the attribute value should be inserted
+                    into the link.
+
+  redirect_warning: [TRUE]: If the context link is clicked it will
+                            open a pop-up dialog first that asks the
+                            user if they would like to proceed to
+                            the linked page. (Recommended for
+                            external pages.)
+                    [FALSE]: The linked page will be opened without
+                             any pop-up. (Recommended for internal
+                             pages.)
+```
+
+### Test configuration
+
+If we want to test our configuration we can use the
+`tsctl validate-context-links-conf` > [here](https://github.com/google/timesketch/blob/master/docs/guides/admin/admin-cli.md#context-links).
+
+## Example entries
+
+Below you can find a list of example entries for popular public lookup services.
+
+**NOTE:** Before running those examples in your environment, verify that the `match_fields` and `validation_regex` work with your data! If you add a field to one of the examples that contain a regex, you need to extend this as well.
+
+### Virustotal
+
+```
+virustotal:
+  short_name: 'VirusTotal'
+  match_fields: ['hash', 'sha256_hash', 'sha256', 'sha1_hash', 'sha1', 'md5_hash', 'md5', 'url']
+  validation_regex: '/^[0-9a-f]{64}$|^[0-9a-f]{40}$|^[0-9a-f]{32}$|((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/i'
+  context_link: 'https://www.virustotal.com/gui/search/<ATTR_VALUE>'
+  redirect_warning: TRUE
+```
+
+### Unfurl
+
+```
+unfurl:
+  short_name: 'unfurl'
+  match_fields: ['url', 'uri']
+  validation_regex: '/((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/i'
+  context_link: 'https://dfir.blog/unfurl/<ATTR_VALUE>'
+  redirect_warning: TRUE
+```
+
+### Microsoft Event ID lookup
+
+Via the [MS Threat Protection documentation](https://learn.microsoft.com/en-us/windows/security/threat-protection/):
+
+```
+mseventid:
+  short_name: 'MS-TP eventID'
+  match_fields: ['event_identifier']
+  context_link: 'https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/event-<ATTR_VALUE>'
+  redirect_warning: TRUE
+```
+
+Via [Ultimate Windows Security](https://www.ultimatewindowssecurity.com/securitylog/):
+
+```
+uws-eventid:
+  short_name: 'UWS eventID'
+  match_fields: ['event_identifier']
+  context_link: 'https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventID=<ATTR_VALUE>'
+  redirect_warning: TRUE
+```
+
+### urlscan.io
+
+```
+urlscanio:
+  short_name: 'urlscan.io'
+  match_fields: ['url', 'uri']
+  validation_regex: '/((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/i'
+  context_link: 'https://urlscan.io/search/#<ATTR_VALUE>'
+  redirect_warning: TRUE
+  ```
+
+### abuse.ch URLhaus
+
+```
+urlhaus:
+  short_name: 'URLhaus'
+  match_fields: ['hash', 'sha256_hash', 'sha256', 'sha1_hash', 'sha1', 'md5_hash', 'md5', 'url']
+  validation_regex: '/^[0-9a-f]{64}$|^[0-9a-f]{40}$|^[0-9a-f]{32}$|((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/i'
+  context_link: 'https://urlhaus.abuse.ch/browse.php?search=<ATTR_VALUE>'
+  redirect_warning: TRUE
+```
+
+### AlienVault OTX
+
+```
+alienvault:
+  short_name: 'alienvault OTX'
+  match_fields: ['hash', 'sha256_hash', 'sha256', 'sha1_hash', 'sha1', 'md5_hash', 'md5', 'url', 'domain', 'ipv4']
+  validation_regex: ''
+  context_link: 'https://otx.alienvault.com/browse/global/pulses?q=<ATTR_VALUE>'
+  redirect_warning: TRUE
+```

--- a/timesketch/tsctl.py
+++ b/timesketch/tsctl.py
@@ -23,7 +23,7 @@ import click
 from flask.cli import FlaskGroup
 from sqlalchemy.exc import IntegrityError
 from prettytable import PrettyTable
-from jsonschema import validate, ValidationError
+from jsonschema import validate, ValidationError, SchemaError
 
 from timesketch import version
 from timesketch.app import create_app
@@ -547,6 +547,7 @@ def validate_context_links_conf(path):
     """Validates the provided context link yaml configuration file."""
 
     schema = {
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "properties": {
             "context_link": {
@@ -596,5 +597,5 @@ def validate_context_links_conf(path):
         try:
             validate(instance=context_link_config[entry], schema=schema)
             print(f'=> OK: "{entry}"')
-        except ValidationError as err:
+        except (ValidationError, SchemaError) as err:
             print(f'=> ERROR: "{entry}" >> {err}\n')


### PR DESCRIPTION
**This PR is part two of working on issue #2439 to create a context lookup for event fields.**

This PR includes:

- Adding info to the changelog for 2022-12.
- Adding info about the `tsctl` context link config validation to the admin-cli doc.
- Adding a new documentation for the context links to admin guides.
  - This document also contains multiple example entries for public lookup services.
- Fixing a bug in the `tsctl validate-context-links-conf` command.