### PR TITLE
add more details to the timelines CLI command

### DIFF
--- a/cli_client/python/timesketch_cli_client/commands/timelines.py
+++ b/cli_client/python/timesketch_cli_client/commands/timelines.py
@@ -63,7 +63,7 @@ def describe_timeline(ctx, timeline_id, output):
         click.echo(f"{timeline.resource_data}")
         return
     elif output != "text":
-        click.echo(f"Unsupported output format: \"{output}\" - using \"text\" instead")
+        click.echo(f'Unsupported output format: "{output}" - using "text" instead')
 
     click.echo(f"Name: {timeline.name}")
     click.echo(f"Index: {timeline.index_name}")

--- a/cli_client/python/timesketch_cli_client/commands/timelines.py
+++ b/cli_client/python/timesketch_cli_client/commands/timelines.py
@@ -59,7 +59,7 @@ def describe_timeline(ctx, timeline_id, output):
         click.echo("No such timeline")
         return
     if output == "json":
-        status = timeline.status  # Trigger to fetch the whole details of the timeline
+        timeline.status  # Trigger to fetch the whole details of the timeline
         click.echo(f"{timeline.resource_data}")
         return
 

--- a/cli_client/python/timesketch_cli_client/commands/timelines.py
+++ b/cli_client/python/timesketch_cli_client/commands/timelines.py
@@ -62,6 +62,8 @@ def describe_timeline(ctx, timeline_id, output):
     if output == "json":
         click.echo(f"{timeline.resource_data}")
         return
+    elif output != "text":
+        click.echo(f"Unsupported output format: {output}")
 
     click.echo(f"Name: {timeline.name}")
     click.echo(f"Index: {timeline.index_name}")

--- a/cli_client/python/timesketch_cli_client/commands/timelines.py
+++ b/cli_client/python/timesketch_cli_client/commands/timelines.py
@@ -40,7 +40,7 @@ def list_timelines(ctx):
     "--output-format",
     "output",
     required=False,
-    help="Set output format (overrides global setting).",
+    help="Set output format [json, text (default)] (overrides global setting).",
 )
 @click.pass_context
 def describe_timeline(ctx, timeline_id, output):

--- a/cli_client/python/timesketch_cli_client/commands/timelines.py
+++ b/cli_client/python/timesketch_cli_client/commands/timelines.py
@@ -36,19 +36,50 @@ def list_timelines(ctx):
 
 @timelines_group.command("describe")
 @click.argument("timeline-id", type=int, required=False)
+@click.option(
+    "--output-format",
+    "output",
+    required=False,
+    help="Set output format (overrides global setting).",
+)
 @click.pass_context
-def describe_timeline(ctx, timeline_id):
+def describe_timeline(ctx, timeline_id, output):
     """Show details for a timeline.
 
     Args:
         ctx: Click CLI context object.
         timeline-id: Timeline ID from argument.
+        output-format: Output format to use.
     """
     sketch = ctx.obj.sketch
-    # TODO (berggren): Add more details to the output, e.g. the data_sources
+    if not output:
+        output = ctx.obj.output_format
     timeline = sketch.get_timeline(timeline_id=timeline_id)
     if not timeline:
         click.echo("No such timeline")
         return
+    if output == "json":
+        status = timeline.status  # Trigger to fetch the whole details of the timeline
+        click.echo(f"{timeline.resource_data}")
+        return
+
     click.echo(f"Name: {timeline.name}")
     click.echo(f"Index: {timeline.index_name}")
+    click.echo(f"Status: {timeline.status}")
+    lines_indexed = timeline.resource_data.get("meta").get("lines_indexed", 0)
+    click.echo(f"Event count: {lines_indexed or 0}")
+
+    for timeline_object in timeline.resource_data.get("objects", None):
+        name = timeline_object.get("name", "no name")
+        created = timeline_object.get("created_at", 0)
+        click.echo(f"Name: {name}")
+        click.echo(f"Created: {created}")
+        click.echo("Datasources:")
+        for datasource in timeline_object.get("datasources", []):
+            error_message = datasource.get("error_message", None)
+            original_filename = datasource.get("original_filename", None)
+            file_on_disk = datasource.get("file_on_disk", None)
+
+            click.echo(f"\tOriginal filename: {original_filename}")
+            click.echo(f"\tFile on disk: {file_on_disk}")
+            click.echo(f"\tError: {error_message}")

--- a/cli_client/python/timesketch_cli_client/commands/timelines.py
+++ b/cli_client/python/timesketch_cli_client/commands/timelines.py
@@ -58,9 +58,8 @@ def describe_timeline(ctx, timeline_id, output):
     if not timeline:
         click.echo("No such timeline")
         return
+    timeline.lazyload_data()
     if output == "json":
-        # Trigger to fetch the whole details of the timeline
-        timeline.status  # pylint: disable=pointless-statement
         click.echo(f"{timeline.resource_data}")
         return
 

--- a/cli_client/python/timesketch_cli_client/commands/timelines.py
+++ b/cli_client/python/timesketch_cli_client/commands/timelines.py
@@ -62,7 +62,7 @@ def describe_timeline(ctx, timeline_id, output):
     if output == "json":
         click.echo(f"{timeline.resource_data}")
         return
-    elif output != "text":
+    if output != "text":
         click.echo(f'Unsupported output format: "{output}" - using "text" instead')
 
     click.echo(f"Name: {timeline.name}")

--- a/cli_client/python/timesketch_cli_client/commands/timelines.py
+++ b/cli_client/python/timesketch_cli_client/commands/timelines.py
@@ -59,7 +59,8 @@ def describe_timeline(ctx, timeline_id, output):
         click.echo("No such timeline")
         return
     if output == "json":
-        timeline.status  # Trigger to fetch the whole details of the timeline
+        # Trigger to fetch the whole details of the timeline
+        timeline.status  # pylint: disable=pointless-statement
         click.echo(f"{timeline.resource_data}")
         return
 

--- a/cli_client/python/timesketch_cli_client/commands/timelines.py
+++ b/cli_client/python/timesketch_cli_client/commands/timelines.py
@@ -49,7 +49,7 @@ def describe_timeline(ctx, timeline_id, output):
     Args:
         ctx: Click CLI context object.
         timeline-id: Timeline ID from argument.
-        output-format: Output format to use.
+        output-format: Output format to use. Available values: 'json' or 'text'
     """
     sketch = ctx.obj.sketch
     if not output:

--- a/cli_client/python/timesketch_cli_client/commands/timelines.py
+++ b/cli_client/python/timesketch_cli_client/commands/timelines.py
@@ -63,7 +63,7 @@ def describe_timeline(ctx, timeline_id, output):
         click.echo(f"{timeline.resource_data}")
         return
     elif output != "text":
-        click.echo(f"Unsupported output format: {output} using text instead")
+        click.echo(f"Unsupported output format: \"{output}\" - using \"text\" instead")
 
     click.echo(f"Name: {timeline.name}")
     click.echo(f"Index: {timeline.index_name}")

--- a/cli_client/python/timesketch_cli_client/commands/timelines.py
+++ b/cli_client/python/timesketch_cli_client/commands/timelines.py
@@ -40,7 +40,7 @@ def list_timelines(ctx):
     "--output-format",
     "output",
     required=False,
-    help="Set output format [json, text (default)] (overrides global setting).",
+    help="Set output format [json, text] (overrides global setting).",
 )
 @click.pass_context
 def describe_timeline(ctx, timeline_id, output):
@@ -63,7 +63,7 @@ def describe_timeline(ctx, timeline_id, output):
         click.echo(f"{timeline.resource_data}")
         return
     elif output != "text":
-        click.echo(f"Unsupported output format: {output}")
+        click.echo(f"Unsupported output format: {output} using text instead")
 
     click.echo(f"Name: {timeline.name}")
     click.echo(f"Index: {timeline.index_name}")


### PR DESCRIPTION
This PR adds more information to the `timesketch timeline`command.

```
timesketch timelines describe 4
Name: tag_test
Index: 56093e2566164c50bdf973643543571b
Status: ready
Event count: 260454
Name: tag_test
Created: 2023-03-30T09:59:36.692486
Datasources:
	Original filename: win7-x86.plaso
	File on disk: /tmp/4c1211627503430090fb73887bd7550e
	Error:
```

```
timelines describe 4 --output-format json
{'meta': {'lines_indexed': 260454}, 'objects': [{'color': '7981F3', 'created_at': '2023-03-30T09:59:36.692486', 'datasources': [{'context': 'win7-x86.plaso', 'created_at': '2023-03-30T09:59:36.709239', 'data_label': '', 'error_message': '', 'file_on_disk': '/tmp/4c1211627503430090fb73887bd7550e', 'file_size': 192270336, 'id': 4, 'original_filename': 'win7-x86.plaso', 'provider': 'WebUpload', 'status': [{'created_at': '2023-03-30T10:03:05.678905', 'id': 12, 'status': 'ready', 'updated_at': '2023-03-30T10:03:05.678905'}], 'total_file_events': 260454, 'updated_at': '2023-03-30T09:59:38.538142', 'user': {'active': True, 'admin': False, 'groups': [], 'username': 'dev'}}], 'deleted': None, 'description': 'win7-x86', 'id': 4, 'label_string': '', 'name': 'tag_test', 'searchindex': {'created_at': '2023-03-30T09:59:36.629023', 'deleted': None, 'description': 'win7-x86', 'id': 4, 'index_name': '56093e2566164c50bdf973643543571b', 'label_string': '["plaso"]', 'name': 'win7-x86', 'status': [{'created_at': '2023-03-30T10:03:05.701635', 'id': 16, 'status': 'ready', 'updated_at': '2023-03-30T10:03:05.701635'}], 'updated_at': '2023-03-30T09:59:36.629023', 'user': {'active': True, 'admin': False, 'groups': [], 'username': 'dev'}}, 'status': [{'created_at': '2023-03-30T10:03:05.691197', 'id': 12, 'status': 'ready', 'updated_at': '2023-03-30T10:03:05.691197'}], 'updated_at': '2023-05-03T12:26:31.845016', 'user': {'active': True, 'admin': False, 'groups': [], 'username': 'dev'}}]}
```

The json output variant might be good for devs to see all content, the other one more for exploring the data at hand.