### PR TITLE
Context Search

### DIFF
--- a/timesketch/frontend-ng/src/components/Explore/EventActionMenu.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventActionMenu.vue
@@ -14,23 +14,34 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <template>
-  <v-menu v-model="showMenu" offset-y transition="slide-y-transition">
-    <template v-slot:activator="{ on, attrs }">
-      <v-icon v-bind="attrs" v-on="on" class="ml-1">mdi-dots-vertical</v-icon>
-    </template>
-    <v-list dense class="mx-auto">
-      <v-list-item style="cursor: pointer" @click="copyEventUrlToClipboard()">
-        <v-list-item-title> <v-icon>mdi-link-variant</v-icon> Copy link to event </v-list-item-title>
-      </v-list-item>
-      <v-list-item style="cursor: pointer" @click="copyEventAsJSON()">
-        <v-list-item-title> <v-icon>mdi-code-json</v-icon> Copy event data as JSON </v-list-item-title>
-      </v-list-item>
-    </v-list>
-  </v-menu>
+  <span>
+    <v-menu v-model="showMenu" offset-y transition="slide-y-transition">
+      <template v-slot:activator="{ on, attrs }">
+        <v-icon v-bind="attrs" v-on="on" class="ml-1">mdi-dots-vertical</v-icon>
+      </template>
+      <v-list dense class="mx-auto">
+        <v-list-item style="cursor: pointer" @click="copyEventUrlToClipboard()">
+          <v-list-item-title> <v-icon>mdi-link-variant</v-icon> Copy link to event </v-list-item-title>
+        </v-list-item>
+        <v-list-item style="cursor: pointer" @click="copyEventAsJSON()">
+          <v-list-item-title> <v-icon>mdi-code-json</v-icon> Copy event data as JSON </v-list-item-title>
+        </v-list-item>
+        <v-list-item style="cursor: pointer" @click="showContextWindow()">
+          <v-list-item-title>
+            <v-icon>mdi-magnify-plus-outline</v-icon> Context search (bottom sheet)
+          </v-list-item-title>
+        </v-list-item>
+        <v-list-item style="cursor: pointer" @click="showContextWindowDialog()">
+          <v-list-item-title> <v-icon>mdi-magnify-plus-outline</v-icon> Context search (dialog) </v-list-item-title>
+        </v-list-item>
+      </v-list>
+    </v-menu>
+  </span>
 </template>
 
 <script>
 import ApiClient from '../../utils/RestApiClient'
+import EventBus from '../../main'
 
 export default {
   props: ['event'],
@@ -46,6 +57,12 @@ export default {
     },
   },
   methods: {
+    showContextWindow() {
+      EventBus.$emit('showContextWindow', this.event)
+    },
+    showContextWindowDialog() {
+      EventBus.$emit('showContextWindowDialog', this.event)
+    },
     copyEventAsJSON() {
       ApiClient.getEvent(this.sketch.id, this.event._index, this.event._id)
         .then((response) => {

--- a/timesketch/frontend-ng/src/components/Explore/EventActionMenu.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventActionMenu.vue
@@ -27,12 +27,7 @@ limitations under the License.
           <v-list-item-title> <v-icon>mdi-code-json</v-icon> Copy event data as JSON </v-list-item-title>
         </v-list-item>
         <v-list-item style="cursor: pointer" @click="showContextWindow()">
-          <v-list-item-title>
-            <v-icon>mdi-magnify-plus-outline</v-icon> Context search (bottom sheet)
-          </v-list-item-title>
-        </v-list-item>
-        <v-list-item style="cursor: pointer" @click="showContextWindowDialog()">
-          <v-list-item-title> <v-icon>mdi-magnify-plus-outline</v-icon> Context search (dialog) </v-list-item-title>
+          <v-list-item-title> <v-icon>mdi-magnify-plus-outline</v-icon> Context search </v-list-item-title>
         </v-list-item>
       </v-list>
     </v-menu>
@@ -59,9 +54,6 @@ export default {
   methods: {
     showContextWindow() {
       EventBus.$emit('showContextWindow', this.event)
-    },
-    showContextWindowDialog() {
-      EventBus.$emit('showContextWindowDialog', this.event)
     },
     copyEventAsJSON() {
       ApiClient.getEvent(this.sketch.id, this.event._index, this.event._id)

--- a/timesketch/frontend-ng/src/components/Explore/EventList.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventList.vue
@@ -290,7 +290,7 @@ limitations under the License.
           <ts-event-tag-menu :event="item"></ts-event-tag-menu>
 
           <!-- Action sub-menu -->
-          <ts-event-action-menu :event="item"></ts-event-action-menu>
+          <ts-event-action-menu :event="item" @showContextWindow="showContextWindow($event)"></ts-event-action-menu>
         </template>
 
         <!-- Datetime field with action buttons -->
@@ -308,7 +308,12 @@ limitations under the License.
             style="cursor: pointer"
             @click="toggleDetailedEvent(item)"
           >
-            <span :class="{ 'ts-event-field-ellipsis': field.text === 'message' }">
+            <span
+              :class="{
+                'ts-event-field-ellipsis': field.text === 'message',
+                'ts-event-field-highlight': item._id === highlightEvent,
+              }"
+            >
               <!-- Tags -->
               <span v-if="displayOptions.showTags && index === 3">
                 <v-chip
@@ -429,6 +434,10 @@ export default {
     disablePagination: {
       type: Boolean,
       default: false,
+    },
+    highlightEvent: {
+      type: String,
+      default: '',
     },
   },
   data() {
@@ -912,6 +921,11 @@ export default {
   top: 50%;
   transform: translateY(-50%);
   left: 0;
+}
+
+.ts-event-field-highlight {
+  font-weight: bold;
+  color: red;
 }
 
 .v-data-table__expanded.v-data-table__expanded__content {

--- a/timesketch/frontend-ng/src/filters/FormatSeconds.js
+++ b/timesketch/frontend-ng/src/filters/FormatSeconds.js
@@ -1,0 +1,24 @@
+/*
+Copyright 2022 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+export default {
+  name: 'formatSeconds',
+  filter: function (seconds) {
+    if (seconds > 60) {
+      return seconds / 60 + 'm'
+    }
+    return seconds + 's'
+  },
+}

--- a/timesketch/frontend-ng/src/views/Sketch.vue
+++ b/timesketch/frontend-ng/src/views/Sketch.vue
@@ -65,8 +65,17 @@ limitations under the License.
     >
       <v-card>
         <v-toolbar dense flat>
-          <strong>Context search {{ contextStartTime }} {{ contextEndTime }}</strong>
+          <strong>Context search {{ contextTimeWindowSeconds }} +/- seconds</strong>
           <v-spacer></v-spacer>
+          <v-slider
+            v-model="contextTimeWindowSeconds"
+            @end="updateContextQuery()"
+            min="0"
+            max="600"
+            step="1"
+            class="mt-6"
+          >
+          </v-slider>
           <v-btn icon :disabled="timelineViewHeight > 40" @click="increaseTimelineViewHeight()">
             <v-icon>mdi-chevron-up</v-icon>
           </v-btn>


### PR DESCRIPTION
This PR adds context searches to the UI.

* Pivot from an event and search all timelines within a time window
* Context search result is displayed in a bottom sheet window (same as in graphs) 
* Option to "pop out" the context search and replace the current search window

<img width="1722" alt="Screenshot 2023-04-26 at 16 17 10" src="https://user-images.githubusercontent.com/316362/234605157-94d92fad-a566-41a6-9547-85201865eb21.png">
