### PR TITLE
[CLI] Add `output-format` as cli wide argument

### DIFF
--- a/cli_client/python/timesketch_cli_client/cli.py
+++ b/cli_client/python/timesketch_cli_client/cli.py
@@ -42,16 +42,26 @@ class TimesketchCli(object):
     Attributes:
         sketch_from_flag: Sketch ID if provided by flag
         config_assistant: Instance of ConfigAssistant
+        output_format_from_flag: Output format to use
     """
 
-    def __init__(self, api_client=None, sketch_from_flag=None, conf_file=""):
+    def __init__(
+        self,
+        api_client=None,
+        sketch_from_flag=None,
+        conf_file="",
+        output_format_from_flag=None,
+    ):
         """Initialize the state object.
 
         Args:
             sketch_from_flag: Sketch ID if provided by flag.
+            conf_file: Path to the config file.
+            output_format_from_flag: Output format to use.
         """
         self.api = api_client
         self.sketch_from_flag = sketch_from_flag
+        self.output_format_from_flag = output_format_from_flag
 
         if not api_client:
             try:
@@ -99,13 +109,22 @@ class TimesketchCli(object):
 
     @property
     def output_format(self):
-        """Get the configured output format, or the default format if missing.
+        """Get the output format
+        The priority is:
+            * output_format set via flag
+            * output_format set via config file
+            * or the default format if missing.
 
         Returns:
             Output format as a string.
         """
-        output_format = self.config_assistant.get_config("output_format")
-        if not output_format:
+        if self.output_format_from_flag:
+            output_format = self.output_format_from_flag
+            self.config_assistant.set_config("output", output_format)
+            self.config_assistant.save_config()
+        elif self.config_assistant.get_config("output"):
+            output_format = self.config_assistant.get_config("output")
+        else:
             self.config_assistant.set_config("output", DEFAULT_OUTPUT_FORMAT)
             self.config_assistant.save_config()
             output_format = DEFAULT_OUTPUT_FORMAT
@@ -115,8 +134,14 @@ class TimesketchCli(object):
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option(version=get_version(), prog_name="Timesketch CLI")
 @click.option("--sketch", type=int, default=None, help="Sketch to work in.")
+@click.option(
+    "--output-format",
+    "output",
+    required=False,
+    help="Set output format [json, text, tabular, csv] (overrides global setting).",
+)
 @click.pass_context
-def cli(ctx, sketch):
+def cli(ctx, sketch, output):
     """Timesketch CLI client.
 
     This tool provides similar features as the web client does.
@@ -130,7 +155,7 @@ def cli(ctx, sketch):
 
     For detailed help on each command, run  <command> --help
     """
-    ctx.obj = TimesketchCli(sketch_from_flag=sketch)
+    ctx.obj = TimesketchCli(sketch_from_flag=sketch, output_format_from_flag=output)
 
 
 # Register all commands.

--- a/cli_client/python/timesketch_cli_client/definitions.py
+++ b/cli_client/python/timesketch_cli_client/definitions.py
@@ -13,5 +13,5 @@
 # limitations under the License.
 """Definitions for the Timesketch CLI client."""
 
-SUPPORTED_OUTPUT_FORMATS = ["text", "csv", "tabular"]
+SUPPORTED_OUTPUT_FORMATS = ["text", "csv", "tabular", "json"]
 DEFAULT_OUTPUT_FORMAT = "tabular"

--- a/docs/guides/user/cli-client.md
+++ b/docs/guides/user/cli-client.md
@@ -44,6 +44,8 @@ Usage: timesketch [OPTIONS] COMMAND [ARGS]...
 Options:
   --version         Show the version and exit.
   --sketch INTEGER  Sketch to work in.
+  --output-format TEXT  Set output format [json, text, tabular, csv]
+                        (overrides global setting).
   -h, --help        Show this message and exit.
 
 Commands:
@@ -79,6 +81,12 @@ Example:
 
 ```
 timesketch config set output csv
+```
+
+The output format can also be set in CLI with the following flag:
+
+```
+timesketch --output-format text [YOURCOMMAND]
 ```
 
 ## Search


### PR DESCRIPTION
Adding a central flag for `output_format` like we have for `sketch` so that every command can be used.

There will be following PRs to remove the output format flag from individual modules and a PR to update the documentation.

This should not break any module but to keep it small I would like to keep this PR minimal.

So one would do:

```
timesketch --output-format text --sketch 1 analyze list
login
ntfs_timestomp
chain
tagger
ssh_sessionizer
``` 

instead of before:

```
timesketch --sketch 1 analyze list --output-format text
login
ntfs_timestomp
chain
tagger
ssh_sessionizer
```

The later will not work any more as the flags are tied to the module they are using them, here the root cli command (this is a click limitation) https://github.com/pallets/click/issues/567

Context: https://github.com/google/timesketch/issues/2608