### PR TITLE
Saved View left panel fixes

### DIFF
--- a/timesketch/frontend-ng/src/components/Explore/EventActionMenu.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventActionMenu.vue
@@ -21,13 +21,22 @@ limitations under the License.
       </template>
       <v-list dense class="mx-auto">
         <v-list-item style="cursor: pointer" @click="copyEventUrlToClipboard()">
-          <v-list-item-title> <v-icon>mdi-link-variant</v-icon> Copy link to event </v-list-item-title>
+          <v-list-item-icon>
+            <v-icon small>mdi-link-variant</v-icon>
+          </v-list-item-icon>
+          <v-list-item-title>Copy link to event</v-list-item-title>
         </v-list-item>
         <v-list-item style="cursor: pointer" @click="copyEventAsJSON()">
-          <v-list-item-title> <v-icon>mdi-code-json</v-icon> Copy event data as JSON </v-list-item-title>
+          <v-list-item-icon>
+            <v-icon small>mdi-code-json</v-icon>
+          </v-list-item-icon>
+          <v-list-item-title>Copy event data as JSON</v-list-item-title>
         </v-list-item>
         <v-list-item style="cursor: pointer" @click="showContextWindow()">
-          <v-list-item-title> <v-icon>mdi-magnify-plus-outline</v-icon> Context search </v-list-item-title>
+          <v-list-item-icon>
+            <v-icon small>mdi-magnify-plus-outline</v-icon>
+          </v-list-item-icon>
+          <v-list-item-title>Context search</v-list-item-title>
         </v-list-item>
       </v-list>
     </v-menu>

--- a/timesketch/frontend-ng/src/components/Explore/EventList.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventList.vue
@@ -838,7 +838,6 @@ export default {
           this.saveSearchMenu = false
           let newView = response.data.objects[0]
           this.$store.state.meta.views.push(newView)
-          this.$router.push({ name: 'Explore', query: { view: newView.id } })
         })
         .catch((e) => {})
     },

--- a/timesketch/frontend-ng/src/components/LeftPanel/SavedSearches.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/SavedSearches.vue
@@ -30,16 +30,36 @@ limitations under the License.
     </div>
 
     <v-expand-transition>
-      <div v-show="expanded">
+      <div v-show="expanded" class="pb-2">
         <div
           v-for="savedSearch in meta.views"
           :key="savedSearch.name"
           @click="setView(savedSearch)"
           style="cursor: pointer; font-size: 0.9em"
         >
-          <v-row no-gutters class="pa-2 pl-5" :class="$vuetify.theme.dark ? 'dark-hover' : 'light-hover'">{{
-            savedSearch.name
-          }}</v-row>
+          <v-row no-gutters class="py-1 pl-5 pr-3" :class="$vuetify.theme.dark ? 'dark-hover' : 'light-hover'">
+            <v-col cols="11"
+              ><div class="mt-1">{{ savedSearch.name }}</div></v-col
+            >
+            <v-col cols="1">
+              <v-menu offset-y>
+                <template v-slot:activator="{ on, attrs }">
+                  <v-btn small icon v-bind="attrs" v-on="on">
+                    <v-icon small>mdi-dots-vertical</v-icon>
+                  </v-btn>
+                </template>
+                <v-card>
+                  <v-list dense class="mx-auto">
+                    <v-list-item style="cursor: pointer" @click="copySavedSearchUrlToClipboard(savedSearch.id)">
+                      <v-list-item-title>
+                        <v-icon>mdi-link-variant</v-icon> Copy link to this search
+                      </v-list-item-title>
+                    </v-list-item>
+                  </v-list>
+                </v-card>
+              </v-menu>
+            </v-col>
+          </v-row>
         </div>
       </div>
     </v-expand-transition>
@@ -68,6 +88,16 @@ export default {
   methods: {
     setView: function (savedSearch) {
       EventBus.$emit('setActiveView', savedSearch)
+    },
+    copySavedSearchUrlToClipboard(savedSearchId) {
+      try {
+        let searchUrl = window.location.origin + this.$route.path + '?view=' + savedSearchId
+        navigator.clipboard.writeText(searchUrl)
+        this.infoSnackBar('Event URL copied to clipboard')
+      } catch (error) {
+        this.errorSnackBar('Failed to load Event URL into the clipboard')
+        console.error(error)
+      }
     },
   },
   created() {},

--- a/timesketch/frontend-ng/src/components/LeftPanel/SavedSearches.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/SavedSearches.vue
@@ -48,15 +48,15 @@ limitations under the License.
                     <v-icon small>mdi-dots-vertical</v-icon>
                   </v-btn>
                 </template>
-                <v-card>
-                  <v-list dense class="mx-auto">
-                    <v-list-item style="cursor: pointer" @click="copySavedSearchUrlToClipboard(savedSearch.id)">
-                      <v-list-item-title>
-                        <v-icon>mdi-link-variant</v-icon> Copy link to this search
-                      </v-list-item-title>
-                    </v-list-item>
-                  </v-list>
-                </v-card>
+
+                <v-list dense class="mx-auto">
+                  <v-list-item style="cursor: pointer" @click="copySavedSearchUrlToClipboard(savedSearch.id)">
+                    <v-list-item-icon>
+                      <v-icon small>mdi-link-variant</v-icon>
+                    </v-list-item-icon>
+                    <v-list-item-title>Copy link to this search </v-list-item-title>
+                  </v-list-item>
+                </v-list>
               </v-menu>
             </v-col>
           </v-row>

--- a/timesketch/frontend-ng/src/components/LeftPanel/SigmaRule.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/SigmaRule.vue
@@ -35,7 +35,7 @@ limitations under the License.
         <v-menu offset-y>
           <template v-slot:activator="{ on, attrs }">
             <v-btn small icon v-bind="attrs" v-on="on">
-              <v-icon>mdi-dots-vertical</v-icon>
+              <v-icon small>mdi-dots-vertical</v-icon>
             </v-btn>
           </template>
           <v-card>

--- a/timesketch/frontend-ng/src/views/Explore.vue
+++ b/timesketch/frontend-ng/src/views/Explore.vue
@@ -401,10 +401,14 @@ export default {
     searchView: function (viewId) {
       this.showSearchDropdown = false
 
+      if (this.$route.name !== 'Explore') {
+        this.$router.push({ name: 'Explore', params: { sketchId: this.sketch.id } })
+      }
+
       if (viewId !== parseInt(viewId, 10) && typeof viewId !== 'string') {
         viewId = viewId.id
-        this.$router.push({ name: 'Explore', query: { view: viewId } })
       }
+
       ApiClient.getView(this.sketchId, viewId)
         .then((response) => {
           let view = response.data.objects[0]


### PR DESCRIPTION
This PR changes how saved searches are handled in the left menu.
* No route is pushed when clicked. Using setView() instead.
* Added 3-dots menu with an option to link to the saved search

<img width="843" alt="Screenshot 2023-04-26 at 09 52 07" src="https://user-images.githubusercontent.com/316362/234546566-6eb159cf-ef9c-48ce-bb3a-6cb52175539a.png">
