### PR TITLE
Add tzdata to all container builds

### DIFF
--- a/docker/dev/build/Dockerfile
+++ b/docker/dev/build/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-wheel \
     python3-setuptools \
     python3-psycopg2 \
+    tzdata \
   && rm -rf /var/lib/apt/lists/*
 
 # Install Plaso

--- a/docker/release/build/Dockerfile-latest
+++ b/docker/release/build/Dockerfile-latest
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-psycopg2 \
     gpg-agent \
     wget \
+    tzdata \
   && rm -rf /var/lib/apt/lists/*
 
 # Install Timesketch

--- a/docker/release/build/Dockerfile-release
+++ b/docker/release/build/Dockerfile-release
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-psycopg2 \
     gpg-agent \
     wget \
+    tzdata \
   && rm -rf /var/lib/apt/lists/*
 
 # Install Timesketch

--- a/docker/release/build/Dockerfile-release-ppa
+++ b/docker/release/build/Dockerfile-release-ppa
@@ -14,7 +14,7 @@ RUN apt-get -y update
 RUN apt-get -y upgrade
 
 # Install dependencies
-RUN apt-get -y install ca-certificates lsb-release locales python3-psycopg2
+RUN apt-get -y install ca-certificates lsb-release locales python3-psycopg2 tzdata
 
 # Install Plaso
 RUN apt-get -y install plaso-tools


### PR DESCRIPTION
Upstream Ubuntu changed and we need to explicitly add tzdata as a dependency for the container builds.
