### PR TITLE
[CLI] bugfix: respect --limit when using a saved_search

### DIFF
--- a/cli_client/python/timesketch_cli_client/commands/search.py
+++ b/cli_client/python/timesketch_cli_client/commands/search.py
@@ -170,6 +170,8 @@ def search_group(
     # Construct query from saved search and return early.
     if saved_search:
         search_obj.from_saved(saved_search)
+        if limit:
+            search_obj.max_entries = limit
         if describe:
             describe_query(search_obj)
             return

--- a/cli_client/python/timesketch_cli_client/commands/search.py
+++ b/cli_client/python/timesketch_cli_client/commands/search.py
@@ -19,7 +19,10 @@ import sys
 import click
 from tabulate import tabulate
 
-from timesketch_api_client import search
+# pylint: disable=import-error
+from timesketch_api_client import test_lib as api_test_lib
+
+# pylint: enable=import-error
 
 
 def format_output(search_obj, output_format, show_headers, show_internal_columns):

--- a/cli_client/python/timesketch_cli_client/commands/search.py
+++ b/cli_client/python/timesketch_cli_client/commands/search.py
@@ -20,7 +20,7 @@ import click
 from tabulate import tabulate
 
 # pylint: disable=import-error
-from timesketch_api_client import test_lib as api_test_lib
+from timesketch_api_client import search
 
 # pylint: enable=import-error
 


### PR DESCRIPTION
This PR fixes a bug where a search executed with the CLI client using a saved search did not respect the limit parameter.

**Checks**

- [x] All tests succeed.
- [x] Unit tests added.
- [x] e2e tests added.
- [x] Documentation updated.

**Closing issues**

closes #2187
