### PR TITLE
Add copy event url to clipboard action

### DIFF
--- a/docs/changelog/2022-12.md
+++ b/docs/changelog/2022-12.md
@@ -28,3 +28,7 @@ Visit [CLI howto](../guides/admin/admin-cli) for more information
 With [#2439](https://github.com/google/timesketch/issues/2439) we introduced context links to the v2 UI. This feature allows linking specific event values to external lookup services for an easy analyst workflow. Now this hash lookup with your favorite CTI platform is just two clicks away.
 
 Check out the [context link documentation](../guides/admin/context-links.md) for more information.
+
+## "Copy url to event" button
+
+Added a new "Copy URL" button to the event details page in Timesketch timeline. This button allows users to easily copy the URL of the specific event to their clipboard, making it easier to share the event with others or to save the URL for later reference.

--- a/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
@@ -27,7 +27,7 @@ limitations under the License.
               <span>Copy event URL to clipboard</span>
             </v-tooltip>
           </v-btn>
-          <v-btn icon small @click="copyEventAsJSON(event)">
+          <v-btn icon small @click="copyEventAsJSON()">
             <v-tooltip top close-delay="300" :open-on-click="false">
               <template v-slot:activator="{ on }">
                 <v-icon v-on="on"> mdi-content-copy </v-icon>
@@ -345,8 +345,8 @@ export default {
       }
       return false
     },
-    copyEventAsJSON(event) {
-      let eventJSON = JSON.stringify(event, null, 2)
+    copyEventAsJSON() {
+      let eventJSON = JSON.stringify(this.fullEvent, null, 3)
       navigator.clipboard.writeText(eventJSON)
     },
     searchContext: function (event) {

--- a/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
@@ -16,6 +16,43 @@ limitations under the License.
 <template>
   <div>
     <v-row>
+      <v-card outlined height="100%">
+        Actions:
+        <v-btn-group>
+          <v-btn icon small @click="copyEventUrlToClipboard(event)">
+            <v-tooltip top close-delay="300" :open-on-click="false">
+              <template v-slot:activator="{ on }">
+                <v-icon v-on="on"> mdi-link </v-icon>
+              </template>
+              <span>Copy event URL to clipboard</span>
+            </v-tooltip>
+          </v-btn>
+          <v-btn icon small @click="copyEventAsJSON(event)">
+            <v-tooltip top close-delay="300" :open-on-click="false">
+              <template v-slot:activator="{ on }">
+                <v-icon v-on="on"> mdi-content-copy </v-icon>
+              </template>
+              <span>Copy event data as JSON to clipboard</span>
+            </v-tooltip>
+          </v-btn>
+          <v-btn small icon @click="toggleStar()">
+            <v-icon v-if="event._source.label.includes('__ts_star')" color="amber">mdi-star</v-icon>
+            <v-icon v-else>mdi-star-outline</v-icon>
+          </v-btn>
+          <ts-event-tag-menu :event="event"></ts-event-tag-menu>
+          <v-btn icon small @click="searchContext(event)">
+            <v-tooltip top close-delay="300" :open-on-click="false">
+              <template v-slot:activator="{ on }">
+                <v-icon v-on="on"> mdi-magnify </v-icon>
+              </template>
+              <span>Search +/- 5 min</span>
+            </v-tooltip>
+          </v-btn>
+        </v-btn-group>
+      </v-card>
+    </v-row>
+
+    <v-row>
       <v-col cols="8">
         <v-card outlined height="100%">
           <v-simple-table dense>
@@ -167,21 +204,6 @@ limitations under the License.
             </v-btn>
           </v-card-actions>
         </v-card>
-        <v-card>
-          <v-card outlined>
-            <v-toolbar dense flat>
-              <v-toolbar-title style="font-size: 1.2em">Actions</v-toolbar-title>
-            </v-toolbar>
-            <v-btn icon small @click="copyEventUrlToClipboard(item)">
-              <v-tooltip top close-delay="300" :open-on-click="false">
-                <template v-slot:activator="{ on }">
-                  <v-icon v-on="on"> mdi-link </v-icon>
-                </template>
-                <span>Copy event URL to clipboard</span>
-              </v-tooltip>
-            </v-btn>
-          </v-card>
-        </v-card>
       </v-col>
     </v-row>
     <br />
@@ -193,11 +215,13 @@ import ApiClient from '../../utils/RestApiClient'
 import EventBus from '../../main'
 import TsFormatXmlString from './FormatXMLString.vue'
 import TsLinkRedirectWarning from './LinkRedirectWarning.vue'
+import TsEventTagMenu from '../../components/Explore/EventTagMenu.vue'
 
 export default {
   components: {
     TsFormatXmlString,
     TsLinkRedirectWarning,
+    TsEventTagMenu,
   },
   props: ['event'],
   data() {
@@ -320,6 +344,13 @@ export default {
         }
       }
       return false
+    },
+    copyEventAsJSON(event) {
+      let eventJSON = JSON.stringify(event, null, 2)
+      navigator.clipboard.writeText(eventJSON)
+    },
+    searchContext: function (event) {
+      // TODO: not yet implemented
     },
     contextLinkRedirect(key, item, value) {
       const fieldConfList = this.contextLinkConf[key.toLowerCase()] ? this.contextLinkConf[key.toLowerCase()] : []

--- a/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
@@ -37,14 +37,9 @@ limitations under the License.
                           v-on="on"
                           @click="formatXMLString = true"
                         >
-                          <v-tooltip top close-delay=300 :open-on-click="false">
+                          <v-tooltip top close-delay="300" :open-on-click="false">
                             <template v-slot:activator="{ on }">
-                              <v-icon
-                                v-on="on"
-                                small
-                              >
-                                mdi-xml
-                              </v-icon>
+                              <v-icon v-on="on" small> mdi-xml </v-icon>
                             </template>
                             <span>Prettify XML</span>
                           </v-tooltip>
@@ -56,28 +51,12 @@ limitations under the License.
                         :xmlString="value"
                       ></ts-format-xml-string>
                     </v-dialog>
-                    <v-menu
-                      v-if="checkContextLinkDisplay(key, value)"
-                      offset-y
-                      transition="slide-y-transition"
-                    >
+                    <v-menu v-if="checkContextLinkDisplay(key, value)" offset-y transition="slide-y-transition">
                       <template v-slot:activator="{ on, attrs }">
-                        <v-btn
-                          icon
-                          color="primary"
-                          x-small
-                          style="cursor: pointer"
-                          v-bind="attrs"
-                          v-on="on"
-                        >
-                          <v-tooltip top close-delay=300 :open-on-click="false">
+                        <v-btn icon color="primary" x-small style="cursor: pointer" v-bind="attrs" v-on="on">
+                          <v-tooltip top close-delay="300" :open-on-click="false">
                             <template v-slot:activator="{ on }">
-                              <v-icon
-                                v-on="on"
-                                small
-                              >
-                                mdi-open-in-new
-                              </v-icon>
+                              <v-icon v-on="on" small> mdi-open-in-new </v-icon>
                             </template>
                             <span>Context Lookup</span>
                           </v-tooltip>
@@ -88,15 +67,13 @@ limitations under the License.
                           v-for="(item, index) in getContextLinkItems(key)"
                           :key="index"
                           style="cursor: pointer"
-                          @click.stop="contextLinkRedirect(key,item,value)"
+                          @click.stop="contextLinkRedirect(key, item, value)"
                         >
-                          <v-list-item-title v-if="getContextLinkRedirectState(key,item)" >{{ item }}</v-list-item-title>
-                          <v-list-item-title v-else >{{ item }}*</v-list-item-title>
-                          <v-dialog
-                            v-model="redirectWarnDialog"
-                            max-width="515"
-                            :retain-focus="false"
-                          >
+                          <v-list-item-title v-if="getContextLinkRedirectState(key, item)">{{
+                            item
+                          }}</v-list-item-title>
+                          <v-list-item-title v-else>{{ item }}*</v-list-item-title>
+                          <v-dialog v-model="redirectWarnDialog" max-width="515" :retain-focus="false">
                             <ts-link-redirect-warning
                               app
                               @cancel="redirectWarnDialog = false"
@@ -189,6 +166,21 @@ limitations under the License.
               <v-icon>mdi-send</v-icon>
             </v-btn>
           </v-card-actions>
+        </v-card>
+        <v-card>
+          <v-card outlined>
+            <v-toolbar dense flat>
+              <v-toolbar-title style="font-size: 1.2em">Actions</v-toolbar-title>
+            </v-toolbar>
+            <v-btn icon small @click="copyEventUrlToClipboard(item)">
+              <v-tooltip top close-delay="300" :open-on-click="false">
+                <template v-slot:activator="{ on }">
+                  <v-icon v-on="on"> mdi-link </v-icon>
+                </template>
+                <span>Copy event URL to clipboard</span>
+              </v-tooltip>
+            </v-btn>
+          </v-card>
         </v-card>
       </v-col>
     </v-row>
@@ -292,16 +284,19 @@ export default {
       changeComment.editable = enable
       this.comments.splice(commentIndex, 1, changeComment)
     },
-
     selectComment(comment) {
       this.selectedComment = comment
     },
     unSelectComment() {
       this.selectedComment = false
     },
+    copyEventUrlToClipboard() {
+      let eventUrl = window.location.origin + this.$route.path + '?q=_id:' + this.event._id
+      navigator.clipboard.writeText(eventUrl)
+    },
     getContextLinkItems(key) {
       let fieldConfList = this.contextLinkConf[key.toLowerCase()] ? this.contextLinkConf[key.toLowerCase()] : []
-      let shortNameList = fieldConfList.map(x => x.short_name)
+      let shortNameList = fieldConfList.map((x) => x.short_name)
       return shortNameList
     },
     checkContextLinkDisplay(key, value) {
@@ -309,17 +304,18 @@ export default {
       for (const confItem of fieldConfList) {
         if (confItem['validation_regex'] !== '' && confItem['validation_regex'] !== undefined) {
           let validationPattern = confItem['validation_regex']
-          let regexIdentifiers = validationPattern.slice(validationPattern.lastIndexOf('/')+1)
-          let regexPattern = validationPattern.slice(validationPattern.indexOf('/')+1, validationPattern.lastIndexOf('/'))
+          let regexIdentifiers = validationPattern.slice(validationPattern.lastIndexOf('/') + 1)
+          let regexPattern = validationPattern.slice(
+            validationPattern.indexOf('/') + 1,
+            validationPattern.lastIndexOf('/')
+          )
           let valueRegex = new RegExp(regexPattern, regexIdentifiers)
           if (valueRegex.test(value)) {
             return true
-          }
-          else {
+          } else {
             return false
           }
-        }
-        else {
+        } else {
           return true
         }
       }
@@ -333,8 +329,7 @@ export default {
             this.redirectWarnDialog = true
             this.contextValue = value
             this.contextUrl = confItem['context_link'].replace('<ATTR_VALUE>', encodeURIComponent(value))
-          }
-          else {
+          } else {
             // TODO verify if encodeURIComponent is sufficient sanitization here?
             window.open(confItem['context_link'].replace('<ATTR_VALUE>', encodeURIComponent(value)), '_blank')
             this.redirectWarnDialog = false
@@ -342,7 +337,7 @@ export default {
         }
       }
     },
-    getContextLinkRedirectState (key, item) {
+    getContextLinkRedirectState(key, item) {
       const fieldConfList = this.contextLinkConf[key.toLowerCase()] ? this.contextLinkConf[key.toLowerCase()] : []
       for (const confItem of fieldConfList) {
         if (confItem['short_name'] === item) {

--- a/timesketch/frontend-ng/src/views/Explore.vue
+++ b/timesketch/frontend-ng/src/views/Explore.vue
@@ -486,22 +486,20 @@ limitations under the License.
         </template>
         <!-- Actions field -->
         <template v-slot:item.actions="{ item }">
-          <td width="10%">
-            <v-btn small icon @click="toggleStar(item)">
-              <v-icon v-if="item._source.label.includes('__ts_star')" color="amber">mdi-star</v-icon>
-              <v-icon v-else>mdi-star-outline</v-icon>
-            </v-btn>
-            <!-- Tag menu -->
-            <ts-event-tag-menu :event="item"></ts-event-tag-menu>
-            <v-btn icon small @click="copyEventUrlToClipboard(item)">
-              <v-tooltip top close-delay="300" :open-on-click="false">
-                <template v-slot:activator="{ on }">
-                  <v-icon v-on="on"> mdi-link </v-icon>
-                </template>
-                <span>Copy event URL to clipboard</span>
-              </v-tooltip>
-            </v-btn>
-          </td>
+          <v-btn small icon @click="toggleStar(item)">
+            <v-icon v-if="item._source.label.includes('__ts_star')" color="amber">mdi-star</v-icon>
+            <v-icon v-else>mdi-star-outline</v-icon>
+          </v-btn>
+          <!-- Tag menu -->
+          <ts-event-tag-menu :event="item"></ts-event-tag-menu>
+          <v-btn icon small @click="copyEventUrlToClipboard(item)">
+            <v-tooltip top close-delay="300" :open-on-click="false">
+              <template v-slot:activator="{ on }">
+                <v-icon v-on="on"> mdi-link </v-icon>
+              </template>
+              <span>Copy event URL to clipboard</span>
+            </v-tooltip>
+          </v-btn>
         </template>
 
         <!-- Generic slot for any field type. Adds tags and emojis to the first column. -->

--- a/timesketch/frontend-ng/src/views/Explore.vue
+++ b/timesketch/frontend-ng/src/views/Explore.vue
@@ -739,7 +739,7 @@ export default {
         },
         {
           value: 'actions',
-          width: '90',
+          width: '120',
         },
         {
           value: '_source.comment',

--- a/timesketch/frontend-ng/src/views/Explore.vue
+++ b/timesketch/frontend-ng/src/views/Explore.vue
@@ -486,12 +486,22 @@ limitations under the License.
         </template>
         <!-- Actions field -->
         <template v-slot:item.actions="{ item }">
-          <v-btn small icon @click="toggleStar(item)">
-            <v-icon v-if="item._source.label.includes('__ts_star')" color="amber">mdi-star</v-icon>
-            <v-icon v-else>mdi-star-outline</v-icon>
-          </v-btn>
-          <!-- Tag menu -->
-          <ts-event-tag-menu :event="item"></ts-event-tag-menu>
+          <td width="10%">
+            <v-btn small icon @click="toggleStar(item)">
+              <v-icon v-if="item._source.label.includes('__ts_star')" color="amber">mdi-star</v-icon>
+              <v-icon v-else>mdi-star-outline</v-icon>
+            </v-btn>
+            <!-- Tag menu -->
+            <ts-event-tag-menu :event="item"></ts-event-tag-menu>
+            <v-btn icon small @click="copyEventUrlToClipboard(item)">
+              <v-tooltip top close-delay="300" :open-on-click="false">
+                <template v-slot:activator="{ on }">
+                  <v-icon v-on="on"> mdi-link </v-icon>
+                </template>
+                <span>Copy event URL to clipboard</span>
+              </v-tooltip>
+            </v-btn>
+          </td>
         </template>
 
         <!-- Generic slot for any field type. Adds tags and emojis to the first column. -->
@@ -1203,6 +1213,11 @@ export default {
     removeField: function (index) {
       this.selectedFields.splice(index, 1)
     },
+    copyEventUrlToClipboard(event) {
+      let eventUrl = window.location.origin + this.$route.path + '?q=_id:' + event._id
+      navigator.clipboard.writeText(eventUrl)
+    },
+
     toggleStar(event) {
       if (event._source.label.includes('__ts_star')) {
         event._source.label.splice(event._source.label.indexOf('__ts_star'), 1)


### PR DESCRIPTION
[BLOCKED (waiting for icon placement guidelines)] 

Create a button to copy the url of an event in Explore and event details view

It is still unclear where and how buttons should be added in the event row, so before we have a decision there, this PR at least show how it can be technically done.

https://github.com/google/timesketch/pull/2305
![copy event url](https://user-images.githubusercontent.com/741037/207637863-cdd4615b-2d79-42d2-83a5-e52c5b8d7c82.png)

**Checks**

- [ ] All tests succeed.
- [ ] Unit tests added.
- [ ] e2e tests added.
- [ ] Documentation updated.

closes #2371