### PR TITLE
Exit early if there is no cytoscape instance

### DIFF
--- a/timesketch/frontend-ng/src/views/Graph.vue
+++ b/timesketch/frontend-ng/src/views/Graph.vue
@@ -655,6 +655,9 @@ export default {
         .update()
     },
     setTheme: function () {
+      if (!this.cy) {
+        return
+      }
       if (this.$vuetify.theme.dark) {
         this.cy
           .style()


### PR DESCRIPTION
This PR fixes a warning that cytoscape instance is not available when changing themes.

Fixes #2683 