### PR TITLE
Updated Tagging UI

### DIFF
--- a/timesketch/frontend-ng/src/components/Explore/EventList.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventList.vue
@@ -310,23 +310,8 @@ limitations under the License.
           >
             <span :class="{ 'ts-event-field-ellipsis': field.text === 'message' }">
               <!-- Tags -->
-              <span v-if="displayOptions.showTags && index === 3">
-                <v-chip
-                  small
-                  class="mr-2"
-                  v-for="tag in item._source.tag"
-                  :key="tag"
-                  :color="tagColor(tag).color"
-                  :text-color="tagColor(tag).textColor"
-                >
-                  <v-icon v-if="tag in tagConfig" left small>{{ tagConfig[tag].label }}</v-icon>
-                  {{ tag }}</v-chip
-                >
-                <span v-for="label in item._source.label" :key="label">
-                  <v-chip v-if="!label.startsWith('__ts')" small outlined class="mr-2">
-                    {{ label }}
-                  </v-chip>
-                </span>
+              <span v-if="displayOptions.showTags && index === 3 && ('tag' in item._source ? (item._source.tag.length > 0) : false )">
+                <ts-event-tags :item="item" :tagConfig="tagConfig" :showDetails="item.showDetails"></ts-event-tags>
               </span>
               <!-- Emojis -->
               <span v-if="displayOptions.showEmojis && index === 0">
@@ -372,6 +357,7 @@ import TsBarChart from './BarChart'
 import TsEventDetail from './EventDetail'
 import TsEventTagMenu from './EventTagMenu.vue'
 import TsEventActionMenu from './EventActionMenu.vue'
+import TsEventTags from './EventTags.vue'
 
 const defaultQueryFilter = () => {
   return {
@@ -400,6 +386,7 @@ export default {
     TsEventDetail,
     TsEventTagMenu,
     TsEventActionMenu,
+    TsEventTags
   },
   props: {
     queryRequest: {
@@ -560,12 +547,6 @@ export default {
     },
   },
   methods: {
-    tagColor: function (tag) {
-      if (this.tagConfig[tag]) {
-        return this.tagConfig[tag]
-      }
-      return 'lightgrey'
-    },
     getFieldName: function (field) {
       return 'item._source.' + field
     },

--- a/timesketch/frontend-ng/src/components/Explore/EventTagMenu.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventTagMenu.vue
@@ -144,17 +144,14 @@ export default {
       }
     },
     removeTags(tag) {
-      console.log('DEMO: removeTag', this.event, tag)
-      this.event._source.tag.splice(this.event._source.tag.indexOf(tag), 1) // DEMO only
-      this.$store.dispatch('updateTimelineTags', { sketchId: this.sketch.id, tag: tag, num: -1 }) // DEMO only
-      // ApiClient.untagEvents(this.sketch.id, [this.event], [tag])
-      //   .then((response) => {
-      //     this.event._source.tag.splice(this.event._source.tag.indexOf(tag), 1)
-      //     this.$store.dispatch('updateTimelineTags', { sketchId: this.sketch.id, tag: tag, num: -1 })
-      //   })
-      //   .catch((e) => {
-      //     console.error(e)
-      //   })
+      ApiClient.untagEvents(this.sketch.id, [this.event], [tag])
+        .then((response) => {
+          this.event._source.tag.splice(this.event._source.tag.indexOf(tag), 1)
+          this.$store.dispatch('updateTimelineTags', { sketchId: this.sketch.id, tag: tag, num: -1 })
+        })
+        .catch((e) => {
+          console.error(e)
+        })
     },
     addTags: function (tagToAdd) {
       if (!this.event._source.hasOwnProperty('tag')) {

--- a/timesketch/frontend-ng/src/components/Explore/EventTagMenu.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventTagMenu.vue
@@ -19,7 +19,10 @@ limitations under the License.
       <v-icon v-bind="attrs" v-on="on" class="ml-1">mdi-tag-plus-outline</v-icon>
     </template>
 
-    <v-card min-width="500px" class="mx-auto">
+    <v-card min-width="500px" class="mx-auto" max-width="500px" min-height="300px">
+      <v-btn class="float-right mr-1 mt-1" icon @click="showMenu = false">
+        <v-icon>mdi-close</v-icon>
+      </v-btn>
       <v-card-text>
         <strong>Quick tags</strong>
         <v-chip-group>
@@ -30,27 +33,59 @@ limitations under the License.
             :text-color="tag.textColor"
             class="text-center"
             small
+            :close="showClose(tag.tag)"
             @click="addTags(tag.tag)"
+            @click:close="removeTags(tag.tag)"
           >
             <v-icon small left> {{ tag.label }} </v-icon>
-            {{ tag.tag }}</v-chip
+            {{ tag.tag }}
+          </v-chip>
+        </v-chip-group>
+        <strong>Custom tags</strong>
+        <v-chip-group column>
+          <v-chip
+            v-for="tag in customSelectedTags"
+            :key="tag"
+            class="text-center"
+            small
+            close
+            @click:close="removeTags(tag)"
           >
+            {{ tag }}
+          </v-chip>
         </v-chip-group>
         <br />
         <v-combobox
           v-model="selectedTags"
-          :items="tags"
-          label="Add tags.."
-          outlined
-          chips
+          :hide-no-data="!search"
+          :items="customTags"
+          :search-input.sync="search"
+          hide-selected
+          label="Add tags ..."
           small-chips
-          multiple
-        ></v-combobox>
+          outlined
+          @change="addTags(selectedTags)"
+        >
+          <template v-slot:no-data>
+            <v-list-item>
+              <span class="subheading">Create new tag: </span>
+              <v-chip
+                class="ml-1"
+                small
+              >
+                {{ search }}
+              </v-chip>
+            </v-list-item>
+          </template>
+          <template v-slot:item="{ item }">
+            <v-chip
+              small
+            >
+              {{ item }}
+            </v-chip>
+          </template>
+        </v-combobox>
       </v-card-text>
-      <v-card-actions>
-        <v-spacer></v-spacer>
-        <v-btn text @click="addTags(selectedTags)">Save</v-btn>
-      </v-card-actions>
     </v-card>
   </v-menu>
 </template>
@@ -64,13 +99,14 @@ export default {
     return {
       showMenu: false,
       listItems: [],
-      selectedTags: [],
+      selectedTags: null,
       // TODO: Refactor this into a configurable option
       quickTags: [
         { tag: 'bad', color: 'red', textColor: 'white', label: 'mdi-alert-circle-outline' },
         { tag: 'suspicious', color: 'orange', textColor: 'white', label: 'mdi-help-circle-outline' },
         { tag: 'good', color: 'green', textColor: 'white', label: 'mdi-check-circle-outline' },
       ],
+      search: null,
     }
   },
   computed: {
@@ -80,30 +116,68 @@ export default {
     tags() {
       return this.$store.state.tags.map((tag) => tag.tag)
     },
+    customSelectedTags() {
+      if (!this.event._source.tag) return []
+      // returns all custom tags that are applied to an event without the quick tags
+      if (this.event._source.tag.length === 0) return []
+      let customSelectedTags = this.tags.filter((tag) => tag !== 'bad' && tag !== 'suspicious' && tag !== 'good')
+      customSelectedTags = customSelectedTags.filter((tag) => this.event._source.tag.includes(tag))
+      customSelectedTags.sort((a, b) => { return a.localeCompare(b)})
+      return customSelectedTags
+    },
+    customTags() {
+      if (!this.event._source.tag) return []
+      // returns all custom tags available for a sketch without the ones that are already applied to an event
+      let customTags = this.tags.filter((tag) => tag !== 'bad' && tag !== 'suspicious' && tag !== 'good')
+      customTags = customTags.filter((tag) => !this.customSelectedTags.includes(tag))
+      customTags.sort((a, b) => { return a.localeCompare(b)})
+      return customTags
+    },
   },
   methods: {
-    addTags: function (tagsToAdd) {
-      if (!Array.isArray(tagsToAdd)) {
-        tagsToAdd = [tagsToAdd]
+    showClose(tag) {
+      if (!this.event._source.tag) return false
+      if (this.event._source.tag.indexOf(tag) !== -1) {
+        return true
+      } else {
+         return false
       }
-
+    },
+    removeTags(tag) {
+      console.log('DEMO: removeTag', this.event, tag)
+      this.event._source.tag.splice(this.event._source.tag.indexOf(tag), 1) // DEMO only
+      this.$store.dispatch('updateTimelineTags', { sketchId: this.sketch.id, tag: tag, num: -1 }) // DEMO only
+      // ApiClient.untagEvents(this.sketch.id, [this.event], [tag])
+      //   .then((response) => {
+      //     this.event._source.tag.splice(this.event._source.tag.indexOf(tag), 1)
+      //     this.$store.dispatch('updateTimelineTags', { sketchId: this.sketch.id, tag: tag, num: -1 })
+      //   })
+      //   .catch((e) => {
+      //     console.error(e)
+      //   })
+    },
+    addTags: function (tagToAdd) {
       if (!this.event._source.hasOwnProperty('tag')) {
         this.$set(this.event._source, 'tag', [])
       }
 
-      tagsToAdd.forEach((tag) => {
-        if (this.event._source.tag.indexOf(tag) === -1) {
-          ApiClient.tagEvents(this.sketch.id, [this.event], [tag])
-            .then((response) => {
-              this.event._source.tag.push(tag)
-              this.$store.dispatch('updateTimelineTags', { sketchId: this.sketch.id, tag: tag, num: 1 })
-            })
-            .catch((e) => {
-              console.error('Cannot tag event')
-            })
+      for (const tag of tagToAdd) {
+        if (this.event._source.tag.indexOf(tag) !== -1) {
+          tagToAdd.splice(tagToAdd.indexOf(tag), 1)
         }
-        this.selectedTags = []
-        this.showMenu = false
+      }
+
+      ApiClient.tagEvents(this.sketch.id, [this.event], [tagToAdd])
+        .then((response) => {
+          this.$set(this.event._source.tag, this.event._source.tag.length, tagToAdd)
+          this.$store.dispatch('updateTimelineTags', { sketchId: this.sketch.id, tag: tagToAdd, num: 1 })
+        })
+        .catch((e) => {
+          console.error('Cannot tag event')
+        })
+      this.$nextTick(() => {
+        this.selectedTags = null
+        this.search = null
       })
     },
   },

--- a/timesketch/frontend-ng/src/components/Explore/EventTags.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventTags.vue
@@ -77,17 +77,14 @@ export default {
       return 'lightgrey'
     },
     removeTag(item, tag) {
-      console.log('DEMO: removeTag', item, tag)
-      item._source.tag.splice(item._source.tag.indexOf(tag), 1) // DEMO only
-      this.$store.dispatch('updateTimelineTags', { sketchId: this.sketch.id, tag: tag, num: -1 }) // DEMO only
-      // ApiClient.untagEvents(this.sketch.id, [item], [tag])
-      //   .then((response) => {
-      //     item._source.tag.splice(item._source.tag.indexOf(tag), 1)
-      //     this.$store.dispatch('updateTimelineTags', { sketchId: this.sketch.id, tag: tag, num: -1 })
-      //   })
-      //   .catch((e) => {
-      //     console.error(e)
-      //   })
+      ApiClient.untagEvents(this.sketch.id, [item], [tag])
+        .then((response) => {
+          item._source.tag.splice(item._source.tag.indexOf(tag), 1)
+          this.$store.dispatch('updateTimelineTags', { sketchId: this.sketch.id, tag: tag, num: -1 })
+        })
+        .catch((e) => {
+          console.error(e)
+        })
     },
   },
 }

--- a/timesketch/frontend-ng/src/components/Explore/EventTags.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventTags.vue
@@ -15,6 +15,7 @@ limitations under the License.
     <span v-for="tag in sortedTags" :key="tag">
       <v-hover v-slot="{ hover }">
         <v-chip
+          :style="hover ? '' : 'padding-right: 32px'"
           small
           class="mr-1"
           :close="hover ? true : false"

--- a/timesketch/frontend-ng/src/components/Explore/EventTags.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventTags.vue
@@ -12,19 +12,21 @@ limitations under the License.
 -->
 <template>
   <span>
-    <v-chip
-      small
-      class="mr-1"
-      v-for="tag in sortedTags"
-      :close="showDetails ? true : false"
-      @click:close="removeTag(item, tag)"
-      :key="tag"
-      :color="tagColor(tag).color"
-      :text-color="tagColor(tag).textColor"
-    >
-      <v-icon v-if="tag in tagConfig" left small>{{ tagConfig[tag].label }}</v-icon>
-      {{ tag }}
-    </v-chip>
+    <span v-for="tag in sortedTags" :key="tag">
+      <v-hover v-slot="{ hover }">
+        <v-chip
+          small
+          class="mr-1"
+          :close="hover ? true : false"
+          @click:close="removeTag(item, tag)"
+          :color="tagColor(tag).color"
+          :text-color="tagColor(tag).textColor"
+        >
+          <v-icon v-if="tag in tagConfig" left small>{{ tagConfig[tag].label }}</v-icon>
+          {{ tag }}
+        </v-chip>
+      </v-hover>
+    </span>
     <span v-for="label in item._source.label" :key="label">
       <v-chip v-if="!label.startsWith('__ts')" small outlined class="mr-2">
         {{ label }}
@@ -43,9 +45,10 @@ export default {
     },
     sortedTags() {
       if (!this.item._source.tag) return []
-      // place "bad", "suspicious" and "good" tags first in the array, sort the rest alphabetically
+      // place quickTags first in the array, sort the rest alphabetically
       let tags = this.item._source.tag
       tags.sort((a, b) => {
+        // TODO: refactor when quickTags become configurable.
         if (a === 'bad') {
           return -1
         }

--- a/timesketch/frontend-ng/src/components/Explore/EventTags.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventTags.vue
@@ -1,0 +1,94 @@
+<!--
+Copyright 2023 Google Inc. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<template>
+  <span>
+    <v-chip
+      small
+      class="mr-1"
+      v-for="tag in sortedTags"
+      :close="showDetails ? true : false"
+      @click:close="removeTag(item, tag)"
+      :key="tag"
+      :color="tagColor(tag).color"
+      :text-color="tagColor(tag).textColor"
+    >
+      <v-icon v-if="tag in tagConfig" left small>{{ tagConfig[tag].label }}</v-icon>
+      {{ tag }}
+    </v-chip>
+    <span v-for="label in item._source.label" :key="label">
+      <v-chip v-if="!label.startsWith('__ts')" small outlined class="mr-2">
+        {{ label }}
+      </v-chip>
+    </span>
+  </span>
+</template>
+
+<script>
+import ApiClient from '../../utils/RestApiClient'
+export default {
+  props: ['item', 'tagConfig', 'showDetails'],
+  computed: {
+    sketch() {
+      return this.$store.state.sketch
+    },
+    sortedTags() {
+      if (!this.item._source.tag) return []
+      // place "bad", "suspicious" and "good" tags first in the array, sort the rest alphabetically
+      let tags = this.item._source.tag
+      tags.sort((a, b) => {
+        if (a === 'bad') {
+          return -1
+        }
+        if (b === 'bad') {
+          return 1
+        }
+        if (a === 'suspicious') {
+          return -1
+        }
+        if (b === 'suspicious') {
+          return 1
+        }
+        if (a === 'good') {
+          return -1
+        }
+        if (b === 'good') {
+          return 1
+        }
+        return a.localeCompare(b)
+      })
+      return tags
+    },
+  },
+  methods: {
+    tagColor: function (tag) {
+      if (this.tagConfig[tag]) {
+        return this.tagConfig[tag]
+      }
+      return 'lightgrey'
+    },
+    removeTag(item, tag) {
+      console.log('DEMO: removeTag', item, tag)
+      item._source.tag.splice(item._source.tag.indexOf(tag), 1) // DEMO only
+      this.$store.dispatch('updateTimelineTags', { sketchId: this.sketch.id, tag: tag, num: -1 }) // DEMO only
+      // ApiClient.untagEvents(this.sketch.id, [item], [tag])
+      //   .then((response) => {
+      //     item._source.tag.splice(item._source.tag.indexOf(tag), 1)
+      //     this.$store.dispatch('updateTimelineTags', { sketchId: this.sketch.id, tag: tag, num: -1 })
+      //   })
+      //   .catch((e) => {
+      //     console.error(e)
+      //   })
+    },
+  },
+}
+</script>

--- a/timesketch/frontend-ng/src/utils/RestApiClient.js
+++ b/timesketch/frontend-ng/src/utils/RestApiClient.js
@@ -165,10 +165,10 @@ export default {
   },
   untagEvents(sketchId, events, tags) {
     let formData = {
-      tags: tags,
+      tags_to_remove: tags,
       events: events,
     }
-    return RestApiClient.post('/sketches/' + sketchId + '/event/tag/', formData)
+    return RestApiClient.post('/sketches/' + sketchId + '/event/untag/', formData)
   },
   updateEventAnnotation(sketchId, annotationType, annotation, events, currentSearchNode) {
     let formData = {

--- a/timesketch/frontend-ng/src/utils/RestApiClient.js
+++ b/timesketch/frontend-ng/src/utils/RestApiClient.js
@@ -163,6 +163,13 @@ export default {
     }
     return RestApiClient.post('/sketches/' + sketchId + '/event/tagging/', formData)
   },
+  untagEvents(sketchId, events, tags) {
+    let formData = {
+      tags: tags,
+      events: events,
+    }
+    return RestApiClient.delete('/sketches/' + sketchId + '/event/tag/', { data: formData })
+  },
   updateEventAnnotation(sketchId, annotationType, annotation, events, currentSearchNode) {
     let formData = {
       annotation: annotation,

--- a/timesketch/frontend-ng/src/utils/RestApiClient.js
+++ b/timesketch/frontend-ng/src/utils/RestApiClient.js
@@ -168,7 +168,7 @@ export default {
       tags: tags,
       events: events,
     }
-    return RestApiClient.delete('/sketches/' + sketchId + '/event/tag/', { data: formData })
+    return RestApiClient.post('/sketches/' + sketchId + '/event/tag/', formData)
   },
   updateEventAnnotation(sketchId, annotationType, annotation, events, currentSearchNode) {
     let formData = {


### PR DESCRIPTION
**IMPORTANT:** ~~This PR is blocked by the missing backend API endpoint for removing tags!~~ See #2689 #2605 
=> Endpoint added in #2724 

This PR updates the UX of the event tagging feature and adds the option to remove tags from events.
* Tags are now sorted. Quick tags first, rest alphabetically.
* Tags can now be dynamically added and removed without the need of confirming the dialog.
* Applied tags can be removed from the EventDetail view or via the EventTagMenu.
* The list for new tags will only show available tags.
* The tag menu also supports timelines with events that have no tag attribute now.

Creating this PR as a draft for review and feedback until the backend API is ready.

Demo: 
![TS_tag_demo](https://user-images.githubusercontent.com/99879757/236769973-734bd7a4-1f90-4a24-a7ed-b1b9afafe0c0.gif)

