### PR TITLE
fix mkdocs warnings

### DIFF
--- a/docs/changelog/2023-02.md
+++ b/docs/changelog/2023-02.md
@@ -57,4 +57,4 @@ tsctl list-sigma-rules --columns=rule_uuid,title,status | grep experimental | wc
 
 ### use a fixed id if crypto.randomUUID is not available (#2537)
 
-In Sigma Rule templates, the code still tried to generate a random UUID, this was causing problems if the connection to TImesketch was not in a HTTPS connection. This is being fixed now.
+In Sigma Rule templates, the code still tried to generate a random UUID, this was causing problems if the connection to Timesketch was not in a HTTPS connection. This is being fixed now.

--- a/docs/changelog/2023-02.md
+++ b/docs/changelog/2023-02.md
@@ -35,7 +35,7 @@ New Studio in Timesketch. First functionality is to edit Sigma rules.
 
 Ability to remove filter chips
 
-![Remove filter chips](../assets/images/removable_chip_filter.png)
+![Remove filter chips](../assets/images/removable_chip_filters.png)
 
 ## Enhance tsctl list-sigma-rules
 

--- a/docs/guides/user/sigma.md
+++ b/docs/guides/user/sigma.md
@@ -35,7 +35,7 @@ This will show a list on the left with all Sigma rules installed on a system. Yo
 
 So if you want to search for ZMap related rules, you can search for `zma` and it will show you the pre installed rule.
 
-![Sigma studio](../assets/images/sigma_studio.png)
+![Sigma studio](../../assets/images/sigma_studio.png)
 
 #### Analyzer
 
@@ -71,7 +71,7 @@ To use the official community rules you can visit [github.com/Neo23x0/sigma](htt
 In the past, Sigma rules where stored on disk, in 2022 this has been changed and Sigma rules are stored in the database.
 New rules can be added / modified via the Sigma portion of the Studio.
 
-Visit 
+Visit
 
 ```
 https://$TIMESKETCH/v2/studio/sigma/new

--- a/docs/guides/user/sketch-overview.md
+++ b/docs/guides/user/sketch-overview.md
@@ -13,7 +13,7 @@ Now you need to add timelines to your new sketch. To do so, you can click “Imp
 
 Alternatively, you can go to “Timelines” tab and select from all available timelines.
 
-![Empty state](../assets/images/empty_state_sketch.png)
+![Empty state](../../assets/images/empty_state_sketch.png)
 
 ## Navigating a sketch
 A sketch consists of 5 tabs: “Overview”, “Explore”, “Stories”, "Attributes", "Intelligence".
@@ -45,7 +45,7 @@ You can share the sketch with users, groups of users, make it available to all u
 
 **Timerange** allows to control the timerange of shown events.
 
-![Timefilter](../assets/images/timefilter.png)
+![Timefilter](../../assets/images/timefilter.png)
 
 **Filter** Add a filter, e.g. to show only starred events
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
           - Tagger analyzer: guides/analyzers/tagger.md
           - Feature extraction analyzer: guides/analyzers/feature_extraction.md
           - Sigma analyzer: guides/analyzers/sigma_analyzer.md
+          - HashR analyzer: guides/analyzers/hashR_lookup.md
   - Admin Guide:
       - Install: guides/admin/install.md
       - Upgrade: guides/admin/upgrade.md


### PR DESCRIPTION
This PR fixes the following [warning](https://github.com/jkppr/timesketch/actions/runs/5517846529/jobs/10061135465) from mkdocs:
```
INFO     -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
  - guides/analyzers/hashR_lookup.md
WARNING  -  Documentation file 'changelog/2023-02.md' contains a link to 'assets/images/removable_chip_filter.png' which is not found in the documentation files.
WARNING  -  Documentation file 'guides/user/sigma.md' contains a link to 'guides/assets/images/sigma_studio.png' which is not found in the documentation files.
WARNING  -  Documentation file 'guides/user/sketch-overview.md' contains a link to 'guides/assets/images/empty_state_sketch.png' which is not found in the documentation files.
WARNING  -  Documentation file 'guides/user/sketch-overview.md' contains a link to 'guides/assets/images/timefilter.png' which is not found in the documentation files.
```