### PR TITLE
correct paramters in cli attributes method

### DIFF
--- a/cli_client/python/timesketch_cli_client/commands/attribute.py
+++ b/cli_client/python/timesketch_cli_client/commands/attribute.py
@@ -88,7 +88,7 @@ def add_attribute(ctx, name, ontology, value):
     if ctx.obj.output_format != "text":
         click.echo(f"Output format {ctx.obj.output_format} not implemented.")
         ctx.exit(1)
-    sketch.add_attribute(name, ontology, value)
+    sketch.add_attribute(name=name, value=value, ontology=ontology)
     click.echo("Attribute added:")
     click.echo(f"Name: {name}")
     click.echo(f"Ontology: {ontology}")


### PR DESCRIPTION
The current way of cli is causing a wrong attribute to be added:

```
./timesketch.par --sketch 123 --output-format text sketch attributes add --name foo --ontology intelligence --value bar
Attribute added:
Name: foo
Ontology: intelligence
Value: bar
❯ ./timesketch.par --sketch 123 --output-format json sketch attributes list
{
    "foo": {
        "ontology": "bar",
        "value": "intelligence"
    },
    "intelligence": {
        "ontology": "intelligence",
        "value": {
            "data": [
                {
                    "externalURI": "aaaa",
                    "ioc": "foo",
                    "tags": [],
                    "type": "other"
                }
            ]
        }
    }
}
```

This is the header of the function that is called:
`def add_attribute(self, name, value, ontology="text"):` 

This PR fixes that and writes the correct values.

**Closing issues**
closes #2862
