### PR TITLE
Save SearchTemplates via YAML only

### DIFF
--- a/timesketch/api/v1/resources/searchtemplate.py
+++ b/timesketch/api/v1/resources/searchtemplate.py
@@ -148,6 +148,14 @@ class SearchTemplateListResource(resources.ResourceMixin, Resource):
         Returns:
             View in JSON (instance of flask.wrappers.Response)
         """
+        # Disable adding search templates from the API. This is not supported yet and
+        # can only be done by the server admin using the YAML format.
+        # TODO: Remove this when support is added for template reviews and tooling.
+        abort(
+            HTTP_STATUS_CODE_BAD_REQUEST,
+            "Unable to save template. Please contact server admin to add using YAML",
+        )
+
         form = request.json
         if not form:
             form = request.data


### PR DESCRIPTION
This PR disables the ability to save search templates from the API. This functionality is not yet supported in the UI and more work is needed for validating user supplied templates.

Long term solution will be tracked separately.
