### PR TITLE
Remove timestamp check

### DIFF
--- a/test_tools/test_events/validate_date_events.csv
+++ b/test_tools/test_events/validate_date_events.csv
@@ -1,3 +1,0 @@
-"message","datetime","timestamp","timestamp_desc","data_type"
-78Vh3h7,2022-11-10T05-07-28+00:00,1668056848119860,Time Logged,This event has a wrong formatted datetime notice the - instead of : in the datetime
-Time offset large,2022-11-09T05-07-28+00:00,1668056848119860,Time Logged,This event has a to large time offset betweeen datetime and timestamp

--- a/test_tools/test_events/validate_date_events2.csv
+++ b/test_tools/test_events/validate_date_events2.csv
@@ -1,5 +1,0 @@
-"message","datetime","timestamp","timestamp_desc","data_type"
-No timestamp,2022-07-24T19:01:01+00:00,,"Time Logged","This event has no timestamp"
-No timestamp 2,2022-07-25T11:01:01+00:00,,"Time Logged","This event has no timestamp"
-No datetime,,1668056848119860,Time Logged,This event has no datetime value
-No datetime second row,,1668056848119861,Time Logged,This event has no datetime value

--- a/timesketch/lib/utils.py
+++ b/timesketch/lib/utils.py
@@ -341,29 +341,8 @@ def read_and_validate_csv(
 
                 # Remove all NAN values from the pandas.Series.
                 row.dropna(inplace=True)
-                MAX_TIMESTAMP_DIFFERENCE = 1000  # 1 second
 
-                # Check datetime plausibility
-                if "timestamp" in row and "datetime" in row:
-                    timestamp_calculated = int(
-                        pandas.Timestamp(row["datetime"]).value / 1000
-                    )
-                    if (
-                        abs(row["timestamp"] - timestamp_calculated)
-                        > MAX_TIMESTAMP_DIFFERENCE
-                    ):
-                        error_string = (
-                            "Timestamp difference between {0!s} "
-                            "and {1!s} is too big {2!s}, "
-                            "aborting ingestion."
-                        ).format(
-                            row["timestamp"],
-                            timestamp_calculated,
-                            abs(row["timestamp"] - timestamp_calculated),
-                        )
-                        logger.error(error_string)
-                        raise errors.DataIngestionError(error_string)
-
+                # Make sure we always have a timestamp
                 if not "timestamp" in row:
                     row["timestamp"] = int(
                         pandas.Timestamp(row["datetime"]).value / 1000

--- a/timesketch/lib/utils_test.py
+++ b/timesketch/lib/utils_test.py
@@ -192,19 +192,6 @@ class TestUtils(BaseTest):
     def test_datetime_parsing_csv_file(self):
         """Test for parsing datetime values in CSV file"""
 
-        # assert if certain lines are written to the log
-        with self.assertLogs(level="WARNING") as log:
-            # Call next to work around lazy generators.
-            next(
-                read_and_validate_csv(
-                    "test_tools/test_events/validate_date_events2.csv"
-                )
-            )
-            self.assertIn(
-                "WARNING:timesketch.utils:2 rows skipped since they were missing datetime field or it was empty ",  # pylint: disable=line-too-long
-                log.output,
-            )
-
         # Test that a timestamp is generated if missing.
         expected_output = {
             "message": "No timestamp",

--- a/timesketch/lib/utils_test.py
+++ b/timesketch/lib/utils_test.py
@@ -25,7 +25,6 @@ from timesketch.lib.utils import read_and_validate_csv
 from timesketch.lib.utils import check_mapping_errors
 from timesketch.lib.utils import _validate_csv_fields
 from timesketch.lib.utils import rename_jsonl_headers
-from timesketch.lib.errors import DataIngestionError
 
 
 TEST_CSV = "test_tools/test_events/sigma_events.csv"

--- a/timesketch/lib/utils_test.py
+++ b/timesketch/lib/utils_test.py
@@ -177,19 +177,7 @@ class TestUtils(BaseTest):
             # Call next to work around lazy generators.
             next(_validate_csv_fields(mandatory_fields, df_02))
 
-    def test_datetime_parsing_csv_file_data_ingestion_error(self):
-        """Test for parsing datetime values in CSV file
-        This test will not go over the full file since it will abort after the
-        row with the large time discrepancy is found.
-        """
-
-        with self.assertRaises(DataIngestionError):
-            # Call next to work around lazy generators.
-            next(
-                read_and_validate_csv("test_tools/test_events/validate_date_events.csv")
-            )
-
-    def test_datetime_parsing_csv_file(self):
+    def test_missing_timestamp_csv_file(self):
         """Test for parsing datetime values in CSV file"""
 
         # Test that a timestamp is generated if missing.


### PR DESCRIPTION
Remove timestamp plausability check. The logic was too naive and resulted in a few valid edgecases to start error out.

Let's rethink this feature at a later time.
