### PR TITLE
Fixed Issue #2505 - interface BaseAnalyzer class name 

### DIFF
--- a/test_tools/timesketch/lib/analyzers/interface.py
+++ b/test_tools/timesketch/lib/analyzers/interface.py
@@ -557,7 +557,7 @@ class Sketch(object):
         self._context = context
 
 
-class BaseIndexAnalyzer(object):
+class BaseAnalyzer(object):
     """Base class for analyzers.
 
     Attributes:
@@ -716,7 +716,7 @@ class BaseIndexAnalyzer(object):
         self.datastore = context
 
 
-class BaseSketchAnalyzer(BaseIndexAnalyzer):
+class BaseSketchAnalyzer(BaseAnalyzer):
     """Base class for sketch analyzers.
 
     Attributes:


### PR DESCRIPTION
Change class name from `BaseIndexAnalyzer` to `BaseAnalyzer`