### PR TITLE
Preserve user defined filters

### DIFF
--- a/timesketch/frontend-ng/src/components/Explore/SearchDropdown.vue
+++ b/timesketch/frontend-ng/src/components/Explore/SearchDropdown.vue
@@ -94,17 +94,6 @@ limitations under the License.
 </template>
 
 <script>
-const defaultQueryFilter = () => {
-  return {
-    from: 0,
-    terminate_after: 40,
-    size: 40,
-    indices: '_all',
-    order: 'asc',
-    chips: [],
-  }
-}
-
 export default {
   props: ['selectedLabels', 'queryString'],
   computed: {
@@ -165,7 +154,6 @@ export default {
       let eventData = {}
       eventData.doSearch = true
       eventData.queryString = '*'
-      eventData.queryFilter = defaultQueryFilter()
       let chip = {
         field: '',
         value: label,
@@ -173,21 +161,19 @@ export default {
         operator: 'must',
         active: true,
       }
-      eventData.queryFilter.chips.push(chip)
+      eventData.chip = chip
       this.$emit('setQueryAndFilter', eventData)
     },
     searchForTag(tag) {
       let eventData = {}
       eventData.doSearch = true
       eventData.queryString = 'tag:' + tag
-      eventData.queryFilter = defaultQueryFilter()
       this.$emit('setQueryAndFilter', eventData)
     },
     searchForDataType(dataType) {
       let eventData = {}
       eventData.doSearch = true
       eventData.queryString = 'data_type:' + '"' + dataType + '"'
-      eventData.queryFilter = defaultQueryFilter()
       this.$emit('setQueryAndFilter', eventData)
     },
     searchForField(field) {
@@ -201,7 +187,6 @@ export default {
       }
       eventData.doSearch = false
       eventData.queryString = separator + field + ':'
-      eventData.queryFilter = defaultQueryFilter()
       this.$emit('setQueryAndFilter', eventData)
     },
   },

--- a/timesketch/frontend-ng/src/components/LeftPanel/DataTypes.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/DataTypes.vue
@@ -77,17 +77,6 @@ limitations under the License.
 <script>
 import EventBus from '../../main'
 
-const defaultQueryFilter = () => {
-  return {
-    from: 0,
-    terminate_after: 40,
-    size: 40,
-    indices: '_all',
-    order: 'asc',
-    chips: [],
-  }
-}
-
 export default {
   props: [],
   data: function () {
@@ -110,7 +99,6 @@ export default {
       let eventData = {}
       eventData.doSearch = true
       eventData.queryString = 'data_type:' + '"' + dataType + '"'
-      eventData.queryFilter = defaultQueryFilter()
       EventBus.$emit('setQueryAndFilter', eventData)
     },
   },

--- a/timesketch/frontend-ng/src/components/LeftPanel/SearchTemplate.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/SearchTemplate.vue
@@ -63,17 +63,6 @@ limitations under the License.
 import ApiClient from '../../utils/RestApiClient'
 import EventBus from '../../main'
 
-const defaultQueryFilter = () => {
-  return {
-    from: 0,
-    terminate_after: 40,
-    size: 40,
-    indices: '_all',
-    order: 'asc',
-    chips: [],
-  }
-}
-
 export default {
   props: ['searchtemplate'],
   data: function () {
@@ -101,7 +90,6 @@ export default {
       let eventData = {}
       eventData.doSearch = true
       eventData.queryString = queryString
-      eventData.queryFilter = defaultQueryFilter()
       EventBus.$emit('setQueryAndFilter', eventData)
     },
     parseQueryAndSearch() {

--- a/timesketch/frontend-ng/src/components/LeftPanel/SigmaRule.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/SigmaRule.vue
@@ -129,17 +129,6 @@ limitations under the License.
 import EventBus from '../../main'
 import ApiClient from '../../utils/RestApiClient'
 
-const defaultQueryFilter = () => {
-  return {
-    from: 0,
-    terminate_after: 40,
-    size: 40,
-    indices: '_all',
-    order: 'asc',
-    chips: [],
-  }
-}
-
 export default {
   components: {},
   props: ['sigmaRule'],
@@ -175,7 +164,6 @@ export default {
       let eventData = {}
       eventData.doSearch = true
       eventData.queryString = queryString
-      eventData.queryFilter = defaultQueryFilter()
       EventBus.$emit('setQueryAndFilter', eventData)
     },
     deleteRule(ruleUuid) {

--- a/timesketch/frontend-ng/src/components/LeftPanel/Tags.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/Tags.vue
@@ -71,17 +71,6 @@ limitations under the License.
 <script>
 import EventBus from '../../main'
 
-const defaultQueryFilter = () => {
-  return {
-    from: 0,
-    terminate_after: 40,
-    size: 40,
-    indices: '_all',
-    order: 'asc',
-    chips: [],
-  }
-}
-
 export default {
   props: [],
   data: function () {
@@ -108,14 +97,12 @@ export default {
       let eventData = {}
       eventData.doSearch = true
       eventData.queryString = 'tag:' + '"' + tag + '"'
-      eventData.queryFilter = defaultQueryFilter()
       EventBus.$emit('setQueryAndFilter', eventData)
     },
     searchForLabel(label) {
       let eventData = {}
       eventData.doSearch = true
       eventData.queryString = '*'
-      eventData.queryFilter = defaultQueryFilter()
       let chip = {
         field: '',
         value: label,
@@ -123,7 +110,7 @@ export default {
         operator: 'must',
         active: true,
       }
-      eventData.queryFilter.chips.push(chip)
+      eventData.chip = chip
       EventBus.$emit('setQueryAndFilter', eventData)
     },
   },

--- a/timesketch/frontend-ng/src/filters/FormatLabelText.js
+++ b/timesketch/frontend-ng/src/filters/FormatLabelText.js
@@ -16,6 +16,8 @@ limitations under the License.
 export default {
   name: 'formatLabelText',
   filter: function (input) {
+    if (input === '__ts_star') return 'All starred events'
+    if (input === '__ts_comment') return 'All commented events'
     return input.replace('__ts_', '')
   },
 }

--- a/timesketch/frontend-ng/src/views/Explore.vue
+++ b/timesketch/frontend-ng/src/views/Explore.vue
@@ -231,10 +231,10 @@ limitations under the License.
       </div>
 
       <!-- Term filters -->
-      <div v-if="filterChips.length">
-        <v-chip-group>
+      <div v-if="filterChips.length" class="mt-1">
+        <v-chip-group column>
           <span v-for="(chip, index) in filterChips" :key="index + chip.value">
-            <v-chip small outlined close @click:close="removeChip(chip)">
+            <v-chip outlined close close-icon="mdi-close" @click:close="removeChip(chip)">
               <v-icon v-if="chip.value === '__ts_star'" left small color="amber">mdi-star</v-icon>
               <v-icon v-if="chip.value === '__ts_comment'" left small>mdi-comment-multiple-outline</v-icon>
               {{ chip.value | formatLabelText }}
@@ -370,17 +370,19 @@ export default {
       }
       this.currentQueryString = searchEvent.queryString
 
-      // Preserve user defined filter instead of resetting.
+      // Preserve user defined filter instead of resetting, if it exist.
       if (!searchEvent.queryFilter) {
         searchEvent.queryFilter = this.currentQueryFilter
       }
       this.currentQueryFilter = searchEvent.queryFilter
-      // TODO: Change how we handle chips in the future. This is temporary until we have
-      // a new filter solution for chips beyond only star and comment chips.
-      this.currentQueryFilter.chips = []
 
+      // Add any chips from the search event and make sure they are not in the
+      // current filter already. E.g. don't add a star filter twice.
       if (searchEvent.chip) {
-        this.currentQueryFilter.chips.push(searchEvent.chip)
+        const chipExist = this.currentQueryFilter.chips.find((chip) => chip.value === searchEvent.chip.value)
+        if (!chipExist) {
+          this.currentQueryFilter.chips.push(searchEvent.chip)
+        }
       }
 
       // Preserve user defined item count instead of resetting.

--- a/timesketch/frontend-ng/src/views/Explore.vue
+++ b/timesketch/frontend-ng/src/views/Explore.vue
@@ -65,6 +65,7 @@ limitations under the License.
             v-click-outside="onClickOutside"
             :selected-labels="selectedLabels"
             :query-string="currentQueryString"
+            :query-filter="currentQueryFilter"
             @setActiveView="searchView"
             @addChip="addChip"
             @updateLabelChips="updateLabelChips()"
@@ -279,7 +280,7 @@ const defaultQueryFilter = () => {
     from: 0,
     terminate_after: 40,
     size: 40,
-    indices: [],
+    indices: '_all',
     order: 'asc',
     chips: [],
   }
@@ -368,7 +369,20 @@ export default {
         this.$router.push({ name: 'Explore', params: { sketchId: this.sketch.id } })
       }
       this.currentQueryString = searchEvent.queryString
+
+      // Preserve user defined filter instead of resetting.
+      if (!searchEvent.queryFilter) {
+        searchEvent.queryFilter = this.currentQueryFilter
+      }
       this.currentQueryFilter = searchEvent.queryFilter
+      // TODO: Change how we handle chips in the future. This is temporary until we have
+      // a new filter solution for chips beyond only star and comment chips.
+      this.currentQueryFilter.chips = []
+
+      if (searchEvent.chip) {
+        this.currentQueryFilter.chips.push(searchEvent.chip)
+      }
+
       // Preserve user defined item count instead of resetting.
       this.currentQueryFilter.size = this.currentItemsPerPage
       this.currentQueryFilter.terminate_after = this.currentItemsPerPage

--- a/timesketch/frontend-ng/src/views/Explore.vue
+++ b/timesketch/frontend-ng/src/views/Explore.vue
@@ -65,7 +65,6 @@ limitations under the License.
             v-click-outside="onClickOutside"
             :selected-labels="selectedLabels"
             :query-string="currentQueryString"
-            :query-filter="currentQueryFilter"
             @setActiveView="searchView"
             @addChip="addChip"
             @updateLabelChips="updateLabelChips()"


### PR DESCRIPTION
This PR fixes an issue where all user defined filter were removed when navigating different searches (left panel navigation and search dropdown).

fixes #2387 
fixes #1834 