### PR TITLE
Update the event tags UI 

### DIFF
--- a/timesketch/frontend-ng/src/components/Explore/EventTagMenu.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventTagMenu.vue
@@ -16,7 +16,8 @@ limitations under the License.
 <template>
   <v-menu v-model="showMenu" offset-x :close-on-content-click="false">
     <template v-slot:activator="{ on, attrs }">
-      <v-icon v-bind="attrs" v-on="on" class="ml-1">mdi-tag-plus-outline</v-icon>
+      <v-icon v-if="assignedTags.length > 0" v-bind="attrs" v-on="on" class="ml-1">mdi-tag-plus</v-icon>
+      <v-icon v-else v-bind="attrs" v-on="on" class="ml-1">mdi-tag-plus-outline</v-icon>
     </template>
 
     <v-card min-width="500px" class="mx-auto" max-width="500px" min-height="260px">

--- a/timesketch/frontend-ng/src/components/Explore/EventTags.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventTags.vue
@@ -13,20 +13,16 @@ limitations under the License.
 <template>
   <span>
     <span v-for="tag in sortedTags" :key="tag">
-      <v-hover v-slot="{ hover }">
-        <v-chip
-          :style="hover ? '' : 'padding-right: 32px'"
-          small
-          class="mr-1"
-          :close="hover ? true : false"
-          @click:close="removeTag(item, tag)"
-          :color="tagColor(tag).color"
-          :text-color="tagColor(tag).textColor"
-        >
-          <v-icon v-if="tag in tagConfig" left small>{{ tagConfig[tag].label }}</v-icon>
-          {{ tag }}
-        </v-chip>
-      </v-hover>
+      <v-chip
+        small
+        class="mr-1"
+        :close="hover ? true : false"
+        :color="tagColor(tag).color"
+        :text-color="tagColor(tag).textColor"
+      >
+        <v-icon v-if="tag in tagConfig" left small>{{ tagConfig[tag].label }}</v-icon>
+        {{ tag }}
+      </v-chip>
     </span>
     <span v-for="label in item._source.label" :key="label">
       <v-chip v-if="!label.startsWith('__ts')" small outlined class="mr-2">
@@ -37,7 +33,6 @@ limitations under the License.
 </template>
 
 <script>
-import ApiClient from '../../utils/RestApiClient'
 export default {
   props: ['item', 'tagConfig', 'showDetails'],
   computed: {
@@ -79,16 +74,6 @@ export default {
         return this.tagConfig[tag]
       }
       return 'lightgrey'
-    },
-    removeTag(item, tag) {
-      ApiClient.untagEvents(this.sketch.id, [item], [tag])
-        .then((response) => {
-          item._source.tag.splice(item._source.tag.indexOf(tag), 1)
-          this.$store.dispatch('updateTimelineTags', { sketchId: this.sketch.id, tag: tag, num: -1 })
-        })
-        .catch((e) => {
-          console.error(e)
-        })
     },
   },
 }


### PR DESCRIPTION
This PR will update the event list UI and remove the "remove tag from event" feature for tags that are in the event row. This is to save some space as indicated in #2804 .
Tags can still be removed using the Event Tag Menu triggered by clicking the tag-plus icon on the left. For better "I can do something here" feedback, this PR will also adjust the event tag menu icon to reflect if there are tags added to the event that can be edited or not.

Example:
![image](https://github.com/google/timesketch/assets/99879757/668fc70c-37d6-4b34-a36f-f9f6eb338322)

**Closing issues**
closes #2804 
