### PR TITLE
fixes #2809 UI bug

### DIFF
--- a/timesketch/frontend-ng/src/components/Explore/EventTags.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventTags.vue
@@ -16,7 +16,6 @@ limitations under the License.
       <v-chip
         small
         class="mr-1"
-        :close="hover ? true : false"
         :color="tagColor(tag).color"
         :text-color="tagColor(tag).textColor"
       >

--- a/timesketch/frontend-ng/src/components/LeftPanel/AnalyzerResultTimeline.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/AnalyzerResultTimeline.vue
@@ -125,7 +125,7 @@ limitations under the License.
               </td>
               <td style="border: none">
                 <span>
-                  {{ verboseAnalyzerOutput.result_summary }}
+                  {{ verboseAnalyzerOutput.result_summary ? verboseAnalyzerOutput.result_summary : 'loading...' }}
                 </span>
               </td>
             </tr>
@@ -135,7 +135,7 @@ limitations under the License.
               </td>
               <td style="border: none">
                 <span>
-                  {{ verboseAnalyzerOutput.result_priority }}
+                  {{ verboseAnalyzerOutput.result_priority ? verboseAnalyzerOutput.result_priority : 'loading...' }}
                 </span>
               </td>
             </tr>
@@ -170,7 +170,7 @@ limitations under the License.
               </td>
               <td style="border: none">
                 <span>
-                  {{ verboseAnalyzerOutput.result_status }}
+                  {{ verboseAnalyzerOutput.result_status ? verboseAnalyzerOutput.result_status : 'loading...' }}
                 </span>
               </td>
             </tr>
@@ -429,6 +429,6 @@ export default {
   background-color: #303030;
 }
 .light-bg {
-  background-color: #F6F6F6;
+  background-color: #f6f6f6;
 }
 </style>


### PR DESCRIPTION
This PR fixes the bug described in #2809 where the analyzer result list UI will throw an error if verbose analyzer results are loaded.
This fix will add checks for the usage of the computed variable and only show the results when they have finished loading.

**Closing issues**
closes #2809 
