### PR TITLE
Empty state for Scenarios tab

### DIFF
--- a/timesketch/frontend-ng/src/views/Sketch.vue
+++ b/timesketch/frontend-ng/src/views/Sketch.vue
@@ -148,8 +148,11 @@ limitations under the License.
         <v-tab-item :transition="false">
           <ts-scenario v-for="scenario in activeScenarios" :key="scenario.id" :scenario="scenario"></ts-scenario>
           <v-row class="mt-0 px-2" flat>
-            <v-col cols="6">
-              <v-btn text color="primary" @click="scenarioDialog = true" style="cursor: pointer"
+            <v-col cols="12">
+              <v-card v-if="!Object.keys(scenarioTemplates).length" flat class="pa-4"
+                >No scenarios available yet.</v-card
+              >
+              <v-btn v-else text color="primary" @click="scenarioDialog = true" style="cursor: pointer"
                 ><v-icon left>mdi-plus</v-icon> Add Scenario</v-btn
               >
             </v-col>


### PR DESCRIPTION
Handle empty state for when there are no scenarios added to the installation.
<img width="427" alt="Screenshot 2023-04-04 at 13 40 35" src="https://user-images.githubusercontent.com/316362/229780471-58446524-557f-4520-9ad2-6d566da51277.png">
