### PR TITLE
Sigma add syslog:line to ssh data_types

### DIFF
--- a/data/sigma_config.yaml
+++ b/data/sigma_config.yaml
@@ -258,6 +258,7 @@ logsources:
     conditions:
       data_type:
         - "syslog:ssh:login"
+        - "syslog:line"
 fieldmappings:
     EventID: event_identifier
     ComputerName: computer_name


### PR DESCRIPTION
Modify data type for ssh to also take syslog:line as a data type.