### PR TITLE
Bugfix: timeline url param support

### DIFF
--- a/timesketch/frontend-ng/src/components/Explore/TimelinePicker.vue
+++ b/timesketch/frontend-ng/src/components/Explore/TimelinePicker.vue
@@ -194,7 +194,6 @@ export default {
   },
   created() {
     EventBus.$on('isDarkTheme', this.toggleTheme)
-    this.enableAllTimelines()
 
     if (this.currentQueryFilter.indices.includes('_all')) {
       this.selectedTimelines = this.activeTimelines


### PR DESCRIPTION
The new UI broke the ability to use `?timeline=1234` in the URL. This PR fixes that.

@jkppr FYI