### PR TITLE
Fix for the pagination problems

### DIFF
--- a/timesketch/frontend-ng/src/components/Explore/EventList.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventList.vue
@@ -853,13 +853,13 @@ export default {
     queryRequest: {
       handler(newQueryRequest, oldqueryRequest) {
         // Return early if this isn't a new request.
-        if (!newQueryRequest) {
+        if (newQueryRequest === oldqueryRequest || !newQueryRequest) {
           return
         }
         this.currentQueryString = newQueryRequest.queryString || ''
         this.currentQueryFilter = newQueryRequest.queryFilter || defaultQueryFilter()
         this.currentQueryDsl = newQueryRequest.queryDsl || null
-        let resetPagination = newQueryRequest['resetPagination'] || true
+        let resetPagination = newQueryRequest['resetPagination'] || false
         let incognito = newQueryRequest['incognito'] || false
         let parent = newQueryRequest['parent'] || false
         // Set additional fields. This is used when loading filter from a saved search.

--- a/timesketch/frontend-ng/src/views/Explore.vue
+++ b/timesketch/frontend-ng/src/views/Explore.vue
@@ -51,8 +51,9 @@ limitations under the License.
               solo
               class="pa-1"
               append-icon="mdi-magnify"
+              @click:append="search()"
               id="tsSearchInput"
-              @keyup.enter="search"
+              @keyup.enter="search()"
               @click="showSearchDropdown = true"
               ref="searchInput"
               v-bind="attrs"


### PR DESCRIPTION
With the new UI there is an issue that the pagination of the event table does automatically resets every time someone switches a page.

This PR should fix this.

Additional new feature: The PR also adds a function to click on the "magnifying glass" in the search bar to trigger the search.