### PR TITLE
Rework comments

### DIFF
--- a/timesketch/frontend-ng/src/components/Explore/Comments.vue
+++ b/timesketch/frontend-ng/src/components/Explore/Comments.vue
@@ -45,9 +45,7 @@ limitations under the License.
 
             <v-card-actions v-if="comment.editable">
               <v-spacer></v-spacer>
-              <v-btn text color="primary" v-if="comment.editable" @click="editComment(index, false)">
-                Cancel
-              </v-btn>
+              <v-btn text color="primary" v-if="comment.editable" @click="editComment(index, false)"> Cancel </v-btn>
               <v-btn text color="primary" @click="updateComment(comment, index)"> Save </v-btn>
             </v-card-actions>
           </v-card>
@@ -116,6 +114,7 @@ export default {
       ApiClient.saveEventAnnotation(this.sketch.id, 'comment', this.comment, [this.event], this.currentSearchNode)
         .then((response) => {
           this.comments.push(response.data.objects[0][0])
+          this.event._source.comment.push(this.comment)
           this.comment = ''
         })
         .catch((e) => {})
@@ -135,6 +134,7 @@ export default {
         ApiClient.deleteEventAnnotation(this.sketch.id, 'comment', commentId, this.event, this.currentSearchNode)
           .then((response) => {
             this.comments.splice(commentIndex, 1)
+            this.event._source.comment.splice(commentIndex, 1)
           })
           .catch((e) => {
             console.error(e)

--- a/timesketch/frontend-ng/src/components/Explore/Comments.vue
+++ b/timesketch/frontend-ng/src/components/Explore/Comments.vue
@@ -1,0 +1,157 @@
+<!--
+Copyright 2023 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<template>
+  <v-card outlined>
+    <v-toolbar dense flat>
+      <v-toolbar-title style="font-size: 1.2em">Comments</v-toolbar-title>
+    </v-toolbar>
+
+    <v-list three-line>
+      <v-list-item
+        v-for="(comment, index) in comments"
+        :key="comment.id"
+        @mouseover="selectComment(comment)"
+        @mouseleave="unSelectComment()"
+      >
+        <v-list-item-avatar>
+          <v-avatar color="grey lighten-1">
+            <span class="white--text">{{ comment.user.username | initialLetter }}</span>
+          </v-avatar>
+        </v-list-item-avatar>
+
+        <v-list-item-content>
+          <v-list-item-title>
+            {{ comment.user.username }}
+          </v-list-item-title>
+          <v-list-item-subtitle>
+            {{ comment.created_at | shortDateTime }} ({{ comment.created_at | timeSince }})
+          </v-list-item-subtitle>
+
+          <v-card flat v-if="comment.editable" class="mt-5">
+            <v-textarea v-model="comments[index].comment" hide-details auto-grow filled></v-textarea>
+
+            <v-card-actions v-if="comment.editable">
+              <v-spacer></v-spacer>
+              <v-btn text color="primary" v-if="comment.editable" @click="editComment(index, false)">
+                Cancel
+              </v-btn>
+              <v-btn text color="primary" @click="updateComment(comment, index)"> Save </v-btn>
+            </v-card-actions>
+          </v-card>
+          <p v-else style="max-width: 90%" class="body-2">{{ comment.comment }}</p>
+        </v-list-item-content>
+
+        <v-list-item-action
+          v-if="comment === selectedComment && meta.permissions.write && currentUser == comment.user.username"
+          style="position: absolute; right: 0"
+        >
+          <v-chip outlined style="margin-right: 10px">
+            <v-btn icon small @click="editComment(index)">
+              <v-icon small>mdi-square-edit-outline</v-icon>
+            </v-btn>
+            <v-btn icon small @click="deleteComment(comment.id, index)">
+              <v-icon small>mdi-trash-can-outline</v-icon>
+            </v-btn>
+          </v-chip>
+        </v-list-item-action>
+      </v-list-item>
+    </v-list>
+
+    <v-card-actions v-if="meta.permissions.write">
+      <v-textarea
+        v-model="comment"
+        hide-details
+        auto-grow
+        filled
+        class="mx-2 mb-2"
+        label="Add comment"
+        rows="1"
+      ></v-textarea>
+      <v-btn icon @click="postComment">
+        <v-icon>mdi-send</v-icon>
+      </v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script>
+import EventBus from '../../main'
+import ApiClient from '../../utils/RestApiClient'
+
+export default {
+  props: ['comments', 'event', 'currentSearchNode'],
+  data() {
+    return {
+      comment: '',
+      selectedComment: false,
+    }
+  },
+  computed: {
+    sketch() {
+      return this.$store.state.sketch
+    },
+    meta() {
+      return this.$store.state.meta
+    },
+    currentUser() {
+      return this.$store.state.currentUser
+    },
+  },
+  methods: {
+    postComment: function () {
+      EventBus.$emit('eventAnnotated', { type: '__ts_comment', event: this.event, searchNode: this.currentSearchNode })
+      ApiClient.saveEventAnnotation(this.sketch.id, 'comment', this.comment, [this.event], this.currentSearchNode)
+        .then((response) => {
+          this.comments.push(response.data.objects[0][0])
+          this.comment = ''
+        })
+        .catch((e) => {})
+    },
+    updateComment: function (comment, commentIndex) {
+      ApiClient.updateEventAnnotation(this.sketch.id, 'comment', comment, [this.event], this.currentSearchNode)
+        .then((response) => {
+          this.comments.splice(commentIndex, 1, comment)
+          comment.editable = false
+        })
+        .catch((e) => {
+          console.error(e)
+        })
+    },
+    deleteComment: function (commentId, commentIndex) {
+      if (confirm('Are you sure?')) {
+        ApiClient.deleteEventAnnotation(this.sketch.id, 'comment', commentId, this.event, this.currentSearchNode)
+          .then((response) => {
+            this.comments.splice(commentIndex, 1)
+          })
+          .catch((e) => {
+            console.error(e)
+          })
+      }
+    },
+    editComment(commentIndex, enable = true) {
+      const changeComment = this.comments[commentIndex]
+      changeComment.editable = enable
+      this.comments.splice(commentIndex, 1, changeComment)
+    },
+    selectComment(comment) {
+      this.selectedComment = comment
+    },
+    unSelectComment() {
+      this.selectedComment = false
+    },
+  },
+}
+</script>

--- a/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
@@ -16,7 +16,7 @@ limitations under the License.
 <template>
   <div>
     <v-row>
-      <v-col :cols="showComments ? 8 : 0">
+      <v-col :cols="event.showComments ? 8 : 0">
         <v-card outlined height="100%">
           <v-simple-table dense>
             <template v-slot:default>
@@ -136,7 +136,7 @@ limitations under the License.
         </v-card>
       </v-col>
       <v-slide-x-reverse-transition>
-        <v-col cols="4" v-show="showComments">
+        <v-col cols="4" v-show="event.showComments">
           <ts-comments :comments="comments" :event="event" :currentSearchNode="currentSearchNode"></ts-comments>
         </v-col>
       </v-slide-x-reverse-transition>
@@ -170,7 +170,7 @@ export default {
     TsLinkRedirectWarning,
     TsComments,
   },
-  props: ['showCommentsTrigger', 'event'],
+  props: ['event'],
   data() {
     return {
       fullEvent: {},
@@ -194,7 +194,6 @@ export default {
       contextUrl: '',
       contextValue: '',
       c_key: -1,
-      schowCommentBlock: false,
     }
   },
   computed: {
@@ -222,13 +221,6 @@ export default {
     contextLinkConf() {
       return this.$store.state.contextLinkConf
     },
-    showComments() {
-      if (this.schowCommentBlock || this.showCommentsTrigger) {
-        return true
-      } else {
-        return false
-      }
-    },
   },
   methods: {
     getEvent: function () {
@@ -240,8 +232,8 @@ export default {
           this.comments = response.data.meta.comments
           this.eventTimestamp = response.data.objects.timestamp
           this.eventTimestampDesc = response.data.objects.timestamp_desc
-          if (this.comments.length > 0 || this.event.showComments) {
-            this.schowCommentBlock = true
+          if (this.comments.length > 0) {
+            this.event.showComments = true
           }
         })
         .catch((e) => {})

--- a/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
@@ -16,7 +16,7 @@ limitations under the License.
 <template>
   <div>
     <v-row>
-      <v-col cols="8">
+      <v-col :cols="comments.length > 0 ? 8 : null ">
         <v-card outlined height="100%">
           <v-simple-table dense>
             <template v-slot:default>
@@ -135,78 +135,8 @@ limitations under the License.
           </v-simple-table>
         </v-card>
       </v-col>
-      <v-col cols="4">
-        <v-card outlined>
-          <v-toolbar dense flat>
-            <v-toolbar-title style="font-size: 1.2em">Comments</v-toolbar-title>
-          </v-toolbar>
-
-          <v-list three-line>
-            <v-list-item
-              v-for="(comment, index) in comments"
-              :key="comment.id"
-              @mouseover="selectComment(comment)"
-              @mouseleave="unSelectComment()"
-            >
-              <v-list-item-avatar>
-                <v-avatar color="grey lighten-1">
-                  <span class="white--text">{{ comment.user.username | initialLetter }}</span>
-                </v-avatar>
-              </v-list-item-avatar>
-
-              <v-list-item-content>
-                <v-list-item-title>
-                  {{ comment.user.username }}
-                </v-list-item-title>
-                <v-list-item-subtitle>
-                  {{ comment.created_at | shortDateTime }} ({{ comment.created_at | timeSince }})
-                </v-list-item-subtitle>
-
-                <v-card flat v-if="comment.editable" class="mt-5">
-                  <v-textarea v-model="comments[index].comment" hide-details auto-grow filled></v-textarea>
-
-                  <v-card-actions v-if="comment.editable">
-                    <v-spacer></v-spacer>
-                    <v-btn text color="primary" v-if="comment.editable" @click="editComment(index, false)">
-                      Cancel
-                    </v-btn>
-                    <v-btn text color="primary" @click="updateComment(comment, index)"> Save </v-btn>
-                  </v-card-actions>
-                </v-card>
-                <p v-else style="max-width: 90%" class="body-2">{{ comment.comment }}</p>
-              </v-list-item-content>
-
-              <v-list-item-action
-                v-if="comment === selectedComment && meta.permissions.write && currentUser == comment.user.username"
-                style="position: absolute; right: 0"
-              >
-                <v-chip outlined style="margin-right: 10px">
-                  <v-btn icon small @click="editComment(index)">
-                    <v-icon small>mdi-square-edit-outline</v-icon>
-                  </v-btn>
-                  <v-btn icon small @click="deleteComment(comment.id, index)">
-                    <v-icon small>mdi-trash-can-outline</v-icon>
-                  </v-btn>
-                </v-chip>
-              </v-list-item-action>
-            </v-list-item>
-          </v-list>
-
-          <v-card-actions v-if="meta.permissions.write">
-            <v-textarea
-              v-model="comment"
-              hide-details
-              auto-grow
-              filled
-              class="mx-2 mb-2"
-              label="Add comment"
-              rows="1"
-            ></v-textarea>
-            <v-btn icon @click="postComment">
-              <v-icon>mdi-send</v-icon>
-            </v-btn>
-          </v-card-actions>
-        </v-card>
+      <v-col cols="4" v-if="comments.length > 0">
+        <ts-comments :comments="comments" :event="event" :currentSearchNode="currentSearchNode"></ts-comments>
       </v-col>
     </v-row>
     <v-dialog scrollable v-model="aggregatorDialog" @click:outside="($event) => (this.aggregatorDialog = false)">
@@ -226,24 +156,23 @@ limitations under the License.
 
 <script>
 import ApiClient from '../../utils/RestApiClient'
-import EventBus from '../../main'
 import TsAggregateDialog from './AggregateDialog.vue'
 import TsFormatXmlString from './FormatXMLString.vue'
 import TsLinkRedirectWarning from './LinkRedirectWarning.vue'
+import TsComments from './Comments.vue'
 
 export default {
   components: {
     TsAggregateDialog,
     TsFormatXmlString,
     TsLinkRedirectWarning,
+    TsComments,
   },
   props: ['event'],
   data() {
     return {
       fullEvent: {},
-      comment: '',
       comments: [],
-      selectedComment: null,
       aggregatorDialog: false,
       ignoredAggregatorFields: new Set([
         'datetime',
@@ -303,48 +232,6 @@ export default {
           this.eventTimestampDesc = response.data.objects.timestamp_desc
         })
         .catch((e) => {})
-    },
-    postComment: function () {
-      EventBus.$emit('eventAnnotated', { type: '__ts_comment', event: this.event, searchNode: this.currentSearchNode })
-      ApiClient.saveEventAnnotation(this.sketch.id, 'comment', this.comment, [this.event], this.currentSearchNode)
-        .then((response) => {
-          this.comments.push(response.data.objects[0][0])
-          this.comment = ''
-        })
-        .catch((e) => {})
-    },
-    updateComment: function (comment, commentIndex) {
-      ApiClient.updateEventAnnotation(this.sketch.id, 'comment', comment, [this.event], this.currentSearchNode)
-        .then((response) => {
-          this.comments.splice(commentIndex, 1, comment)
-          comment.editable = false
-        })
-        .catch((e) => {
-          console.error(e)
-        })
-    },
-    deleteComment: function (commentId, commentIndex) {
-      if (confirm('Are you sure?')) {
-        ApiClient.deleteEventAnnotation(this.sketch.id, 'comment', commentId, this.event, this.currentSearchNode)
-          .then((response) => {
-            this.comments.splice(commentIndex, 1)
-          })
-          .catch((e) => {
-            console.error(e)
-          })
-      }
-    },
-    editComment(commentIndex, enable = true) {
-      const changeComment = this.comments[commentIndex]
-      changeComment.editable = enable
-      this.comments.splice(commentIndex, 1, changeComment)
-    },
-
-    selectComment(comment) {
-      this.selectedComment = comment
-    },
-    unSelectComment() {
-      this.selectedComment = false
     },
     getContextLinkItems(key) {
       let fieldConfList = this.contextLinkConf[key.toLowerCase()] ? this.contextLinkConf[key.toLowerCase()] : []

--- a/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
@@ -16,7 +16,7 @@ limitations under the License.
 <template>
   <div>
     <v-row>
-      <v-col :cols="comments.length > 0 ? 8 : null ">
+      <v-col :cols="showComments ? 8 : 0">
         <v-card outlined height="100%">
           <v-simple-table dense>
             <template v-slot:default>
@@ -135,7 +135,7 @@ limitations under the License.
           </v-simple-table>
         </v-card>
       </v-col>
-      <v-col cols="4" v-if="comments.length > 0">
+      <v-col cols="4" v-show="showComments">
         <ts-comments :comments="comments" :event="event" :currentSearchNode="currentSearchNode"></ts-comments>
       </v-col>
     </v-row>
@@ -192,6 +192,7 @@ export default {
       contextUrl: '',
       contextValue: '',
       c_key: -1,
+      showComments: false,
     }
   },
   computed: {
@@ -230,6 +231,9 @@ export default {
           this.comments = response.data.meta.comments
           this.eventTimestamp = response.data.objects.timestamp
           this.eventTimestampDesc = response.data.objects.timestamp_desc
+          if (this.comments.length > 0 || this.event.showComments) {
+            this.showComments = true
+          }
         })
         .catch((e) => {})
     },

--- a/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
@@ -135,9 +135,11 @@ limitations under the License.
           </v-simple-table>
         </v-card>
       </v-col>
-      <v-col cols="4" v-show="showComments">
-        <ts-comments :comments="comments" :event="event" :currentSearchNode="currentSearchNode"></ts-comments>
-      </v-col>
+      <v-slide-x-reverse-transition>
+        <v-col cols="4" v-show="showComments">
+          <ts-comments :comments="comments" :event="event" :currentSearchNode="currentSearchNode"></ts-comments>
+        </v-col>
+      </v-slide-x-reverse-transition>
     </v-row>
     <v-dialog scrollable v-model="aggregatorDialog" @click:outside="($event) => (this.aggregatorDialog = false)">
       <ts-aggregate-dialog
@@ -168,7 +170,7 @@ export default {
     TsLinkRedirectWarning,
     TsComments,
   },
-  props: ['event'],
+  props: ['showCommentsTrigger', 'event'],
   data() {
     return {
       fullEvent: {},
@@ -192,7 +194,7 @@ export default {
       contextUrl: '',
       contextValue: '',
       c_key: -1,
-      showComments: false,
+      schowCommentBlock: false,
     }
   },
   computed: {
@@ -220,6 +222,13 @@ export default {
     contextLinkConf() {
       return this.$store.state.contextLinkConf
     },
+    showComments() {
+      if (this.schowCommentBlock || this.showCommentsTrigger) {
+        return true
+      } else {
+        return false
+      }
+    },
   },
   methods: {
     getEvent: function () {
@@ -232,7 +241,7 @@ export default {
           this.eventTimestamp = response.data.objects.timestamp
           this.eventTimestampDesc = response.data.objects.timestamp_desc
           if (this.comments.length > 0 || this.event.showComments) {
-            this.showComments = true
+            this.schowCommentBlock = true
           }
         })
         .catch((e) => {})

--- a/timesketch/frontend-ng/src/components/Explore/EventList.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventList.vue
@@ -366,9 +366,38 @@ limitations under the License.
 
         <!-- Comment field -->
         <template v-slot:item._source.comment="{ item }">
-          <v-badge :offset-y="10" bordered v-if="item._source.comment.length" :content="item._source.comment.length">
-            <v-icon small @click="toggleDetailedEvent(item)"> mdi-comment-text-multiple-outline </v-icon>
-          </v-badge>
+          <v-tooltip top open-delay="300">
+            <template v-slot:activator="{ on }">
+              <div v-on="on" class="d-inline-block">
+                <v-btn
+                  icon
+                  small
+                  @click="toggleDetailedEvent(item)"
+                   v-if="item._source.comment.length"
+                >
+                  <v-badge :offset-y="10" :offset-x="10" bordered :content="item._source.comment.length">
+                    <v-icon small> mdi-comment-text-multiple-outline </v-icon>
+                  </v-badge>
+                </v-btn>
+              </div>
+            </template>
+            <span>Open comments</span>
+          </v-tooltip>
+          <v-tooltip top open-delay="300">
+            <template v-slot:activator="{ on }">
+              <div v-on="on" class="d-inline-block">
+                <v-btn
+                  icon
+                  small
+                  @click="toggleDetailedEvent(item)"
+                  v-if="item['showDetails'] && !item._source.comment.length"
+                >
+                  <v-icon> mdi-comment-plus-outline </v-icon>
+                </v-btn>
+              </div>
+            </template>
+            <span>Add a comment</span>
+          </v-tooltip>
         </template>
       </v-data-table>
     </div>

--- a/timesketch/frontend-ng/src/components/Explore/EventList.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventList.vue
@@ -369,7 +369,7 @@ limitations under the License.
 
         <!-- Comment field -->
         <template v-slot:item._source.comment="{ item }">
-          <v-tooltip top open-delay="300">
+          <v-tooltip top open-delay="500">
             <template v-slot:activator="{ on }">
               <div v-on="on" class="d-inline-block">
                 <v-btn icon small @click="toggleDetailedEvent(item)" v-if="item._source.comment.length">
@@ -382,7 +382,7 @@ limitations under the License.
             <span v-if="!item['showDetails']">Open comments</span>
             <span v-if="item['showDetails']">Close comments</span>
           </v-tooltip>
-          <v-tooltip top open-delay="300">
+          <v-tooltip top open-delay="500">
             <template v-slot:activator="{ on }">
               <div v-on="on" class="d-inline-block">
                 <v-btn
@@ -397,7 +397,7 @@ limitations under the License.
             </template>
             <span>Add a comment</span>
           </v-tooltip>
-          <v-tooltip top open-delay="300">
+          <v-tooltip top open-delay="500">
             <template v-slot:activator="{ on }">
               <div v-on="on" class="d-inline-block">
                 <v-btn

--- a/timesketch/frontend-ng/src/components/Explore/EventList.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventList.vue
@@ -274,9 +274,7 @@ limitations under the License.
           <td :colspan="headers.length">
             <!-- Details -->
             <v-container v-if="item.showDetails" fluid class="mt-4">
-              <v-slide-y-transition>
-                <ts-event-detail :key="refreshComponent" :event="item"></ts-event-detail>
-              </v-slide-y-transition>
+              <ts-event-detail :showCommentsTrigger="showCommentsTrigger" :event="item"></ts-event-detail>
             </v-container>
 
             <!-- Time bubble -->
@@ -387,12 +385,32 @@ limitations under the License.
           <v-tooltip top open-delay="300">
             <template v-slot:activator="{ on }">
               <div v-on="on" class="d-inline-block">
-                <v-btn icon small @click="newComment(item)" v-if="item['showDetails'] && !item._source.comment.length">
+                <v-btn
+                  v-if="item['showDetails'] && !item._source.comment.length && !showCommentsTrigger"
+                  icon
+                  small
+                  @click="newComment(item)"
+                >
                   <v-icon> mdi-comment-plus-outline </v-icon>
                 </v-btn>
               </div>
             </template>
             <span>Add a comment</span>
+          </v-tooltip>
+          <v-tooltip top open-delay="300">
+            <template v-slot:activator="{ on }">
+              <div v-on="on" class="d-inline-block">
+                <v-btn
+                  v-if="item['showDetails'] && !item._source.comment.length && showCommentsTrigger"
+                  icon
+                  small
+                  @click="showCommentsTrigger = false"
+                >
+                  <v-icon> mdi-comment-remove-outline </v-icon>
+                </v-btn>
+              </div>
+            </template>
+            <span>Close comments</span>
           </v-tooltip>
         </template>
       </v-data-table>
@@ -516,8 +534,7 @@ export default {
       showHistogram: false,
       branchParent: null,
       sortOrderAsc: true,
-      refreshComponent: 0,
-
+      showCommentsTrigger: false,
     }
   },
   computed: {
@@ -634,7 +651,7 @@ export default {
         if (row.showDetails) {
           row['showDetails'] = false
           this.expandedRows.splice(index, 1)
-          row['showComments'] = false
+          this.showCommentsTrigger = false
         } else {
           row['showDetails'] = true
           this.expandedRows.splice(index, 1)
@@ -653,10 +670,10 @@ export default {
     },
     newComment: function (row) {
       if (row.showDetails) {
-        row['showComments'] = true
+        this.showCommentsTrigger = true
         this.refreshComponent += 1
       } else {
-        row['showComments'] = true
+        this.showCommentsTrigger = true
         this.toggleDetailedEvent(row)
       }
     },

--- a/timesketch/frontend-ng/src/components/Explore/EventList.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventList.vue
@@ -274,7 +274,9 @@ limitations under the License.
           <td :colspan="headers.length">
             <!-- Details -->
             <v-container v-if="item.showDetails" fluid class="mt-4">
-              <ts-event-detail :key="refreshComponent" :event="item"></ts-event-detail>
+              <v-slide-y-transition>
+                <ts-event-detail :key="refreshComponent" :event="item"></ts-event-detail>
+              </v-slide-y-transition>
             </v-container>
 
             <!-- Time bubble -->

--- a/timesketch/frontend-ng/src/components/Explore/EventList.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventList.vue
@@ -668,7 +668,6 @@ export default {
     newComment: function (row) {
       if (row.showDetails) {
         this.$set(row, 'showComments', true)
-        this.refreshComponent += 1
       } else {
         this.$set(row, 'showComments', true)
         this.toggleDetailedEvent(row)

--- a/timesketch/frontend-ng/src/components/Explore/EventList.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventList.vue
@@ -274,7 +274,7 @@ limitations under the License.
           <td :colspan="headers.length">
             <!-- Details -->
             <v-container v-if="item.showDetails" fluid class="mt-4">
-              <ts-event-detail :showCommentsTrigger="showCommentsTrigger" :event="item"></ts-event-detail>
+              <ts-event-detail :event="item"></ts-event-detail>
             </v-container>
 
             <!-- Time bubble -->
@@ -379,33 +379,31 @@ limitations under the License.
                 </v-btn>
               </div>
             </template>
-            <span v-if="!item['showDetails']">Open comments</span>
-            <span v-if="item['showDetails']">Close comments</span>
+            <span v-if="!item['showDetails']">Open event & comments</span>
+            <span v-if="item['showDetails']">Close event & comments</span>
           </v-tooltip>
-          <v-tooltip top open-delay="500">
+          <v-tooltip
+            v-if="item['showDetails'] && !item._source.comment.length && !item.showComments"
+            top
+            open-delay="500"
+          >
             <template v-slot:activator="{ on }">
               <div v-on="on" class="d-inline-block">
-                <v-btn
-                  v-if="item['showDetails'] && !item._source.comment.length && !showCommentsTrigger"
-                  icon
-                  small
-                  @click="newComment(item)"
-                >
+                <v-btn icon small @click="newComment(item)">
                   <v-icon> mdi-comment-plus-outline </v-icon>
                 </v-btn>
               </div>
             </template>
             <span>Add a comment</span>
           </v-tooltip>
-          <v-tooltip top open-delay="500">
+          <v-tooltip
+            v-if="item['showDetails'] && !item._source.comment.length && item.showComments"
+            top
+            open-delay="500"
+          >
             <template v-slot:activator="{ on }">
               <div v-on="on" class="d-inline-block">
-                <v-btn
-                  v-if="item['showDetails'] && !item._source.comment.length && showCommentsTrigger"
-                  icon
-                  small
-                  @click="showCommentsTrigger = false"
-                >
+                <v-btn icon small @click="item.showComments = false">
                   <v-icon> mdi-comment-remove-outline </v-icon>
                 </v-btn>
               </div>
@@ -534,7 +532,6 @@ export default {
       showHistogram: false,
       branchParent: null,
       sortOrderAsc: true,
-      showCommentsTrigger: false,
     }
   },
   computed: {
@@ -651,7 +648,7 @@ export default {
         if (row.showDetails) {
           row['showDetails'] = false
           this.expandedRows.splice(index, 1)
-          this.showCommentsTrigger = false
+          this.$set(row, 'showComments', false)
         } else {
           row['showDetails'] = true
           this.expandedRows.splice(index, 1)
@@ -670,10 +667,10 @@ export default {
     },
     newComment: function (row) {
       if (row.showDetails) {
-        this.showCommentsTrigger = true
+        this.$set(row, 'showComments', true)
         this.refreshComponent += 1
       } else {
-        this.showCommentsTrigger = true
+        this.$set(row, 'showComments', true)
         this.toggleDetailedEvent(row)
       }
     },

--- a/timesketch/frontend-ng/src/components/Explore/EventList.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventList.vue
@@ -379,8 +379,8 @@ limitations under the License.
                 </v-btn>
               </div>
             </template>
-            <span v-if="!item['showDetails']">Open event & comments</span>
-            <span v-if="item['showDetails']">Close event & comments</span>
+            <span v-if="!item['showDetails']">Open event &amp; comments</span>
+            <span v-if="item['showDetails']">Close event &amp; comments</span>
           </v-tooltip>
           <v-tooltip
             v-if="item['showDetails'] && !item._source.comment.length && !item.showComments"

--- a/timesketch/frontend-ng/src/components/Explore/EventList.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventList.vue
@@ -369,29 +369,20 @@ limitations under the License.
           <v-tooltip top open-delay="300">
             <template v-slot:activator="{ on }">
               <div v-on="on" class="d-inline-block">
-                <v-btn
-                  icon
-                  small
-                  @click="toggleDetailedEvent(item)"
-                   v-if="item._source.comment.length"
-                >
+                <v-btn icon small @click="toggleDetailedEvent(item)" v-if="item._source.comment.length">
                   <v-badge :offset-y="10" :offset-x="10" bordered :content="item._source.comment.length">
                     <v-icon small> mdi-comment-text-multiple-outline </v-icon>
                   </v-badge>
                 </v-btn>
               </div>
             </template>
-            <span>Open comments</span>
+            <span v-if="!item['showDetails']">Open comments</span>
+            <span v-if="item['showDetails']">Close comments</span>
           </v-tooltip>
           <v-tooltip top open-delay="300">
             <template v-slot:activator="{ on }">
               <div v-on="on" class="d-inline-block">
-                <v-btn
-                  icon
-                  small
-                  @click="newComment(item)"
-                  v-if="item['showDetails'] && !item._source.comment.length"
-                >
+                <v-btn icon small @click="newComment(item)" v-if="item['showDetails'] && !item._source.comment.length">
                   <v-icon> mdi-comment-plus-outline </v-icon>
                 </v-btn>
               </div>

--- a/timesketch/frontend-ng/src/components/Explore/EventList.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventList.vue
@@ -271,7 +271,7 @@ limitations under the License.
           <td :colspan="headers.length">
             <!-- Details -->
             <v-container v-if="item.showDetails" fluid class="mt-4">
-              <ts-event-detail :event="item"></ts-event-detail>
+              <ts-event-detail :key="refreshComponent" :event="item"></ts-event-detail>
             </v-container>
 
             <!-- Time bubble -->
@@ -389,7 +389,7 @@ limitations under the License.
                 <v-btn
                   icon
                   small
-                  @click="toggleDetailedEvent(item)"
+                  @click="newComment(item)"
                   v-if="item['showDetails'] && !item._source.comment.length"
                 >
                   <v-icon> mdi-comment-plus-outline </v-icon>
@@ -519,6 +519,7 @@ export default {
       },
       showHistogram: false,
       branchParent: null,
+      refreshComponent: 0,
     }
   },
   computed: {
@@ -621,6 +622,7 @@ export default {
         if (row.showDetails) {
           row['showDetails'] = false
           this.expandedRows.splice(index, 1)
+          row['showComments'] = false
         } else {
           row['showDetails'] = true
           this.expandedRows.splice(index, 1)
@@ -635,6 +637,15 @@ export default {
       } else {
         row['showDetails'] = true
         this.expandedRows.push(row)
+      }
+    },
+    newComment: function (row) {
+      if (row.showDetails) {
+        row['showComments'] = true
+        this.refreshComponent += 1
+      } else {
+        row['showComments'] = true
+        this.toggleDetailedEvent(row)
       }
     },
     addTimeBubbles: function () {


### PR DESCRIPTION
This PR will hide the comments column in the event details per default and display a new "add comments" icon on the top instead. When clicked, the user can add a comment like it used to be. 

If the event already has a comment, it will be displayed by default.

 closes #2677 