### PR TITLE
Fixing #2393 - analysis of broken timelines

### DIFF
--- a/timesketch/api/v1/resources/analysis.py
+++ b/timesketch/api/v1/resources/analysis.py
@@ -283,6 +283,14 @@ class AnalyzerRunResource(resources.ResourceMixin, Resource):
             timeline = Timeline.query.get(timeline_id)
             if not timeline:
                 continue
+            if not timeline.status[0].status == "ready":
+                logger.warning(
+                    'Timeline "{0:d}" is in status "{1:s}". Analyzer cannot be '
+                    'run if the status is not "ready". Skipping timeline!'.format(
+                        timeline.id, timeline.status[0].status
+                    )
+                )
+                continue
             searchindex_id = timeline.searchindex.id
             searchindex_name = timeline.searchindex.index_name
 

--- a/timesketch/api/v1/resources/analysis.py
+++ b/timesketch/api/v1/resources/analysis.py
@@ -284,12 +284,6 @@ class AnalyzerRunResource(resources.ResourceMixin, Resource):
             if not timeline:
                 continue
             if not timeline.status[0].status == "ready":
-                logger.warning(
-                    'Timeline "{0:d}" is in status "{1:s}". Analyzer cannot be '
-                    'run if the status is not "ready". Skipping timeline!'.format(
-                        timeline.id, timeline.status[0].status
-                    )
-                )
                 continue
             searchindex_id = timeline.searchindex.id
             searchindex_name = timeline.searchindex.index_name


### PR DESCRIPTION
This PR adds a check if the timeline status is not "ready" and will skipp such timelines. This will prevent any analysis to be run on timelines that are not in the ready state and therefore going stale / looping for ever.

closes #2393