### PR TITLE
[CLI] add labels to one event

### DIFF
--- a/cli_client/python/timesketch_cli_client/commands/timelines.py
+++ b/cli_client/python/timesketch_cli_client/commands/timelines.py
@@ -92,3 +92,45 @@ def event_add_tags(ctx, timeline_id, event_id, tags, output):
         click.echo(return_value)
     else:
         click.echo(f"Tags {tags_list} added to event {event_id}")
+
+
+@timelines_group.command("event-add-labels")
+@click.argument("timeline_id", type=int, required=False)
+@click.option("--event_id", required=True, help="ID of the event.")
+@click.option(
+    "--labels",
+    required=True,
+    help="Comma seperated list of Labels to add to the event.",
+)
+@click.option(
+    "--output-format",
+    "output",
+    required=False,
+    help="Set output format (overrides global setting)",
+)
+@click.pass_context
+def event_add_labels(ctx, timeline_id, event_id, labels, output):
+    """Add labels to an event."""
+    sketch = ctx.obj.sketch
+    timeline = sketch.get_timeline(timeline_id=timeline_id)
+    if not timeline:
+        click.echo("No such timeline")
+        return
+    events = [
+        {
+            "_id": event_id,
+            "_index": timeline.index_name,
+            "_type": "generic_event",
+        }
+    ]
+    labels_list = labels.split(",")
+    # label_events only takes one label per call, so we need to loop
+    for label in labels_list:
+        return_value = sketch.label_events(events, label)
+        if return_value is None:
+            click.echo("No labels where added to the event.")
+            return
+        if output == "json":
+            click.echo(return_value)
+        else:
+            click.echo(f"Tags {labels_list} added to event {event_id}")


### PR DESCRIPTION
Add labels to one event in the Timesketch CLI

```
timesketch timelines event-add-labels --event_id A9BGwYYBe0OIiBUpWy3U --labels "comment1 foobar2","asdasd2" 19 --output-format json
{'meta': {}, 'objects': [[{'created_at': '2023-03-09T15:24:40.519907', 'name': None, 'updated_at': '2023-03-09T15:24:40.543321', 'user': {'active': True, 'admin': True, 'groups': [], 'username': 'dev'}}]]}
{'meta': {}, 'objects': [[{'created_at': '2023-03-09T15:27:03.308873', 'name': None, 'updated_at': '2023-03-09T15:27:03.332113', 'user': {'active': True, 'admin': True, 'groups': [], 'username': 'dev'}}]]}
```