### PR TITLE
Add proxy_read_timeout in gninx conf

### DIFF
--- a/contrib/nginx.conf
+++ b/contrib/nginx.conf
@@ -11,6 +11,7 @@ http {
             proxy_buffer_size 128k;
             proxy_buffers 4 256k;
             proxy_busy_buffers_size 256k;
+            proxy_read_timeout 120s;
             proxy_pass http://timesketch-web:5000;
             proxy_set_header Host $host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -20,6 +21,7 @@ http {
             proxy_buffer_size 128k;
             proxy_buffers 4 256k;
             proxy_busy_buffers_size 256k;
+            proxy_read_timeout 120s;
             proxy_pass http://timesketch-web-v2:5000;
             proxy_set_header Host $host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
This PR is linked to issue #2465.

Add "proxy_read_timeout" in nginx.conf to change if you need because you use queries that take long time (>60s).



**Closing issues**

closes #2465`
