### PR TITLE
Add Context card for scenarios

### DIFF
--- a/timesketch/frontend-ng/src/assets/main.scss
+++ b/timesketch/frontend-ng/src/assets/main.scss
@@ -144,6 +144,19 @@ html {
   background-color: #303030;
 }
 
+.light-info-card {
+  background-color: rgba(33, 150, 243, .1);
+  color: #333;
+  border-radius: 6px;
+}
+
+.dark-info-card {
+  background-color: rgba(33, 150, 243, .1);
+  color:#fff;
+  border-radius: 6px;
+  border:1px solid rgba(33, 150, 243, 0.3);
+}
+
 .timeline-name-ellipsis {
   width: 200px;
   white-space: nowrap;

--- a/timesketch/frontend-ng/src/components/Explore/EventActionMenu.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventActionMenu.vue
@@ -14,24 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <template>
-  <v-menu
-    v-model="showMenu"
-    offset-y
-    transition="slide-y-transition"
-  >
+  <v-menu v-model="showMenu" offset-y transition="slide-y-transition">
     <template v-slot:activator="{ on, attrs }">
-      <v-icon v-bind="attrs" v-on="on" class="ml-1">mdi-dots-vertical</v-icon>
+      <v-icon v-bind="attrs" v-on="on" class="ml-2">mdi-dots-vertical</v-icon>
     </template>
     <v-list dense class="mx-auto">
       <v-list-item style="cursor: pointer" @click="copyEventUrlToClipboard()">
-        <v-list-item-title>
-          <v-icon>mdi-link-variant</v-icon> Copy link to event
-        </v-list-item-title>
+        <v-list-item-title> <v-icon>mdi-link-variant</v-icon> Copy link to event </v-list-item-title>
       </v-list-item>
-      <v-list-item style="cursor: pointer"  @click="copyEventAsJSON()">
-        <v-list-item-title>
-          <v-icon>mdi-code-json</v-icon> Copy event data as JSON
-        </v-list-item-title>
+      <v-list-item style="cursor: pointer" @click="copyEventAsJSON()">
+        <v-list-item-title> <v-icon>mdi-code-json</v-icon> Copy event data as JSON </v-list-item-title>
       </v-list-item>
     </v-list>
   </v-menu>

--- a/timesketch/frontend-ng/src/components/Explore/EventTagMenu.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventTagMenu.vue
@@ -16,7 +16,7 @@ limitations under the License.
 <template>
   <v-menu v-model="showMenu" offset-x :close-on-content-click="false">
     <template v-slot:activator="{ on, attrs }">
-      <v-icon v-bind="attrs" v-on="on" class="ml-2">mdi-tag-plus-outline</v-icon>
+      <v-icon v-bind="attrs" v-on="on">mdi-tag-plus-outline</v-icon>
     </template>
 
     <v-card min-width="500px" class="mx-auto">

--- a/timesketch/frontend-ng/src/components/LeftPanel/DataTypes.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/DataTypes.vue
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <template>
-  <div v-if="dataTypes.length">
+  <div>
     <div class="pa-4" flat :class="$vuetify.theme.dark ? 'dark-hover' : 'light-hover'">
       <span style="cursor: pointer" @click="expanded = !expanded"
         ><v-icon left>mdi-database-outline</v-icon> Data Types (<small
@@ -26,7 +26,7 @@ limitations under the License.
     <v-expand-transition>
       <div v-show="expanded">
         <v-data-iterator :items="dataTypes" :items-per-page.sync="itemsPerPage" :search="search">
-          <template v-slot:header>
+          <template v-slot:header v-if="dataTypes.length > itemsPerPage">
             <v-toolbar flat>
               <v-text-field
                 v-model="search"

--- a/timesketch/frontend-ng/src/components/LeftPanel/SearchTemplates.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/SearchTemplates.vue
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <template>
-  <div v-if="searchtemplates.length">
+  <div>
     <div class="pa-4" flat :class="$vuetify.theme.dark ? 'dark-hover' : 'light-hover'">
       <span style="cursor: pointer" @click="expanded = !expanded"
         ><v-icon left>mdi-text-box-search-outline</v-icon> Search Templates (<small

--- a/timesketch/frontend-ng/src/components/LeftPanel/SigmaRules.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/SigmaRules.vue
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <template>
-  <div v-if="ruleCount > 0">
+  <div>
     <v-row
       no-gutters
       style="cursor: pointer"

--- a/timesketch/frontend-ng/src/components/LeftPanel/Tags.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/Tags.vue
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <template>
-  <div v-if="tags.length">
+  <div>
     <div class="pa-4" flat :class="$vuetify.theme.dark ? 'dark-hover' : 'light-hover'">
       <span style="cursor: pointer" @click="expanded = !expanded"
         ><v-icon left>mdi-tag-multiple-outline</v-icon> Tags (<small
@@ -24,7 +24,7 @@ limitations under the License.
     </div>
 
     <v-expand-transition>
-      <div v-show="expanded">
+      <div v-show="expanded && tags.length">
         <v-row
           no-gutters
           v-for="label in labels"

--- a/timesketch/frontend-ng/src/components/Scenarios/Question.vue
+++ b/timesketch/frontend-ng/src/components/Scenarios/Question.vue
@@ -17,36 +17,19 @@ limitations under the License.
   <div>
     <v-divider></v-divider>
     <div
-      class="pa-2 pl-10"
+      class="pa-2 pl-3"
       @click="expanded = !expanded"
       style="cursor: pointer; font-size: 0.9em"
-      :class="[
-        $vuetify.theme.dark ? 'dark-hover' : 'light-hover',
-        !$vuetify.theme.dark && expanded ? 'light-highlight' : '',
-        $vuetify.theme.dark && expanded ? 'dark-highlight' : '',
-      ]"
+      :class="[$vuetify.theme.dark ? 'dark-hover' : 'light-hover']"
     >
       <strong v-if="!question.conclusions.length">{{ question.display_name }}</strong>
       <span v-else>{{ question.display_name }}</span>
     </div>
 
     <v-expand-transition>
-      <div v-show="expanded" class="ml-6 mt-2">
-        <div class="ma-2 mx-4 mb-4 mt-n1">
-          <div v-if="fullDescription">
-            <small>{{ question.description }} <a @click="fullDescription = !fullDescription">show less</a></small>
-          </div>
-          <div v-if="!fullDescription">
-            <span>
-              <small>
-                {{ question.description.slice(0, 100) }}...
-                <a @click="fullDescription = !fullDescription">show more</a>
-              </small>
-            </span>
-          </div>
-        </div>
-
-        <div v-if="question.search_templates.length" class="ma-2 mx-4 mb-3">
+      <div v-show="expanded">
+        <!-- Query suggestions -->
+        <div v-if="question.search_templates.length" class="ma-2 mb-3">
           <v-icon x-small class="mr-1">mdi-magnify</v-icon>
           <strong><small>Query suggestions</small></strong>
           <div v-for="searchtemplate in question.search_templates" :key="searchtemplate.id" class="pa-1 mt-1">

--- a/timesketch/frontend-ng/src/views/Explore.vue
+++ b/timesketch/frontend-ng/src/views/Explore.vue
@@ -76,6 +76,48 @@ limitations under the License.
         </v-menu>
       </v-card>
 
+      <!-- Search History -->
+      <div class="mt-4">
+        <v-card v-show="showSearchHistory" outlined>
+          <v-toolbar dense flat>
+            <v-toolbar-title>Search history</v-toolbar-title>
+            <v-spacer></v-spacer>
+            <v-slider
+              v-model="zoomLevel"
+              thumb-label
+              ticks
+              append-icon="mdi-magnify-plus-outline"
+              prepend-icon="mdi-magnify-minus-outline"
+              min="0.1"
+              max="1"
+              step="0.1"
+              class="mt-6"
+            >
+              <template v-slot:thumb-label="{ value }"> {{ value * 100 }}% </template>
+            </v-slider>
+
+            <v-btn icon @click="showSearchHistory = false" class="ml-4">
+              <v-icon>mdi-close</v-icon>
+            </v-btn>
+          </v-toolbar>
+
+          <v-divider></v-divider>
+
+          <div
+            v-dragscroll
+            class="pa-md-4 no-scrollbars"
+            style="overflow: scroll; white-space: nowrap; max-height: 500px; min-height: 500px"
+          >
+            <ts-search-history-tree
+              @node-click="jumpInHistory"
+              :show-history="showSearchHistory"
+              v-bind:style="{ transform: 'scale(' + zoomLevel + ')' }"
+              style="transform-origin: top left"
+            ></ts-search-history-tree>
+          </div>
+        </v-card>
+      </div>
+
       <!-- Timeline picker -->
       <v-sheet class="mb-4 mt-4" color="transparent">
         <ts-timeline-picker
@@ -202,44 +244,21 @@ limitations under the License.
       </div>
     </v-card>
 
-    <!-- Search History -->
-
-    <v-card v-show="showSearchHistory" outlined class="pa-3 mt-3 mx-3">
-      <v-toolbar elevation="0" dense>
-        <v-toolbar-title>Search history</v-toolbar-title>
-        <v-spacer></v-spacer>
-
-        <v-slider
-          v-model="zoomLevel"
-          thumb-label
-          ticks
-          append-icon="mdi-magnify-plus-outline"
-          prepend-icon="mdi-magnify-minus-outline"
-          min="0.1"
-          max="1"
-          step="0.1"
-          class="mt-6"
-        >
-          <template v-slot:thumb-label="{ value }"> {{ value * 100 }}% </template>
-        </v-slider>
-
-        <v-btn icon @click="showSearchHistory = false" class="ml-4">
-          <v-icon>mdi-close</v-icon>
-        </v-btn>
-      </v-toolbar>
-      <div
-        v-dragscroll
-        class="pa-md-4 no-scrollbars"
-        style="overflow: scroll; white-space: nowrap; max-height: 500px; min-height: 500px"
-      >
-        <ts-search-history-tree
-          @node-click="jumpInHistory"
-          :show-history="showSearchHistory"
-          v-bind:style="{ transform: 'scale(' + zoomLevel + ')' }"
-          style="transform-origin: top left"
-        ></ts-search-history-tree>
+    <!-- DFIQ context -->
+    <div class="mt-3 mx-3">
+      <div :class="[$vuetify.theme.dark ? 'dark-info-card' : 'light-info-card']" v-if="activeContext.question">
+        <v-toolbar dense flat color="transparent">
+          <h4>{{ activeContext.question.display_name }}</h4>
+          <v-spacer></v-spacer>
+          <v-btn small icon @click="$store.dispatch('clearActiveContext')" class="mr-1">
+            <v-icon>mdi-close</v-icon>
+          </v-btn>
+        </v-toolbar>
+        <p class="mt-1 pb-4 px-4" style="font-size: 0.9em">
+          {{ activeContext.question.description }}
+        </p>
       </div>
-    </v-card>
+    </div>
 
     <!-- Eventlist -->
     <v-card
@@ -259,7 +278,7 @@ limitations under the License.
     <v-card
       v-if="eventList.objects.length || (searchInProgress && this.currentQueryFilter.indices.length)"
       flat
-      class="mt-5"
+      class="mt-5 mx-3"
     >
       <v-data-table
         v-model="selectedEvents"
@@ -746,6 +765,9 @@ export default {
     currentSearchNode() {
       return this.$store.state.currentSearchNode
     },
+    activeContext() {
+      return this.$store.state.activeContext
+    },
     headers() {
       let baseHeaders = [
         {
@@ -754,7 +776,7 @@ export default {
         },
         {
           value: 'actions',
-          width: '100',
+          width: '105',
         },
         {
           text: 'Datetime (UTC)',
@@ -1448,10 +1470,10 @@ export default {
 
 .ts-time-bubble {
   width: 120px;
-  height: 20px;
-  border-radius: 6px;
+  height: 25px;
+  border-radius: 20px;
   position: relative;
-  margin: 0 0 0 35px;
+  margin: 0 0 0 136px;
   text-align: center;
   font-size: var(--font-size-small);
 }
@@ -1468,7 +1490,7 @@ export default {
 .ts-time-bubble-vertical-line {
   width: 2px;
   height: 15px;
-  margin: 0 0 0 95px;
+  margin: 0 0 0 194px;
   background-color: #f5f5f5;
 }
 

--- a/timesketch/frontend-ng/src/views/Sketch.vue
+++ b/timesketch/frontend-ng/src/views/Sketch.vue
@@ -30,10 +30,6 @@ limitations under the License.
         <v-icon>mdi-menu</v-icon>
       </v-btn>
 
-      <div v-if="activeContext.question" class="ml-2">
-        <strong>{{ activeContext.question.display_name }}</strong>
-      </div>
-
       <v-spacer></v-spacer>
       <v-btn small depressed v-on:click="switchUI"> Use the old UI </v-btn>
 
@@ -330,9 +326,6 @@ export default {
     },
     scenarioTemplates() {
       return this.$store.state.scenarioTemplates
-    },
-    activeContext() {
-      return this.$store.state.activeContext
     },
     currentUser() {
       return this.$store.state.currentUser


### PR DESCRIPTION
This PR adds a context card when the user is using the Scenarios (DFIQ) system. and a few fixes:
- UI consistency in a few places
- Always load left panel items

<img width="1098" alt="Screenshot 2023-02-15 at 10 59 38" src="https://user-images.githubusercontent.com/316362/218996869-4ede1b75-453c-424d-a450-8042f17489e6.png">
