### PR TITLE
Ensure that upload path is valid

### DIFF
--- a/end_to_end_tests/__init__.py
+++ b/end_to_end_tests/__init__.py
@@ -20,3 +20,4 @@ from . import client_test
 from . import data_finder_test
 from . import graph_test
 from . import query_test
+from . import upload_test

--- a/end_to_end_tests/interface.py
+++ b/end_to_end_tests/interface.py
@@ -20,6 +20,7 @@ import json
 import time
 import traceback
 import unittest
+import uuid
 
 import opensearchpy
 import opensearchpy.helpers
@@ -60,7 +61,7 @@ class BaseEndToEndTest(object):
         self._counter = collections.Counter()
         self._imported_files = []
 
-    def import_timeline(self, filename):
+    def import_timeline(self, filename, index_name=None):
         """Import a Plaso, CSV or JSONL file.
 
         Args:
@@ -72,11 +73,13 @@ class BaseEndToEndTest(object):
         if filename in self._imported_files:
             return
         file_path = os.path.join(TEST_DATA_DIR, filename)
-        print("Importing: {0:s}".format(file_path))
+        if not index_name:
+            index_name = uuid.uuid4().hex
 
         with importer.ImportStreamer() as streamer:
             streamer.set_sketch(self.sketch)
             streamer.set_timeline_name(file_path)
+            streamer.set_index_name(index_name)
             streamer.add_file(file_path)
             timeline = streamer.timeline
 
@@ -91,7 +94,15 @@ class BaseEndToEndTest(object):
             _ = timeline.lazyload_data(refresh_cache=True)
             status = timeline.status
 
-            # TODO: Do something with other statuses? (e.g. failed)
+            if not timeline.index:
+                retry_count += 1
+                time.sleep(sleep_time_seconds)
+                continue
+
+            if status == "fail" or timeline.index.status == "fail":
+                if retry_count > 3:
+                    raise RuntimeError("Unable to import timeline.")
+
             if status == "ready" and timeline.index.status == "ready":
                 break
             retry_count += 1

--- a/end_to_end_tests/upload_test.py
+++ b/end_to_end_tests/upload_test.py
@@ -1,0 +1,31 @@
+# Copyright 2023 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""End to end tests of Timesketch upload functionality."""
+
+from . import interface
+from . import manager
+
+
+class UploadTest(interface.BaseEndToEndTest):
+    """End to end tests for upload functionality."""
+
+    NAME = "upload_test"
+
+    def test_invalid_index_name(self):
+        """Test uploading a timeline with an invalid index name."""
+        with self.assertions.assertRaises(RuntimeError):
+            self.import_timeline("evtx.plaso", index_name="/invalid/index/name")
+
+
+manager.EndToEndTestManager.register_test(UploadTest)

--- a/timesketch/api/v1/resources/upload.py
+++ b/timesketch/api/v1/resources/upload.py
@@ -16,8 +16,10 @@
 import codecs
 import logging
 import os
+import re
 import uuid
 import json
+import pathlib
 
 from flask import jsonify
 from flask import request
@@ -355,7 +357,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
             filename = codecs.decode(filename, "utf-8")
 
         upload_folder = current_app.config["UPLOAD_FOLDER"]
-        file_path = os.path.join(upload_folder, filename)
+        file_path = utils.format_upload_path(upload_folder, filename)
 
         chunk_index = form.get("chunk_index")
         if isinstance(chunk_index, str) and chunk_index.isdigit():
@@ -394,11 +396,21 @@ class UploadFileResource(resources.ResourceMixin, Resource):
         # For file chunks we need the correct filepath, otherwise each chunk
         # will get their own UUID as a filename.
         if index_name:
-            file_path = os.path.join(upload_folder, index_name)
+            if not utils.is_valid_index_name(index_name):
+                abort(
+                    HTTP_STATUS_CODE_BAD_REQUEST,
+                    "Unable to upload file. Index name is not valid",
+                )
+            file_path = utils.format_upload_path(upload_folder, index_name)
         elif chunk_index_name:
-            file_path = os.path.join(upload_folder, chunk_index_name)
+            if not utils.is_valid_index_name(chunk_index_name):
+                abort(
+                    HTTP_STATUS_CODE_BAD_REQUEST,
+                    "Unable to upload file. Index name is not valid",
+                )
+            file_path = utils.format_upload_path(upload_folder, chunk_index_name)
         else:
-            file_path = os.path.join(upload_folder, uuid.uuid4().hex)
+            file_path = utils.format_upload_path(upload_folder, uuid.uuid4().hex)
 
         try:
             with open(file_path, "ab") as fh:

--- a/timesketch/api/v1/resources/upload.py
+++ b/timesketch/api/v1/resources/upload.py
@@ -16,10 +16,8 @@
 import codecs
 import logging
 import os
-import re
 import uuid
 import json
-import pathlib
 
 from flask import jsonify
 from flask import request

--- a/timesketch/api/v1/utils.py
+++ b/timesketch/api/v1/utils.py
@@ -304,7 +304,7 @@ def is_valid_index_name(index_name):
     Returns:
         A boolean indicating whether the index name is valid or not.
     """
-    regex = re.compile("[0-9a-f]{32}\Z", re.I)
+    regex = re.compile(r"[0-9a-f]{32}", re.I)
     match = regex.match(index_name)
     return bool(match)
 

--- a/timesketch/api/v1/utils.py
+++ b/timesketch/api/v1/utils.py
@@ -16,9 +16,9 @@ import logging
 import json
 import time
 import os
-import yaml
 import pathlib
 import re
+import yaml
 
 from flask import abort
 from flask import jsonify

--- a/timesketch/api/v1/utils.py
+++ b/timesketch/api/v1/utils.py
@@ -17,6 +17,8 @@ import json
 import time
 import os
 import yaml
+import pathlib
+import re
 
 from flask import abort
 from flask import jsonify
@@ -291,3 +293,40 @@ def escape_query_string(query_string):
         )
     )
     return escaped_query_string
+
+
+def is_valid_index_name(index_name):
+    """Validate index name.
+
+    Args:
+        index_name: string with the index name in uuid.uuid4.hex format.
+
+    Returns:
+        A boolean indicating whether the index name is valid or not.
+    """
+    regex = re.compile("[0-9a-f]{32}\Z", re.I)
+    match = regex.match(index_name)
+    return bool(match)
+
+
+def format_upload_path(upload_path, index_name):
+    """Format upload path.
+
+    Args:
+        upload_path: string with the upload path.
+        index_name: string with the index name in uuid.uuid4.hex format.
+
+    Returns:
+        A string with the formatted upload path.
+    """
+    base_path = pathlib.Path(upload_path)
+    index_name_path = pathlib.Path(index_name)
+    if not base_path.is_absolute():
+        raise ValueError("Upload path must be absolute")
+
+    if not index_name_path.is_absolute():
+        full_path = base_path / index_name_path
+        return full_path.as_posix()
+
+    full_path = base_path / index_name_path.relative_to(base_path.anchor)
+    return full_path.as_posix()

--- a/timesketch/api/v1/utils_test.py
+++ b/timesketch/api/v1/utils_test.py
@@ -25,3 +25,44 @@ class TestApiUtils(BaseTest):
         expected_output = r"\/foo\/bar\/test\.txt c:\\foo\\bar"
         escaped_query_string = utils.escape_query_string(query_string_to_test)
         self.assertEqual(escaped_query_string, expected_output)
+
+    def test_valid_index_name(self):
+        """Test valid index name."""
+        valid_index_name = "a89933473b2a48948beee2c7e870209f"
+        self.assertTrue(utils.is_valid_index_name(valid_index_name))
+
+    def test_invalid_index_name(self):
+        """Test invalid index name."""
+        invalid_index_name = "/invalid/index/name"
+        self.assertFalse(utils.is_valid_index_name(invalid_index_name))
+
+    def test_invalid_upload_path(self):
+        """Test invalid upload path.
+
+        Resulting path should be a concatenation of the two paths anchored at the
+        base path.
+        """
+        base_path = "/tmp"
+        user_supplied_index_name = "/foo/bar/test.txt"
+        expected_path = "/tmp/foo/bar/test.txt"
+        resulting_path = utils.format_upload_path(base_path, user_supplied_index_name)
+        self.assertEqual(resulting_path, expected_path)
+
+    def test_valid_upload_path(self):
+        """Test valid upload path.
+
+        Resulting path should be a concatenation of the two paths anchored at the
+        base path.
+        """
+        base_path = "/tmp"
+        user_supplied_index_name = "a89933473b2a48948beee2c7e870209f"
+        expected_path = "/tmp/a89933473b2a48948beee2c7e870209f"
+        resulting_path = utils.format_upload_path(base_path, user_supplied_index_name)
+        self.assertEqual(resulting_path, expected_path)
+
+    def test_relative_base_upload_path(self):
+        """Test invalid base upload path."""
+        base_path = "tmp"
+        user_supplied_index_name = "a89933473b2a48948beee2c7e870209f"
+        with self.assertRaises(ValueError):
+            utils.format_upload_path(base_path, user_supplied_index_name)


### PR DESCRIPTION
This PR fixes a bug where the upload path could be invalid based on the API request.
* Validate index name passed in from the request
* Make sure upload path is relative to the configured UPLOAD_PATH parameter
* Add tests