### PR TITLE
🐛 Handle None response from ip2geo

### DIFF
--- a/timesketch/lib/analyzers/geoip.py
+++ b/timesketch/lib/analyzers/geoip.py
@@ -297,6 +297,9 @@ class BaseGeoIpAnalyzer(interface.BaseAnalyzer):
         for ip_address, ip_address_fields in ip_addresses.items():
             response = client.ip2geo(ip_address)
 
+            if not response:
+                continue
+
             try:
                 iso_code, latitude, longitude, country_name, city_name = response
             except ValueError:


### PR DESCRIPTION
We found the GeoIP analyser would never complete with our timelines as we were getting `None` responses from ip2geo. E.g.
```python
Traceback (most recent call last): File "/usr/local/lib/python3.10/dist-packages/timesketch/lib/analyzers/interface.py", line 1134, in run_wrapper result = self.run() File "/usr/local/lib/python3.10/dist-packages/timesketch/lib/analyzers/geoip.py", line 301, in run continue TypeError: cannot unpack non-iterable NoneType object
```

This fix continues the loop early if we haven't got a result

#### Before 😢
<img width="1627" alt="image" src="https://github.com/google/timesketch/assets/939704/99399e61-7d6d-4581-82f1-107f28e28dca">

#### After 🥳
<img width="1623" alt="image" src="https://github.com/google/timesketch/assets/939704/bfee7812-f1cd-45c2-8301-2d7c99174b52">

