### PR TITLE
CLI: Add Tag to single event

### DIFF
--- a/api_client/python/timesketch_api_client/test_lib.py
+++ b/api_client/python/timesketch_api_client/test_lib.py
@@ -95,11 +95,14 @@ def mock_response(*args, **kwargs):
     }
 
     add_event_attribute_data = {
-        "events_processed_by_api": 1,
-        "number_of_events_passed_to_api": 1,
-        "number_of_events_with_added_tags": 1,
-        "tags_applied": 2,
-        "total_number_of_events_sent_by_client": 2,
+        "meta": {
+            "attributes_added": 2,
+            "chunks_per_index": {"1": 1},
+            "error_count": 0,
+            "errors": [],
+            "events_modified": 2,
+        },
+        "objects": [],
     }
 
     add_event_tag_data = {

--- a/api_client/python/timesketch_api_client/test_lib.py
+++ b/api_client/python/timesketch_api_client/test_lib.py
@@ -105,6 +105,25 @@ def mock_response(*args, **kwargs):
         "objects": [],
     }
 
+    add_event_tag_data = {
+        "meta": {},
+        "objects": [
+            [
+                {
+                    "created_at": "2023-03-09T08:52:10.595285",
+                    "name": None,
+                    "updated_at": "2023-03-09T08:52:10.623554",
+                    "user": {
+                        "active": True,
+                        "admin": True,
+                        "groups": [],
+                        "username": "testuser",
+                    },
+                }
+            ]
+        ],
+    }
+
     sketch_data = {
         "meta": {
             "views": [{"id": 1, "name": "test"}, {"id": 2, "name": "test"}],
@@ -429,6 +448,9 @@ def mock_response(*args, **kwargs):
         ),
         "http://127.0.0.1/api/v1/sketches/1/event/attributes/": MockResponse(
             json_data=add_event_attribute_data
+        ),
+        "http://127.0.0.1/api/v1/sketches/1/event/tagging/": MockResponse(
+            json_data=add_event_tag_data
         ),
         "http://127.0.0.1/api/v1/sketches/1/views/1/": MockResponse(
             json_data=view_data_1

--- a/api_client/python/timesketch_api_client/test_lib.py
+++ b/api_client/python/timesketch_api_client/test_lib.py
@@ -95,14 +95,11 @@ def mock_response(*args, **kwargs):
     }
 
     add_event_attribute_data = {
-        "meta": {
-            "attributes_added": 2,
-            "chunks_per_index": {"1": 1},
-            "error_count": 0,
-            "errors": [],
-            "events_modified": 2,
-        },
-        "objects": [],
+        "events_processed_by_api": 1,
+        "number_of_events_passed_to_api": 1,
+        "number_of_events_with_added_tags": 1,
+        "tags_applied": 2,
+        "total_number_of_events_sent_by_client": 2,
     }
 
     add_event_tag_data = {

--- a/cli_client/python/timesketch_cli_client/commands/timelines.py
+++ b/cli_client/python/timesketch_cli_client/commands/timelines.py
@@ -54,13 +54,23 @@ def describe_timeline(ctx, timeline_id):
     click.echo(f"Index: {timeline.index_name}")
 
 
-@timelines_group.command("event-add-tag")
+@timelines_group.command("event-add-tags")
 @click.argument("timeline_id", type=int, required=False)
 @click.option("--event_id", required=True, help="ID of the event.")
-@click.option("--tag", required=True, help="Tag to add to the event.")
+@click.option(
+    "--tags",
+    required=True,
+    help="Comma seperated list of Tags to add to the event.",
+)
+@click.option(
+    "--output-format",
+    "output",
+    required=False,
+    help="Set output format (overrides global setting)",
+)
 @click.pass_context
-def event_add_tag(ctx, timeline_id, event_id, tag):
-    """Add a tag to an event."""
+def event_add_tags(ctx, timeline_id, event_id, tags, output):
+    """Add tags to an event."""
     sketch = ctx.obj.sketch
     timeline = sketch.get_timeline(timeline_id=timeline_id)
     if not timeline:
@@ -73,6 +83,9 @@ def event_add_tag(ctx, timeline_id, event_id, tag):
             "_type": "generic_event",
         }
     ]
-    tags = [tag]
-    sketch.label_events(events, tags)
-    click.echo(f"Tag {tag} added to event {event_id}")
+    tags_list = tags.split(",")
+    return_value = sketch.tag_events(events, tags_list)
+    if output == "json":
+        click.echo(return_value)
+    else:
+        click.echo(f"Tags {tags_list} added to event {event_id}")

--- a/cli_client/python/timesketch_cli_client/commands/timelines.py
+++ b/cli_client/python/timesketch_cli_client/commands/timelines.py
@@ -66,7 +66,7 @@ def event_add_tag(ctx, timeline_id, event_id, tag):
     if not timeline:
         click.echo("No such timeline")
         return
-    events2 = [
+    events = [
         {
             "_id": event_id,
             "_index": timeline.index_name,
@@ -74,5 +74,5 @@ def event_add_tag(ctx, timeline_id, event_id, tag):
         }
     ]
     tags = [tag]
-    sketch.label_events(events2, tags)
+    sketch.label_events(events, tags)
     click.echo(f"Tag {tag} added to event {event_id}")

--- a/cli_client/python/timesketch_cli_client/commands/timelines.py
+++ b/cli_client/python/timesketch_cli_client/commands/timelines.py
@@ -52,3 +52,27 @@ def describe_timeline(ctx, timeline_id):
         return
     click.echo(f"Name: {timeline.name}")
     click.echo(f"Index: {timeline.index_name}")
+
+
+@timelines_group.command("event-add-tag")
+@click.argument("timeline_id", type=int, required=False)
+@click.option("--event_id", required=True, help="ID of the event.")
+@click.option("--tag", required=True, help="Tag to add to the event.")
+@click.pass_context
+def event_add_tag(ctx, timeline_id, event_id, tag):
+    """Add a tag to an event."""
+    sketch = ctx.obj.sketch
+    timeline = sketch.get_timeline(timeline_id=timeline_id)
+    if not timeline:
+        click.echo("No such timeline")
+        return
+    events2 = [
+        {
+            "_id": event_id,
+            "_index": timeline.index_name,
+            "_type": "generic_event",
+        }
+    ]
+    tags = [tag]
+    sketch.label_events(events2, tags)
+    click.echo(f"Tag {tag} added to event {event_id}")

--- a/cli_client/python/timesketch_cli_client/commands/timelines.py
+++ b/cli_client/python/timesketch_cli_client/commands/timelines.py
@@ -85,6 +85,9 @@ def event_add_tags(ctx, timeline_id, event_id, tags, output):
     ]
     tags_list = tags.split(",")
     return_value = sketch.tag_events(events, tags_list)
+    if return_value is None:
+        click.echo("No tags where added to the event.")
+        return
     if output == "json":
         click.echo(return_value)
     else:

--- a/cli_client/python/timesketch_cli_client/commands/timelines_test.py
+++ b/cli_client/python/timesketch_cli_client/commands/timelines_test.py
@@ -43,3 +43,14 @@ class TimelinesTest(unittest.TestCase):
         runner = CliRunner()
         result = runner.invoke(timelines_group, ["describe", "1"], obj=self.ctx)
         assert result.output == "Name: test\nIndex: test\n"
+
+    def test_add_event_tag(self):
+        """Test to add a tag to an event."""
+        runner = CliRunner()
+        result = runner.invoke(
+            timelines_group,
+            ["event-add-tag", "--event_id", "1", "--tag", "test", "1"],
+            obj=self.ctx,
+        )
+        print(result.output)
+        assert "Tag test added to event 1" in result.output

--- a/cli_client/python/timesketch_cli_client/commands/timelines_test.py
+++ b/cli_client/python/timesketch_cli_client/commands/timelines_test.py
@@ -89,4 +89,10 @@ class TimelinesTest(unittest.TestCase):
             ],
             obj=self.ctx,
         )
-        assert "{'total_number_of_events_sent_by_client': 1}" in result.output
+        # pylint: disable=line-too-long
+
+        assert (
+            "{'events_processed_by_api': 1,'number_of_events_passed_to_api': 1,'number_of_events_with_added_tags': 1,'tags_applied': 2,'total_number_of_events_sent_by_client': 2,}"
+            in result.output
+        )
+        # pylint: enable=line-too-long

--- a/cli_client/python/timesketch_cli_client/commands/timelines_test.py
+++ b/cli_client/python/timesketch_cli_client/commands/timelines_test.py
@@ -49,8 +49,44 @@ class TimelinesTest(unittest.TestCase):
         runner = CliRunner()
         result = runner.invoke(
             timelines_group,
-            ["event-add-tag", "--event_id", "1", "--tag", "test", "1"],
+            ["event-add-tags", "--event_id", "1", "--tags", "test", "1"],
             obj=self.ctx,
         )
-        print(result.output)
-        assert "Tag test added to event 1" in result.output
+        assert "Tags ['test'] added to event 1" in result.output
+
+    def test_add_event_tags(self):
+        """Test to add multiple tags to an event."""
+        runner = CliRunner()
+        result = runner.invoke(
+            timelines_group,
+            [
+                "event-add-tags",
+                "--event_id",
+                "1",
+                "--tags",
+                "test1,test2",
+                "1",
+            ],
+            obj=self.ctx,
+        )
+
+        assert "Tags ['test1', 'test2'] added to event 1" in result.output
+
+    def test_add_event_tags_json(self):
+        """Test to add multiple tags to an event and output as json."""
+        runner = CliRunner()
+        result = runner.invoke(
+            timelines_group,
+            [
+                "event-add-tags",
+                "--event_id",
+                "1",
+                "--tags",
+                "test1,test2",
+                "1",
+                "--output-format",
+                "json",
+            ],
+            obj=self.ctx,
+        )
+        assert "{'total_number_of_events_sent_by_client': 1}" in result.output


### PR DESCRIPTION
A fairly common uecase is one has a event ID and wants to codify to add a tag to it without using the API client. This PR adds this functionality.

E.G: 
```
timesketch timelines list
16 timeline test - First 10k (2)
17 new
18 timeline test - First 10k (3)
19 Manual events
root@5b49c41f6fef:/usr/local/src/timesketch/cli_client/python# timesketch timelines describe 19
Name: Manual events
Index: 49a318b0ba17867fd71b50903774a0c8
```

And then to add it:
```
timesketch timelines event-add-tags --event_id BNCewYYBe0OIiBUpeC37 --tags fooobarrrrrrr 19 --output-format json
{'events_processed_by_api': 1, 'number_of_events_passed_to_api': 1, 'number_of_events_with_added_tags': 1, 'tags_applied': 5, 'total_number_of_events_sent_by_client': 1}
```

It can be discussed if that function makes more sense under the timelines context of sketch context. The API method is in the sketch context, but without a timeline, it does not really works.