### PR TITLE
Update Nginx configuration to allow use of custom ports

### DIFF
--- a/contrib/nginx.conf
+++ b/contrib/nginx.conf
@@ -12,7 +12,7 @@ http {
             proxy_buffers 4 256k;
             proxy_busy_buffers_size 256k;
             proxy_pass http://timesketch-web:5000;
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
@@ -21,7 +21,7 @@ http {
             proxy_buffers 4 256k;
             proxy_busy_buffers_size 256k;
             proxy_pass http://timesketch-web-v2:5000;
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
         }


### PR DESCRIPTION
The current nginx configuration doesn't support exposing Timesketch on non-standard ports; because the proxy_set_header Host field doesn't include the port number, so any Timesketch redirects go back to the default port. This PR updates the nginx configuration to use the $http_host variable which will include the port number.

**IMPORTANT: All Pull Requests should be connected to an issue, if you don't
have an issue, please start by creating an issue and link it to the PR.**

Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or adding a minor bug fix -->

+ What existing problem does this PR solve? #2458 
+ What new feature is being introduced with this PR?
+ Overview of changes to existing functions if required.

<!-- Example: This PR adds a function to do X, which adds the ability to do Y.
-->

**Checks**

- [ ] All tests succeed.
- [ ] Unit tests added.
- [ ] e2e tests added.
- [ ] Documentation updated.

**Closing issues**
Closes #2458 
Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes
(if such).
