### PR TITLE
Consitent forms and cleaned up XML viewer

### DIFF
--- a/timesketch/frontend-ng/src/components/Explore/AddManualEvent.vue
+++ b/timesketch/frontend-ng/src/components/Explore/AddManualEvent.vue
@@ -18,7 +18,7 @@ limitations under the License.
     <v-container class="px-8">
       <br />
       <v-row>
-        <v-col cols="6">
+        <v-col cols="12">
           <v-text-field
             :value="datetime"
             label="Datetime"
@@ -47,13 +47,13 @@ limitations under the License.
       </v-row>
 
       <v-row>
-        <v-col cols="6">
+        <v-col cols="12">
           <v-text-field :value="message" v-model="message" label="Message" outlined hide-details> </v-text-field>
         </v-col>
       </v-row>
 
       <v-row>
-        <v-col cols="6">
+        <v-col cols="12">
           <v-text-field
             :value="timestampDesc"
             label="Timestamp Description"
@@ -75,12 +75,13 @@ limitations under the License.
       </v-row>
 
       <v-card-actions>
-        <v-spacer></v-spacer>
         <v-btn text color="primary" @click="attributes.push({ name: '', value: '' })" :disabled="isDisabled">
+          <v-icon>mdi-plus</v-icon>
           Add Attribute
         </v-btn>
-        <v-btn text color="primary" @click="clearAndCancel"> Cancel </v-btn>
-        <v-btn text color="primary" @click="submit"> Add Event </v-btn>
+        <v-spacer></v-spacer>
+        <v-btn text @click="clearAndCancel()"> Cancel </v-btn>
+        <v-btn text color="primary" @click="submit"> Save </v-btn>
       </v-card-actions>
     </v-container>
   </v-card>

--- a/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
@@ -21,13 +21,17 @@ limitations under the License.
           <v-simple-table dense>
             <template v-slot:default>
               <tbody>
-                <tr v-for="(value, key) in fullEventFiltered" :key="key" @mouseover="c_key = key" @mouseleave="c_key = -1">
+                <tr
+                  v-for="(value, key) in fullEventFiltered"
+                  :key="key"
+                  @mouseover="c_key = key"
+                  @mouseleave="c_key = -1"
+                >
                   <!-- Event field name actions -->
                   <td v-if="key == c_key" class="text-right">
-
                     <!-- Copy field name -->
                     <v-btn
-                      v-if="(key == c_key) && key != '' && !ignoredAggregatorFields.has(key)"
+                      v-if="key == c_key && key != '' && !ignoredAggregatorFields.has(key)"
                       @click.stop="loadAggregation(key, value)"
                       icon
                       x-small
@@ -35,13 +39,7 @@ limitations under the License.
                     >
                       <v-icon>mdi-chart-bar</v-icon>
                     </v-btn>
-                    <v-btn
-                      icon
-                      x-small
-                      style="cursor: pointer"
-                      @click="copyToClipboard(key)"
-                      class="pr-1"
-                    >
+                    <v-btn icon x-small style="cursor: pointer" @click="copyToClipboard(key)" class="pr-1">
                       <v-icon small>mdi-content-copy</v-icon>
                     </v-btn>
                   </td>
@@ -56,21 +54,17 @@ limitations under the License.
                   </td>
 
                   <!-- Event field value action icons -->
-                  <td v-if="key.includes('xml') || checkContextLinkDisplay(key, value) || (key == c_key)" class="text-right pr-1">
-
+                  <td
+                    v-if="key.includes('xml') || checkContextLinkDisplay(key, value) || key == c_key"
+                    class="text-right pr-1"
+                  >
                     <!-- Copy event value -->
-                    <v-btn
-                      icon
-                      x-small
-                      style="cursor: pointer"
-                      @click="copyToClipboard(value)"
-                      v-show="key == c_key"
-                    >
+                    <v-btn icon x-small style="cursor: pointer" @click="copyToClipboard(value)" v-show="key == c_key">
                       <v-icon small>mdi-content-copy</v-icon>
                     </v-btn>
 
                     <!-- XML prettify dialog -->
-                    <v-dialog v-if="key.includes('xml')" v-model="formatXMLString" width="1000">
+                    <v-dialog v-if="key.includes('xml')" v-model="formatXMLString">
                       <template v-slot:activator="{ on, attrs }">
                         <v-btn
                           icon
@@ -81,43 +75,24 @@ limitations under the License.
                           v-on="on"
                           @click="formatXMLString = true"
                         >
-                          <v-tooltip top close-delay=300 :open-on-click="false">
+                          <v-tooltip top close-delay="300" :open-on-click="false">
                             <template v-slot:activator="{ on }">
-                              <v-icon v-on="on" small>
-                                mdi-xml
-                              </v-icon>
+                              <v-icon v-on="on" small> mdi-xml </v-icon>
                             </template>
                             <span>Prettify XML</span>
                           </v-tooltip>
                         </v-btn>
                       </template>
-                      <ts-format-xml-string
-                        app
-                        @cancel="formatXMLString = false"
-                        :xmlString="value"
-                      ></ts-format-xml-string>
+                      <ts-format-xml-string @close="formatXMLString = false" :xmlString="value"></ts-format-xml-string>
                     </v-dialog>
 
                     <!-- Context link submenu -->
-                    <v-menu
-                      v-if="checkContextLinkDisplay(key, value)"
-                      offset-y
-                      transition="slide-y-transition"
-                    >
+                    <v-menu v-if="checkContextLinkDisplay(key, value)" offset-y transition="slide-y-transition">
                       <template v-slot:activator="{ on, attrs }">
-                        <v-btn
-                          icon
-                          color="primary"
-                          x-small
-                          style="cursor: pointer"
-                          v-bind="attrs"
-                          v-on="on"
-                        >
-                          <v-tooltip top close-delay=300 :open-on-click="false">
+                        <v-btn icon color="primary" x-small style="cursor: pointer" v-bind="attrs" v-on="on">
+                          <v-tooltip top close-delay="300" :open-on-click="false">
                             <template v-slot:activator="{ on }">
-                              <v-icon v-on="on" small>
-                                mdi-open-in-new
-                              </v-icon>
+                              <v-icon v-on="on" small> mdi-open-in-new </v-icon>
                             </template>
                             <span>Context Lookup</span>
                           </v-tooltip>
@@ -128,15 +103,13 @@ limitations under the License.
                           v-for="(item, index) in getContextLinkItems(key)"
                           :key="index"
                           style="cursor: pointer"
-                          @click.stop="contextLinkRedirect(key,item,value)"
+                          @click.stop="contextLinkRedirect(key, item, value)"
                         >
-                          <v-list-item-title v-if="getContextLinkRedirectState(key,item)" >{{ item }}</v-list-item-title>
-                          <v-list-item-title v-else >{{ item }}*</v-list-item-title>
-                          <v-dialog
-                            v-model="redirectWarnDialog"
-                            max-width="515"
-                            :retain-focus="false"
-                          >
+                          <v-list-item-title v-if="getContextLinkRedirectState(key, item)">{{
+                            item
+                          }}</v-list-item-title>
+                          <v-list-item-title v-else>{{ item }}*</v-list-item-title>
+                          <v-dialog v-model="redirectWarnDialog" max-width="515" :retain-focus="false">
                             <ts-link-redirect-warning
                               app
                               @cancel="redirectWarnDialog = false"
@@ -147,7 +120,6 @@ limitations under the License.
                         </v-list-item>
                       </v-list>
                     </v-menu>
-
                   </td>
                   <td v-else>
                     <div class="px-5"></div>
@@ -237,18 +209,15 @@ limitations under the License.
         </v-card>
       </v-col>
     </v-row>
-    <v-dialog
-      scrollable
-      v-model="aggregatorDialog"
-      @click:outside="$event => this.aggregatorDialog = false"
-    >
+    <v-dialog scrollable v-model="aggregatorDialog" @click:outside="($event) => (this.aggregatorDialog = false)">
       <ts-aggregate-dialog
         :eventKey="eventKey"
         :eventValue="eventValue"
         :eventTimestamp="eventTimestamp"
         :eventTimestampDesc="eventTimestampDesc"
         :reloadData="aggregatorDialog"
-        @cancel=" aggregatorDialog = false">
+        @cancel="aggregatorDialog = false"
+      >
       </ts-aggregate-dialog>
     </v-dialog>
     <br />
@@ -276,17 +245,15 @@ export default {
       comments: [],
       selectedComment: null,
       aggregatorDialog: false,
-      ignoredAggregatorFields: new Set(
-          [
-              'datetime',
-              'message',
-              'path_spec',
-              'strings',
-              'timestamp',
-              'timestamp_desc',
-              'xml_string'
-          ]
-      ),
+      ignoredAggregatorFields: new Set([
+        'datetime',
+        'message',
+        'path_spec',
+        'strings',
+        'timestamp',
+        'timestamp_desc',
+        'xml_string',
+      ]),
       eventKey: '',
       eventValue: '',
       eventTimestamp: 0,
@@ -381,7 +348,7 @@ export default {
     },
     getContextLinkItems(key) {
       let fieldConfList = this.contextLinkConf[key.toLowerCase()] ? this.contextLinkConf[key.toLowerCase()] : []
-      let shortNameList = fieldConfList.map(x => x.short_name)
+      let shortNameList = fieldConfList.map((x) => x.short_name)
       return shortNameList
     },
     checkContextLinkDisplay(key, value) {
@@ -389,17 +356,18 @@ export default {
       for (const confItem of fieldConfList) {
         if (confItem['validation_regex'] !== '' && confItem['validation_regex'] !== undefined) {
           let validationPattern = confItem['validation_regex']
-          let regexIdentifiers = validationPattern.slice(validationPattern.lastIndexOf('/')+1)
-          let regexPattern = validationPattern.slice(validationPattern.indexOf('/')+1, validationPattern.lastIndexOf('/'))
+          let regexIdentifiers = validationPattern.slice(validationPattern.lastIndexOf('/') + 1)
+          let regexPattern = validationPattern.slice(
+            validationPattern.indexOf('/') + 1,
+            validationPattern.lastIndexOf('/')
+          )
           let valueRegex = new RegExp(regexPattern, regexIdentifiers)
           if (valueRegex.test(value)) {
             return true
-          }
-          else {
+          } else {
             return false
           }
-        }
-        else {
+        } else {
           return true
         }
       }
@@ -413,8 +381,7 @@ export default {
             this.redirectWarnDialog = true
             this.contextValue = value
             this.contextUrl = confItem['context_link'].replace('<ATTR_VALUE>', encodeURIComponent(value))
-          }
-          else {
+          } else {
             // TODO verify if encodeURIComponent is sufficient sanitization here?
             window.open(confItem['context_link'].replace('<ATTR_VALUE>', encodeURIComponent(value)), '_blank')
             this.redirectWarnDialog = false
@@ -422,7 +389,7 @@ export default {
         }
       }
     },
-    getContextLinkRedirectState (key, item) {
+    getContextLinkRedirectState(key, item) {
       const fieldConfList = this.contextLinkConf[key.toLowerCase()] ? this.contextLinkConf[key.toLowerCase()] : []
       for (const confItem of fieldConfList) {
         if (confItem['short_name'] === item) {
@@ -435,7 +402,7 @@ export default {
       this.eventValue = eventValue
       this.aggregatorDialog = true
     },
-    copyToClipboard (content) {
+    copyToClipboard(content) {
       try {
         navigator.clipboard.writeText(content)
         this.infoSnackBar('copied')

--- a/timesketch/frontend-ng/src/components/Explore/EventList.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventList.vue
@@ -72,7 +72,7 @@ limitations under the License.
                   <v-card-actions>
                     <v-spacer></v-spacer>
                     <v-btn text @click="saveSearchMenu = false"> Cancel </v-btn>
-                    <v-btn color="primary" depressed @click="saveSearch" :disabled="!saveSearchFormName"> Save </v-btn>
+                    <v-btn text color="primary" @click="saveSearch" :disabled="!saveSearchFormName"> Save </v-btn>
                   </v-card-actions>
                 </v-card>
               </v-dialog>
@@ -119,10 +119,8 @@ limitations under the License.
 
                   <v-card-actions>
                     <v-spacer></v-spacer>
-                    <v-btn color="primary" text @click="selectedFields = [{ field: 'message', type: 'text' }]">
-                      Reset
-                    </v-btn>
-                    <v-btn color="primary" text @click="columnDialog = false"> Close </v-btn>
+                    <v-btn text @click="selectedFields = [{ field: 'message', type: 'text' }]"> Reset </v-btn>
+                    <v-btn text color="primary" @click="columnDialog = false"> Set columns </v-btn>
                   </v-card-actions>
                 </v-card>
               </v-dialog>
@@ -315,7 +313,13 @@ limitations under the License.
               }"
             >
               <!-- Tags -->
-              <span v-if="displayOptions.showTags && index === 3 && ('tag' in item._source ? (item._source.tag.length > 0) : false )">
+              <span
+                v-if="
+                  displayOptions.showTags &&
+                  index === 3 &&
+                  ('tag' in item._source ? item._source.tag.length > 0 : false)
+                "
+              >
                 <ts-event-tags :item="item" :tagConfig="tagConfig" :showDetails="item.showDetails"></ts-event-tags>
               </span>
               <!-- Emojis -->
@@ -391,7 +395,7 @@ export default {
     TsEventDetail,
     TsEventTagMenu,
     TsEventActionMenu,
-    TsEventTags
+    TsEventTags,
   },
   props: {
     queryRequest: {

--- a/timesketch/frontend-ng/src/components/Explore/FilterMenu.vue
+++ b/timesketch/frontend-ng/src/components/Explore/FilterMenu.vue
@@ -72,7 +72,7 @@ limitations under the License.
 
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn text color="primary" @click="clearAndCancel"> Cancel </v-btn>
+        <v-btn text @click="clearAndCancel"> Cancel </v-btn>
         <v-btn text color="primary" @click="submit()"> Add filter </v-btn>
       </v-card-actions>
     </v-container>

--- a/timesketch/frontend-ng/src/components/Explore/FormatXMLString.vue
+++ b/timesketch/frontend-ng/src/components/Explore/FormatXMLString.vue
@@ -14,17 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <template>
-  <v-card width="1000" style="overflow: initial">
-    <v-container class="px-8">
-      <v-alert border="top" colored-border type="info" elevation="2"> XML viewer </v-alert>
-      <v-alert colored-border :color="'success'" border="left" elevation="1">
-        <pre lang="xml">{{ xmlString }}</pre>
-      </v-alert>
-      <v-card-actions>
-        <v-spacer></v-spacer>
-        <v-btn text color="primary" @click="clearAndCancel"> Close </v-btn>
-      </v-card-actions>
-    </v-container>
+  <v-card>
+    <div class="pa-8">
+      <pre lang="xml" style="font-size: 0.9em">{{ xmlString }}</pre>
+    </div>
+    <v-divider></v-divider>
+    <v-card-actions>
+      <v-spacer></v-spacer>
+      <v-btn text color="primary" @click="close()"> Close </v-btn>
+    </v-card-actions>
   </v-card>
 </template>
 
@@ -32,8 +30,8 @@ limitations under the License.
 export default {
   props: ['xmlString'],
   methods: {
-    clearAndCancel: function () {
-      this.$emit('cancel')
+    close: function () {
+      this.$emit('close')
     },
   },
 }

--- a/timesketch/frontend-ng/src/components/Explore/TimelineChip.vue
+++ b/timesketch/frontend-ng/src/components/Explore/TimelineChip.vue
@@ -115,7 +115,7 @@ limitations under the License.
             <v-icon v-if="timelineFailed" @click="dialogStatus = true" left color="red" size="x-large">
               mdi-alert-circle-outline
             </v-icon>
-            <v-icon v-if="!timelineFailed" left :color="timelineChipColor" size="x-large"> mdi-circle </v-icon>
+            <v-icon v-if="!timelineFailed" left :color="timelineChipColor" size="26" class="ml-n2"> mdi-circle </v-icon>
 
             <v-tooltip bottom :disabled="timeline.name.length < 30" open-delay="300">
               <template v-slot:activator="{ on: onTooltip, attrs }">

--- a/timesketch/frontend-ng/src/components/Explore/TimelineChip.vue
+++ b/timesketch/frontend-ng/src/components/Explore/TimelineChip.vue
@@ -108,46 +108,39 @@ limitations under the License.
           @click="toggleTimeline()"
           :style="getTimelineStyle(timeline)"
           class="mr-2 mb-3 pr-1 timeline-chip"
-          :class="{failed: timelineFailed}"
+          :class="{ failed: timelineFailed }"
           :ripple="!timelineFailed"
         >
           <div class="chip-content">
-
-            <v-icon v-if="timelineFailed" @click="dialogStatus = true" left color="red" size="x-large"> mdi-alert-circle-outline </v-icon>
-            <v-icon v-if="!timelineFailed" left :color="timelineChipColor" size="xx-large" class="ml-n3"> mdi-circle </v-icon>
+            <v-icon v-if="timelineFailed" @click="dialogStatus = true" left color="red" size="x-large">
+              mdi-alert-circle-outline
+            </v-icon>
+            <v-icon v-if="!timelineFailed" left :color="timelineChipColor" size="xx-large" class="ml-n3">
+              mdi-circle
+            </v-icon>
 
             <v-tooltip bottom :disabled="timeline.name.length < 30" open-delay="300">
               <template v-slot:activator="{ on: onTooltip, attrs }">
-                <span class="timeline-name-ellipsis" :class="{ disabled: !isSelected && timelineStatus === 'ready'}"
-                v-bind="attrs"
-                v-on="onTooltip"
-                >{{ timeline.name }}</span>
+                <span
+                  class="timeline-name-ellipsis"
+                  :class="{ disabled: !isSelected && timelineStatus === 'ready' }"
+                  v-bind="attrs"
+                  v-on="onTooltip"
+                  >{{ timeline.name }}</span
+                >
               </template>
               <span>{{ timeline.name }}</span>
             </v-tooltip>
 
             <span class="right">
-              <span
-                v-if="timelineStatus === 'processing'"
-                class="ml-3"
-              >
+              <span v-if="timelineStatus === 'processing'" class="ml-3">
                 <v-progress-circular small indeterminate color="grey" :size="20" :width="2"></v-progress-circular>
               </span>
 
-              <v-chip
-                v-if="!timelineFailed"
-                class="events-count"
-                :color="$vuetify.theme.dark ? 'grey' : '#fff'"
-                small
-              >
+              <v-chip v-if="!timelineFailed" class="events-count" :color="$vuetify.theme.dark ? 'grey' : '#fff'" small>
                 {{ eventsCount | compactNumber }}
               </v-chip>
-              <v-btn
-                class="ma-1"
-                small
-                icon
-                v-on="on"
-              >
+              <v-btn class="ma-1" small icon v-on="on">
                 <v-icon> mdi-dots-vertical </v-icon>
               </v-btn>
             </span>
@@ -166,25 +159,34 @@ limitations under the License.
               </v-list-item>
             </template>
             <v-card class="pa-4">
-              <h3>Rename timeline</h3>
-              <br />
-              <v-text-field outlined dense autofocus v-model="newTimelineName" @focus="$event.target.select()">
-              </v-text-field>
-              <v-card-actions>
-                <v-spacer></v-spacer>
-                <v-btn color="primary" text @click="dialogRename = false"> Close </v-btn>
-                <v-btn color="primary" depressed @click="rename"> Save </v-btn>
-              </v-card-actions>
+              <v-form @submit.prevent="rename()">
+                <h3>Rename timeline</h3>
+                <br />
+                <v-text-field outlined dense autofocus v-model="newTimelineName" @focus="$event.target.select()">
+                </v-text-field>
+                <v-card-actions>
+                  <v-spacer></v-spacer>
+                  <v-btn text @click="dialogRename = false"> Cancel </v-btn>
+                  <v-btn color="primary" text @click="rename()"> Save </v-btn>
+                </v-card-actions>
+              </v-form>
             </v-card>
           </v-dialog>
 
-          <v-list-item @click="$emit('toggle', timeline)" v-if="timelineStatus === 'ready'">
+          <v-list-item v-if="timelineStatus === 'ready'" @click="$emit('toggle', timeline)">
             <v-list-item-action>
               <v-icon v-if="isSelected">mdi-eye-off</v-icon>
               <v-icon v-else>mdi-eye</v-icon>
             </v-list-item-action>
             <v-list-item-subtitle v-if="isSelected">Temporarily disabled</v-list-item-subtitle>
             <v-list-item-subtitle v-else>Re-enable</v-list-item-subtitle>
+          </v-list-item>
+
+          <v-list-item v-if="timelineStatus === 'ready'" @click="$emit('disableAllOtherTimelines', timeline)">
+            <v-list-item-action>
+              <v-icon>mdi-checkbox-marked-circle-minus-outline</v-icon>
+            </v-list-item-action>
+            <v-list-item-subtitle>Unselect other timelines</v-list-item-subtitle>
           </v-list-item>
 
           <v-dialog v-model="dialogStatus" width="600">
@@ -197,9 +199,9 @@ limitations under the License.
               </v-list-item>
             </template>
             <v-card>
-              <v-app-bar flat dense>{{ timeline.name }}</v-app-bar>
-              <div class="pa-3">
+              <div class="pa-4">
                 <ul style="list-style-type: none">
+                  <li><strong>Timeline name: </strong>{{ timeline.name }}</li>
                   <li><strong>Opensearch index: </strong>{{ timeline.searchindex.index_name }}</li>
                   <li v-if="timelineStatus === 'processing' || timelineStatus === 'ready'">
                     <strong>Number of events: </strong>
@@ -210,17 +212,15 @@ limitations under the License.
                     <strong>Created at: </strong>{{ timeline.created_at | shortDateTime }}
                     <small>({{ timeline.created_at | timeSince }})</small>
                   </li>
+                  <li><strong>Number of datasources: </strong>{{ datasources.length }}</li>
                 </ul>
 
-                <br />
-                {{ datasources.length }} data source(s) in this timeline <br /><br />
                 <v-alert
                   v-for="datasource in datasources"
                   :key="datasource.id"
-                  colored-border
-                  border="left"
-                  elevation="1"
-                  :color="datasourceStatusColors(datasource)"
+                  outlined
+                  :type="datasourceStatusColors(datasource)"
+                  class="ma-5"
                 >
                   <ul style="list-style-type: none">
                     <li><strong>Original filename:</strong> {{ datasource.original_filename }}</li>
@@ -240,7 +240,6 @@ limitations under the License.
                       <code v-if="datasource.error_message"> {{ datasource.error_message }}</code>
                     </li>
                   </ul>
-                  <br />
                 </v-alert>
               </div>
               <v-card-actions>
@@ -406,14 +405,14 @@ export default {
       return 'mdi-alert-circle-outline'
     },
     timelineFailed() {
-      return this.timelineStatus === 'fail';
+      return this.timelineStatus === 'fail'
     },
     timelineChipColor() {
       if (!this.timeline.color.startsWith('#')) {
         return '#' + this.timeline.color
       }
       return this.timeline.color
-    }
+    },
   },
   methods: {
     rename() {
@@ -455,9 +454,9 @@ export default {
       this.$emit('save', this.timeline)
     }, 300),
     getTimelineStyle(timeline) {
-      const greyOut = (this.timelineStatus === 'ready' && !this.isSelected)
+      const greyOut = this.timelineStatus === 'ready' && !this.isSelected
       return {
-        opacity: greyOut ? '50%':'100%',
+        opacity: greyOut ? '50%' : '100%',
       }
     },
     fetchData() {
@@ -570,10 +569,8 @@ export default {
 
 <!-- CSS scoped to this component only -->
 <style scoped lang="scss">
-
 .timeline-chip {
-
-  .right{
+  .right {
     margin-left: auto;
   }
 

--- a/timesketch/frontend-ng/src/components/Explore/TimelineChip.vue
+++ b/timesketch/frontend-ng/src/components/Explore/TimelineChip.vue
@@ -187,7 +187,7 @@ limitations under the License.
             <v-list-item-subtitle>Unselect other timelines</v-list-item-subtitle>
           </v-list-item>
 
-          <v-dialog v-model="dialogStatus" width="600">
+          <v-dialog v-model="dialogStatus" width="800">
             <template v-slot:activator="{ on, attrs }">
               <v-list-item v-bind="attrs" v-on="on">
                 <v-list-item-action>
@@ -217,7 +217,8 @@ limitations under the License.
                   v-for="datasource in datasources"
                   :key="datasource.id"
                   outlined
-                  :type="datasourceStatusColors(datasource)"
+                  text
+                  :color="datasourceStatusColors(datasource)"
                   class="ma-5"
                 >
                   <ul style="list-style-type: none">
@@ -230,7 +231,7 @@ limitations under the License.
                     <li v-if="datasource.data_label"><strong>Data label:</strong> {{ datasource.data_label }}</li>
                     <li><strong>Status:</strong> {{ dataSourceStatus(datasource) }}</li>
                     <li>
-                      <strong>Total File Events:</strong
+                      <strong>Total File Events: </strong
                       >{{ totalEventsDatasource(datasource.file_on_disk) | compactNumber }}
                     </li>
                     <li v-if="dataSourceStatus(datasource) === 'fail'">
@@ -240,6 +241,7 @@ limitations under the License.
                   </ul>
                 </v-alert>
               </div>
+              <v-divider></v-divider>
               <v-card-actions>
                 <v-spacer></v-spacer>
                 <v-btn color="primary" text @click="dialogStatus = false"> Close </v-btn>

--- a/timesketch/frontend-ng/src/components/Explore/TimelinePicker.vue
+++ b/timesketch/frontend-ng/src/components/Explore/TimelinePicker.vue
@@ -25,10 +25,11 @@ limitations under the License.
       @remove="remove"
       @save="save"
       @toggle="toggleTimeline"
+      @disableAllOtherTimelines="disableAllOtherTimelines"
     ></ts-timeline-chip>
     <v-btn
       small
-      outlined
+      text
       rounded
       color="primary"
       v-if="sketch.timelines.length > 20"
@@ -38,15 +39,16 @@ limitations under the License.
       <span v-if="showAll"> show less </span>
       <span v-else> {{ sketch.timelines.length - 20 }} more.. </span>
     </v-btn>
-    <span v-if="sketch.timelines.length > 5" style="position: relative; top: -5px">
-      <v-btn-toggle dense rounded>
-        <v-btn small outlined rounded color="primary" v-if="sketch.timelines.length > 5" @click="enableAllTimelines()">
-          Select all
-        </v-btn>
-        <v-btn small outlined rounded color="primary" v-if="sketch.timelines.length > 5" @click="disableAllTimelines()">
-          Unselect all
-        </v-btn>
-      </v-btn-toggle>
+    <br />
+    <span v-if="sketch.timelines.length > 5">
+      <v-btn small text rounded color="primary" @click="enableAllTimelines()">
+        <v-icon left small>mdi-checkbox-outline</v-icon>
+        <span>Select all</span>
+      </v-btn>
+      <v-btn small text rounded color="primary" @click="disableAllTimelines()">
+        <v-icon left small>mdi-minus-box-outline</v-icon>
+        <span>Unselect all</span>
+      </v-btn>
     </span>
   </span>
 </template>
@@ -154,6 +156,10 @@ export default {
     },
     disableAllTimelines() {
       this.selectedTimelines = []
+      this.$emit('updateSelectedTimelines', this.selectedTimelines)
+    },
+    disableAllOtherTimelines(timeline) {
+      this.selectedTimelines = [timeline]
       this.$emit('updateSelectedTimelines', this.selectedTimelines)
     },
     toggleTimeline(timeline) {

--- a/timesketch/frontend-ng/src/components/RenameSketch.vue
+++ b/timesketch/frontend-ng/src/components/RenameSketch.vue
@@ -17,12 +17,14 @@ limitations under the License.
   <div>
     <h3>Rename sketch</h3>
     <br />
-    <v-text-field outlined dense autofocus v-model="newSketchName" @focus="$event.target.select()"> </v-text-field>
-    <v-card-actions>
-      <v-spacer></v-spacer>
-      <v-btn color="primary" text @click="closeDialog()"> Cancel </v-btn>
-      <v-btn color="primary" depressed @click="renameSketch()"> Save </v-btn>
-    </v-card-actions>
+    <v-form @submit.prevent="renameSketch()">
+      <v-text-field outlined dense autofocus v-model="newSketchName" @focus="$event.target.select()"> </v-text-field>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn text @click="closeDialog()"> Cancel </v-btn>
+        <v-btn text color="primary" @click="renameSketch()"> Save </v-btn>
+      </v-card-actions>
+    </v-form>
   </div>
 </template>
 

--- a/timesketch/frontend-ng/src/components/Scenarios/Scenario.vue
+++ b/timesketch/frontend-ng/src/components/Scenarios/Scenario.vue
@@ -30,17 +30,17 @@ limitations under the License.
       <v-col cols="1">
         <!-- Rename dialog -->
         <v-dialog v-model="renameDialog" max-width="500">
-          <v-card>
-            <v-card-title class="text-h5"> Rename scenario </v-card-title>
-            <v-card-text>
-              Use a custom name for the scenario.
-              <v-text-field v-model="newName"></v-text-field>
-            </v-card-text>
-            <v-card-actions>
-              <v-spacer></v-spacer>
-              <v-btn color="primary" text @click="renameDialog = false"> Cancel </v-btn>
-              <v-btn color="primary" text @click="renameScenario()"> Save </v-btn>
-            </v-card-actions>
+          <v-card class="pa-4">
+            <v-form @submit.prevent="renameScenario()">
+              <h3>Rename scenario</h3>
+              <br />
+              <v-text-field outlined dense autofocus v-model="newName" @focus="$event.target.select()"></v-text-field>
+              <v-card-actions>
+                <v-spacer></v-spacer>
+                <v-btn text @click="renameDialog = false"> Cancel </v-btn>
+                <v-btn color="primary" text @click="renameScenario()"> Save </v-btn>
+              </v-card-actions>
+            </v-form>
           </v-card>
         </v-dialog>
         <v-menu offset-y :close-on-content-click="true">

--- a/timesketch/frontend-ng/src/components/SketchList.vue
+++ b/timesketch/frontend-ng/src/components/SketchList.vue
@@ -16,22 +16,25 @@ limitations under the License.
 <template>
   <div>
     <v-row no-gutters class="mt-5">
-      <v-text-field
-        outlined
-        flat
-        dense
-        hide-details
-        single-line
-        label="Search"
-        prepend-inner-icon="mdi-magnify"
-        @change="search"
-      ></v-text-field>
-      <v-spacer></v-spacer>
-      <v-btn-toggle dense group v-model="toggleStateButton">
-        <v-btn @click="switchScope('recent')"> Recent </v-btn>
-        <v-btn @click="switchScope('user')"> My sketches </v-btn>
-        <v-btn @click="switchScope('shared')"> Shared with me </v-btn>
-      </v-btn-toggle>
+      <v-col cols="9">
+        <v-btn-toggle dense group v-model="toggleStateButton">
+          <v-btn style="border-radius: 6px" @click="switchScope('recent')"> Recent </v-btn>
+          <v-btn style="border-radius: 6px" @click="switchScope('user')"> My sketches </v-btn>
+          <v-btn style="border-radius: 6px" @click="switchScope('shared')"> Shared with me </v-btn>
+        </v-btn-toggle>
+      </v-col>
+      <v-col cols="3">
+        <v-text-field
+          outlined
+          flat
+          dense
+          hide-details
+          single-line
+          label="Search"
+          prepend-inner-icon="mdi-magnify"
+          @change="search"
+        ></v-text-field>
+      </v-col>
     </v-row>
 
     <br />

--- a/timesketch/frontend-ng/src/components/ThreatIntel/IndicatorDialog.vue
+++ b/timesketch/frontend-ng/src/components/ThreatIntel/IndicatorDialog.vue
@@ -34,7 +34,7 @@ limitations under the License.
       <v-card-actions>
         <v-spacer></v-spacer>
         <v-btn text @click="closeDialog()"> Cancel </v-btn>
-        <v-btn color="primary" depressed :disabled="!newIndicator.ioc" @click="saveIndicator"> Save </v-btn>
+        <v-btn text color="primary" :disabled="!newIndicator.ioc" @click="saveIndicator"> Save </v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>

--- a/timesketch/frontend-ng/src/components/UploadForm.vue
+++ b/timesketch/frontend-ng/src/components/UploadForm.vue
@@ -38,8 +38,9 @@ limitations under the License.
         </v-btn>
       </template>
       <v-card>
-        <v-container class="px-8">
-          <v-card-title class="text-h5"> {{ title }} </v-card-title>
+        <v-container class="pa-4">
+          <h3>{{ title }}</h3>
+          <br />
 
           <div v-if="error.length > 0">
             <v-alert outlined type="error" v-for="(errorMessage, index) in error" :key="index">
@@ -129,7 +130,7 @@ limitations under the License.
 
           <div v-else>
             <v-file-input
-              label="Plaso/CSV/JSONL file"
+              label="Select file (Plaso/JSONL/CSV)"
               outlined
               dense
               clearable
@@ -145,17 +146,8 @@ limitations under the License.
         </v-container>
         <v-card-actions>
           <v-spacer></v-spacer>
-          <v-btn
-            color="primary"
-            text
-            @click="
-              clearFormData()
-              dialog = false
-            "
-          >
-            Cancel
-          </v-btn>
-          <v-btn v-if="fileName" color="primary" text @click="clearFormData()"> Select another file </v-btn>
+          <v-btn text @click="dialog = false"> Cancel </v-btn>
+          <v-btn v-if="fileName" text @click="clearFormData()"> Select another file </v-btn>
           <v-btn color="primary" text @click="submitForm()" v-if="!(error.length > 0 || !fileName)"> Submit </v-btn>
         </v-card-actions>
       </v-card>
@@ -171,7 +163,7 @@ export default {
     return {
       headersString: '', // headers string not formatted (used when changing CSV separator)
       valuesString: [],
-      title: 'Upload your Plaso/CSV/JSONL file',
+      title: 'Upload Plaso/JSONL/CSV file',
       /**
        *  headersMapping: list of object containing the:
        * (i) target header to be modified [key=target],
@@ -426,7 +418,7 @@ export default {
       this.headersString = ''
       this.valuesString = []
       this.uploadedFiles = []
-      this.title = 'Upload your Plaso/JSONL/CSV file'
+      this.title = 'Upload Plaso/JSONL/CSV file'
       this.error = []
       this.percentCompleted = 0
 
@@ -490,7 +482,7 @@ export default {
         }
       }
       if (this.error.length === 0) {
-        this.title = 'Submit your file to Timesketch'
+        this.title = 'Select file to upload'
       } else {
         this.title = 'Almost there... Map the ' + this.missingHeaders.length + ' missing headers.'
       }

--- a/timesketch/frontend-ng/src/views/Explore.vue
+++ b/timesketch/frontend-ng/src/views/Explore.vue
@@ -128,11 +128,11 @@ limitations under the License.
           :count-per-timeline="countPerTimeline"
         ></ts-timeline-picker>
 
-        <span style="position: relative; top: -5px">
+        <span style="position: relative">
           <ts-upload-timeline-form btn-type="small"></ts-upload-timeline-form>
         </span>
 
-        <span style="position: relative; top: -5px">
+        <span style="position: relative">
           <v-dialog v-model="addManualEvent" width="600">
             <template v-slot:activator="{ on, attrs }">
               <v-btn small text rounded color="primary" v-bind="attrs" v-on="on">
@@ -220,7 +220,7 @@ limitations under the License.
           >
             <template v-slot:activator="{ on, attrs }">
               <v-btn small text rounded color="primary" v-bind="attrs" v-on="on">
-                <v-icon left small> mdi-plus </v-icon>
+                <v-icon left small> mdi-clock-plus-outline </v-icon>
                 Add timefilter
               </v-btn>
             </template>

--- a/timesketch/frontend-ng/src/views/Home.vue
+++ b/timesketch/frontend-ng/src/views/Home.vue
@@ -70,19 +70,22 @@ limitations under the License.
       <v-sheet class="pa-5" :color="$vuetify.theme.dark ? 'grey darken-4' : 'grey lighten-3'" min-height="200">
         <h2>Start new investigation</h2>
         <v-row no-gutters class="mt-5">
-          <v-dialog width="500">
+          <v-dialog v-model="createSketchDialog" width="500">
             <template v-slot:activator="{ on, attrs }">
               <v-btn depressed small class="mr-5" color="primary" v-bind="attrs" v-on="on"> Blank sketch </v-btn>
             </template>
             <v-card class="pa-4">
               <h3>New sketch</h3>
               <br />
-              <v-text-field v-model="sketchForm.name" outlined dense placeholder="Name your sketch" autofocus>
-              </v-text-field>
-              <v-card-actions>
-                <v-spacer></v-spacer>
-                <v-btn :disabled="!sketchForm.name" @click="createSketch()" color="primary" text> Create </v-btn>
-              </v-card-actions>
+              <v-form @submit.prevent="createSketch()">
+                <v-text-field v-model="sketchForm.name" outlined dense placeholder="Name your sketch" autofocus>
+                </v-text-field>
+                <v-card-actions>
+                  <v-spacer></v-spacer>
+                  <v-btn text @click="createSketchDialog = false"> Cancel </v-btn>
+                  <v-btn :disabled="!sketchForm.name" @click="createSketch()" color="primary" text> Create </v-btn>
+                </v-card-actions>
+              </v-form>
             </v-card>
           </v-dialog>
         </v-row>
@@ -106,6 +109,7 @@ export default {
       sketchForm: {
         name: '',
       },
+      createSketchDialog: false,
       scenarioTemplates: [],
     }
   },

--- a/timesketch/frontend-ng/src/views/Sketch.vue
+++ b/timesketch/frontend-ng/src/views/Sketch.vue
@@ -89,6 +89,13 @@ limitations under the License.
       </v-card>
     </v-bottom-sheet>
 
+    <!-- Rename sketch dialog -->
+    <v-dialog v-model="renameSketchDialog" width="600">
+      <v-card class="pa-4">
+        <ts-rename-sketch @close="renameSketchDialog = false"></ts-rename-sketch>
+      </v-card>
+    </v-dialog>
+
     <!-- Left panel -->
     <v-navigation-drawer
       v-if="showLeftPanel && hasTimelines && !isArchived"
@@ -105,59 +112,33 @@ limitations under the License.
           </router-link>
         </v-avatar>
 
-        <div
-          @click="showSketchMetadata = !showSketchMetadata"
-          style="font-size: 1.1em; cursor: pointer; white-space: nowrap; overflow: hidden; text-overflow: ellipsis"
-          :title="sketch.name"
-        >
-          {{ sketch.name }}
-        </div>
+        <v-hover v-slot="{ hover }">
+          <div class="d-flex flex-wrap">
+            <div
+              class="flex-1-0"
+              @dblclick="renameSketchDialog = true"
+              style="
+                font-size: 1.1em;
+                cursor: pointer;
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                max-width: 300px;
+              "
+              :title="sketch.name"
+            >
+              {{ sketch.name }}
+            </div>
+            <div>
+              <v-icon small class="ml-1" v-if="hover" @click="renameSketchDialog = true">mdi-pencil</v-icon>
+            </div>
+          </div>
+        </v-hover>
 
         <v-spacer></v-spacer>
         <v-icon @click="toggleLeftPanel">mdi-chevron-left</v-icon>
       </v-toolbar>
-      <v-expand-transition>
-        <div class="px-4" v-show="showSketchMetadata">
-          <v-dialog v-model="renameSketchDialog" width="600">
-            <template v-slot:activator="{ on, attrs }">
-              <v-btn small outlined depressed color="primary" v-bind="attrs" v-on="on">
-                <v-icon left> mdi-pencil </v-icon>
-                Rename</v-btn
-              >
-            </template>
-            <v-card class="pa-4">
-              <ts-rename-sketch @close="renameSketchDialog = false"></ts-rename-sketch>
-            </v-card>
-          </v-dialog>
 
-          <v-list class="mx-n4" two-line>
-            <v-list-item v-if="sketch.user">
-              <v-list-item-content>
-                <v-list-item-title>
-                  <strong>Created:</strong> {{ sketch.created_at | shortDateTime }}
-                </v-list-item-title>
-                <v-list-item-subtitle>
-                  <small>{{ sketch.created_at | timeSince }} by {{ sketch.user.username }}</small>
-                </v-list-item-subtitle>
-              </v-list-item-content>
-            </v-list-item>
-
-            <v-list-item>
-              <v-list-item-content>
-                <v-list-item-title>
-                  <strong>Access: </strong>
-                  <span v-if="meta.permissions && meta.permissions.public">Public</span>
-                  <span v-else>Restricted</span>
-                </v-list-item-title>
-                <v-list-item-subtitle>
-                  <small v-if="meta.permissions && meta.permissions.public">Visible to all users on this server</small>
-                  <small v-else>Only people with access can open</small>
-                </v-list-item-subtitle>
-              </v-list-item-content>
-            </v-list-item>
-          </v-list>
-        </div>
-      </v-expand-transition>
       <v-divider></v-divider>
 
       <!-- Dialog for adding a scenario -->
@@ -181,8 +162,8 @@ limitations under the License.
           <v-divider></v-divider>
           <v-card-actions>
             <v-spacer></v-spacer>
-            <v-btn @click="scenarioDialog = false" color="primary" text> Close </v-btn>
-            <v-btn :disabled="!selectedScenario" @click="addScenario(selectedScenario.id)" color="primary" text>
+            <v-btn @click="scenarioDialog = false" text> Cancel </v-btn>
+            <v-btn text color="primary" :disabled="!selectedScenario" @click="addScenario(selectedScenario.id)">
               Add
             </v-btn>
           </v-card-actions>
@@ -285,6 +266,33 @@ limitations under the License.
           </v-avatar>
         </template>
         <v-card>
+          <v-list two-line>
+            <v-list-item v-if="sketch.user">
+              <v-list-item-content>
+                <v-list-item-title>
+                  <strong>Created:</strong> {{ sketch.created_at | shortDateTime }}
+                </v-list-item-title>
+                <v-list-item-subtitle>
+                  <small>{{ sketch.created_at | timeSince }} by {{ sketch.user.username }}</small>
+                </v-list-item-subtitle>
+              </v-list-item-content>
+            </v-list-item>
+
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title>
+                  <strong>Access: </strong>
+                  <span v-if="meta.permissions && meta.permissions.public">Public</span>
+                  <span v-else>Restricted</span>
+                </v-list-item-title>
+                <v-list-item-subtitle>
+                  <small v-if="meta.permissions && meta.permissions.public">Visible to all users on this server</small>
+                  <small v-else>Only people with access can open</small>
+                </v-list-item-subtitle>
+              </v-list-item-content>
+            </v-list-item>
+          </v-list>
+
           <v-list>
             <v-list-item-group color="primary">
               <v-list-item v-on:click="toggleTheme">

--- a/timesketch/frontend-ng/src/views/Sketch.vue
+++ b/timesketch/frontend-ng/src/views/Sketch.vue
@@ -304,6 +304,15 @@ limitations under the License.
                 </v-list-item-content>
               </v-list-item>
 
+              <v-list-item @click="renameSketchDialog = true">
+                <v-list-item-icon>
+                  <v-icon>mdi-pencil</v-icon>
+                </v-list-item-icon>
+                <v-list-item-content>
+                  <v-list-item-title>Rename sketch</v-list-item-title>
+                </v-list-item-content>
+              </v-list-item>
+
               <v-list-item @click="archiveSketch()">
                 <v-list-item-icon>
                   <v-icon>mdi-archive</v-icon>

--- a/timesketch/frontend-ng/src/views/Story.vue
+++ b/timesketch/frontend-ng/src/views/Story.vue
@@ -19,12 +19,14 @@ limitations under the License.
       <v-card class="pa-4">
         <h3>Rename story</h3>
         <br />
-        <v-text-field outlined dense autofocus v-model="titleDraft" @focus="$event.target.select()"> </v-text-field>
-        <v-card-actions>
-          <v-spacer></v-spacer>
-          <v-btn text @click="renameStoryDialog = false"> Cancel </v-btn>
-          <v-btn color="primary" depressed @click="rename()"> Save </v-btn>
-        </v-card-actions>
+        <v-form @submit.prevent="rename()">
+          <v-text-field outlined dense autofocus v-model="titleDraft" @focus="$event.target.select()"> </v-text-field>
+          <v-card-actions>
+            <v-spacer></v-spacer>
+            <v-btn text @click="renameStoryDialog = false"> Cancel </v-btn>
+            <v-btn color="primary" text @click="rename()"> Save </v-btn>
+          </v-card-actions>
+        </v-form>
       </v-card>
     </v-dialog>
 


### PR DESCRIPTION
* This PR cleans up how we do forms (wrap in a proper <v-form> to enable submit on enter)
* Cleaned up data sources info card for timelines
* Removed the expanding info for sketch name, and moved "rename sketch" to dblclick and icon (as with stories)
* Cleaned up the style of the XML viewer
* Created a "disable all other timelines" from the timeline-chip menu

<img width="749" alt="Screenshot 2023-07-04 at 12 47 08" src="https://github.com/google/timesketch/assets/316362/87cf934a-9cea-4b30-bab7-ee1fdced128d">

<img width="1032" alt="Screenshot 2023-07-04 at 12 46 56" src="https://github.com/google/timesketch/assets/316362/c66981d7-0f8c-481e-bd5f-51ef16558a74">


<img width="1251" alt="Screenshot 2023-07-04 at 12 07 22" src="https://github.com/google/timesketch/assets/316362/7a85b165-00ae-450e-a6d2-cc0ae483349f">

<img width="633" alt="Screenshot 2023-07-04 at 12 59 03" src="https://github.com/google/timesketch/assets/316362/a348206c-4552-4569-89e0-fb3c9bdb4db8">


<img width="565" alt="Screenshot 2023-07-04 at 10 04 47" src="https://github.com/google/timesketch/assets/316362/090f7cc5-2456-47d2-aea4-4776bd5bd2e8">


