### PR TITLE
Search with no timeline selected

### DIFF
--- a/timesketch/frontend-ng/src/components/Explore/EventList.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventList.vue
@@ -650,9 +650,17 @@ export default {
       }
     },
     search: function (resetPagination = true, incognito = false, parent = false) {
+      // Exit early if there are no indices selected.
+      if (this.currentQueryFilter.indices && !this.currentQueryFilter.indices.length) {
+        this.eventList = emptyEventList()
+        return
+      }
+
+      // Exit early if there is no query string or DSL provided.
       if (!this.currentQueryString && !this.currentQueryDsl) {
         return
       }
+
       this.searchInProgress = true
       this.selectedEvents = []
       this.eventList = emptyEventList()


### PR DESCRIPTION
This PR adds a check to check that there are indices selected before doing a search. This removed the endless loading and error result.

fixes #2682 