### PR TITLE
[SigmaStudio]don't mutate the prop

### DIFF
--- a/timesketch/frontend-ng/src/components/Studio/SigmaRuleModification.vue
+++ b/timesketch/frontend-ng/src/components/Studio/SigmaRuleModification.vue
@@ -131,7 +131,6 @@ export default {
       this.ruleYamlTextArea = defaultSigmaPlaceholder
       this.editingRule.rule_yaml = defaultSigmaPlaceholder
       this.parseSigma(this.editingRule.rule_yaml)
-      this.rule_uuid = this.editingRule.rule_uuid
     },
     selectTemplate(text) {
       var matchingTemplate = this.SigmaTemplates.find((obj) => {
@@ -154,7 +153,6 @@ export default {
             this.isParsingSuccesful = false
           } else {
             this.editingRule = parsedRule
-            this.rule_uuid = parsedRule.uuid
             this.isParsingSuccesful = true
             this.status_text = ''
           }

--- a/timesketch/frontend-ng/src/utils/SigmaRuleTemplates.js
+++ b/timesketch/frontend-ng/src/utils/SigmaRuleTemplates.js
@@ -31,7 +31,7 @@ status: experimental
 falsepositives: unknown
 level: informational
 tags:
-    -`
+    - attack.defense_evasion`
 
 // General last part of every Sigma rule:
 const SkeletonLast = `falsepositives:


### PR DESCRIPTION
Small fix in Sigma Studio to not mutate a prob and adding a sample tag to the template, otherwise everyone using a template gets a error by default

closes #2542