### PR TITLE
fixing failing tests

### DIFF
--- a/timesketch/frontend-ng/package.json
+++ b/timesketch/frontend-ng/package.json
@@ -24,7 +24,7 @@
     "dompurify": "^3.0.1",
     "eslint-config-prettier": "^8.3.0",
     "lodash": "^4.17.11",
-    "marked": ">=2.0.0",
+    "marked": ">=2.0.0 <5.0.0",
     "moment": "^2.24.0",
     "v-calendar": "^2.4.0",
     "vega": "^5.4.0",

--- a/timesketch/frontend/package.json
+++ b/timesketch/frontend/package.json
@@ -21,7 +21,7 @@
     "cytoscape-spread": "^3.0.0",
     "eslint-config-prettier": "^8.3.0",
     "lodash": "^4.17.11",
-    "marked": ">=2.0.0",
+    "marked": ">=2.0.0 <5.0.0",
     "moment": "^2.24.0",
     "vega": "^5.4.0",
     "vega-embed": "^4.2.2",


### PR DESCRIPTION
Pinning node package `"marked": ">=2.0.0 <5.0.0"` since 5.0.0 does not support node 14 anymore.

Context:
Since building the marked package fails, the tests are not able to setup properly. As a temporary quick solution I pinned the marked package to  ">=2.0.0 <5.0.0". 

Long term fix:
We are currently running on node version 14 which is [EoL since 2023-04-30](https://github.com/nodejs/release#release-schedule). So we should update to at least node version 18 running the supported LTS version again. => tracking in #2718 
