### PR TITLE
UI update for the Left Panel

### DIFF
--- a/timesketch/frontend-ng/src/components/LeftPanel/DataTypes.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/DataTypes.vue
@@ -16,11 +16,12 @@ limitations under the License.
 <template>
   <div>
     <div class="pa-4" flat :class="$vuetify.theme.dark ? 'dark-hover' : 'light-hover'">
-      <span style="cursor: pointer" @click="expanded = !expanded"
-        ><v-icon left>mdi-database-outline</v-icon> Data Types (<small
-          ><strong>{{ dataTypes.length }}</strong></small
-        >)</span
-      >
+      <span style="cursor: pointer" @click="expanded = !expanded">
+        <v-icon left>mdi-database-outline</v-icon> Data Types
+      </span>
+      <span class="float-right mr-2">
+        <small><strong>{{ dataTypes.length }}</strong></small>
+      </span>
     </div>
 
     <v-expand-transition>

--- a/timesketch/frontend-ng/src/components/LeftPanel/DataTypes.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/DataTypes.vue
@@ -26,8 +26,27 @@ limitations under the License.
 
     <v-expand-transition>
       <div v-show="expanded">
-        <v-data-iterator :items="dataTypes" :items-per-page.sync="itemsPerPage" :search="search">
-          <template v-slot:header v-if="dataTypes.length > itemsPerPage">
+        <v-data-iterator v-if="dataTypes.length <= itemsPerPage" :items="dataTypes" hide-default-footer>
+          <template v-slot:default="props">
+            <v-row
+              no-gutters
+              v-for="dataType in props.items"
+              :key="dataType.data_type"
+              class="pa-2 pl-5"
+              :class="$vuetify.theme.dark ? 'dark-hover' : 'light-hover'"
+            >
+              <div @click="setQueryAndFilter(dataType.data_type)" style="cursor: pointer; font-size: 0.9em">
+                <span
+                  >{{ dataType.data_type }} (<small
+                    ><strong>{{ dataType.count | compactNumber }}</strong></small
+                  >)</span
+                >
+              </div>
+            </v-row>
+          </template>
+        </v-data-iterator>
+        <v-data-iterator v-else :items="dataTypes" :items-per-page.sync="itemsPerPage" :search="search">
+          <template v-slot:header>
             <v-toolbar flat>
               <v-text-field
                 v-model="search"

--- a/timesketch/frontend-ng/src/components/LeftPanel/SavedSearches.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/SavedSearches.vue
@@ -16,11 +16,12 @@ limitations under the License.
 <template>
   <div v-if="meta.views.length">
     <div class="pa-4" flat :class="$vuetify.theme.dark ? 'dark-hover' : 'light-hover'">
-      <span style="cursor: pointer" @click="expanded = !expanded"
-        ><v-icon left>mdi-content-save-outline</v-icon>Saved Searches (<small
-          ><strong>{{ meta.views.length }}</strong></small
-        >)</span
-      >
+      <span style="cursor: pointer" @click="expanded = !expanded">
+        <v-icon left>mdi-content-save-outline</v-icon>Saved Searches
+      </span>
+      <span class="float-right mr-2">
+        <small><strong>{{ meta.views.length }}</strong></small>
+      </span>
     </div>
 
     <v-expand-transition>

--- a/timesketch/frontend-ng/src/components/LeftPanel/SearchTemplates.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/SearchTemplates.vue
@@ -16,11 +16,12 @@ limitations under the License.
 <template>
   <div>
     <div class="pa-4" flat :class="$vuetify.theme.dark ? 'dark-hover' : 'light-hover'">
-      <span style="cursor: pointer" @click="expanded = !expanded"
-        ><v-icon left>mdi-text-box-search-outline</v-icon> Search Templates (<small
-          ><strong>{{ searchtemplates.length }}</strong></small
-        >)</span
-      >
+      <span style="cursor: pointer" @click="expanded = !expanded">
+        <v-icon left>mdi-text-box-search-outline</v-icon> Search Templates
+      </span>
+      <span class="float-right mr-2">
+        <small><strong>{{ searchtemplates.length }}</strong></small>
+      </span>
     </div>
     <v-expand-transition>
       <div v-show="expanded && searchtemplates.length">

--- a/timesketch/frontend-ng/src/components/LeftPanel/SigmaRules.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/SigmaRules.vue
@@ -15,7 +15,7 @@ limitations under the License.
 -->
 <template>
   <div>
-    <v-row
+    <div
       no-gutters
       style="cursor: pointer"
       class="pa-4"
@@ -23,23 +23,35 @@ limitations under the License.
       @click="expanded = !expanded"
       :class="$vuetify.theme.dark ? 'dark-hover' : 'light-hover'"
     >
-      <v-col cols="11">
-        <v-icon left>mdi-sigma-lower</v-icon> Sigma Rules (<small
-          ><strong>{{ ruleCount }}</strong></small
-        >)
-      </v-col>
-      <v-col cols="1">
-        <v-btn small icon>
-          <v-icon v-if="expanded" v-on:click="createNewSigmaRule()">mdi-plus</v-icon>
-        </v-btn>
-      </v-col>
-    </v-row>
+      <span>
+        <v-icon left>mdi-sigma-lower</v-icon> Sigma Rules
+      </span>
+      <v-btn
+        v-if="expanded"
+        small
+        color="primary"
+        text
+        class="ml-1"
+        :to="{ name: 'Studio', params: { id: 'new', type: 'sigma' } }"
+        @click.stop=""
+      >
+        <v-icon small left>mdi-plus</v-icon>New Rule
+      </v-btn>
+      <span class="float-right mr-2">
+        <small><strong>{{ ruleCount }}</strong></small>
+      </span>
+    </div>
 
     <v-expand-transition>
       <div v-show="expanded">
-        <v-data-iterator :items="sigmaRules" :items-per-page.sync="itemsPerPage" :search="search">
+        <v-data-iterator v-if="ruleCount <= itemsPerPage" :items="sigmaRules" hide-default-footer>
+          <template v-slot:default="props">
+            <ts-sigma-rule v-for="sigmaRule in props.items" :key="sigmaRule.rule_uuid" :sigma-rule="sigmaRule" />
+          </template>
+        </v-data-iterator>
+        <v-data-iterator v-else :items="sigmaRules" :items-per-page.sync="itemsPerPage" :search="search">
           <template v-slot:header>
-            <v-toolbar flat v-if="ruleCount > itemsPerPage">
+            <v-toolbar flat>
               <v-text-field
                 v-model="search"
                 clearable
@@ -53,8 +65,7 @@ limitations under the License.
           </template>
 
           <template v-slot:default="props">
-            <ts-sigma-rule v-for="sigmaRule in props.items" :key="sigmaRule.rule_uuid" :sigma-rule="sigmaRule">
-            </ts-sigma-rule>
+            <ts-sigma-rule v-for="sigmaRule in props.items" :key="sigmaRule.rule_uuid" :sigma-rule="sigmaRule"/>
           </template>
         </v-data-iterator>
       </div>
@@ -81,19 +92,6 @@ export default {
     }
   },
   methods: {
-    createNewSigmaRule() {
-      // check current router location
-      if (this.$route.params.id === 'new') {
-        return
-      }
-      this.$router.push({
-        name: 'Studio',
-        params: {
-          id: 'new',
-          type: 'sigma',
-        },
-      })
-    },
   },
   computed: {
     sigmaRules() {

--- a/timesketch/frontend-ng/src/components/LeftPanel/Tags.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/Tags.vue
@@ -16,11 +16,12 @@ limitations under the License.
 <template>
   <div>
     <div class="pa-4" flat :class="$vuetify.theme.dark ? 'dark-hover' : 'light-hover'">
-      <span style="cursor: pointer" @click="expanded = !expanded"
-        ><v-icon left>mdi-tag-multiple-outline</v-icon> Tags (<small
-          ><strong>{{ tags.length }}</strong></small
-        >)</span
-      >
+      <span style="cursor: pointer" @click="expanded = !expanded">
+        <v-icon left>mdi-tag-multiple-outline</v-icon> Tags
+      </span>
+      <span class="float-right mr-2">
+        <small><strong>{{ tags.length }}</strong></small>
+      </span>
     </div>
 
     <v-expand-transition>

--- a/timesketch/frontend-ng/src/components/LeftPanel/ThreatIntel.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/ThreatIntel.vue
@@ -15,7 +15,7 @@ limitations under the License.
 -->
 <template>
   <div>
-    <v-row
+    <div
       no-gutters
       style="cursor: pointer"
       class="pa-4"
@@ -23,25 +23,26 @@ limitations under the License.
       @click="expanded = !expanded"
       :class="$vuetify.theme.dark ? 'dark-hover' : 'light-hover'"
     >
-      <span
-        ><v-icon left>mdi-shield-search</v-icon> Threat Intelligence (<small
-          ><strong>{{ intelligenceData.length }}</strong></small
-        >)</span
-      >
-      <v-spacer></v-spacer>
-
+      <span>
+        <v-icon left>mdi-shield-search</v-icon> Threat Intelligence
+      </span>
       <v-btn
         v-if="expanded"
         small
-        depressed
         color="primary"
-        outlined
+        text
+        class="ml-1"
         :to="{ name: 'Intelligence', params: { sketchId: sketch.id } }"
         @click.stop=""
       >
         <v-icon small left>mdi-pencil</v-icon>Manage
       </v-btn>
-    </v-row>
+      <span class="float-right mr-2">
+        <small><strong>{{ intelligenceData.length }}</strong></small>
+      </span>
+
+
+    </div>
 
     <v-expand-transition>
       <div v-show="expanded">
@@ -57,7 +58,26 @@ limitations under the License.
         </v-tabs>
         <v-tabs-items v-model="tabs">
           <v-tab-item :transition="false">
-            <v-data-table dense :headers="indicatorHeaders" :items="intelligenceData" :items-per-page="10">
+            <v-data-table v-if="intelligenceData.length >= 10" dense :headers="indicatorHeaders" :items="intelligenceData" :items-per-page="10">
+              <template v-slot:item.ioc="{ item }">
+                <span :title="item.ioc">
+                  <div style="max-width: 200px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis">
+                    {{ item.ioc }}
+                  </div>
+                </span>
+              </template>
+
+              <template v-slot:item.type="{ item }">
+                <small>{{ item.type }}</small>
+              </template>
+
+              <template v-slot:item.actions="{ item }">
+                <v-btn icon small @click="generateSearchQuery(item.ioc)">
+                  <v-icon small>mdi-magnify</v-icon>
+                </v-btn>
+              </template>
+            </v-data-table>
+            <v-data-table v-else dense :headers="indicatorHeaders" :items="intelligenceData" hide-default-footer>
               <template v-slot:item.ioc="{ item }">
                 <span :title="item.ioc">
                   <div style="max-width: 200px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis">

--- a/timesketch/frontend-ng/src/views/Sketch.vue
+++ b/timesketch/frontend-ng/src/views/Sketch.vue
@@ -287,7 +287,7 @@ export default {
     return {
       showSketchMetadata: false,
       navigationDrawer: {
-        width: 370,
+        width: 375,
       },
       selectedScenario: null,
       scenarioDialog: false,

--- a/timesketch/frontend-ng/src/views/Sketch.vue
+++ b/timesketch/frontend-ng/src/views/Sketch.vue
@@ -287,7 +287,7 @@ export default {
     return {
       showSketchMetadata: false,
       navigationDrawer: {
-        width: 375,
+        width: 400,
       },
       selectedScenario: null,
       scenarioDialog: false,


### PR DESCRIPTION
This PR will update the UI of the Left Panel component to reflect the latest feedback from the UX team.

+ The counter of each entry is now aligned to the right side for a cleaner look.
+ The action buttons for Sigma Rules and Threat Intelligence are now unified to match the general design language.
+ The pagination footer for the Data Types, Sigma Rules and Threat Intelligence entries will now only show up when there are more than 10 entries. 
+ I had to increase the default width of the Left Panel component to 400 (+30). Otherwise the table footer wouldn't fit in one row.

Screenshot of closed menu entries:
![LeftPanelClosed](https://user-images.githubusercontent.com/99879757/221687760-7b03fd4e-274b-4216-8214-04053ba577ed.png)

Screenshot with some menu entries opened:
![LefPanelExpanded](https://user-images.githubusercontent.com/99879757/221687767-921b3411-f978-4c23-8bd9-aee5d60c8426.png)
