### PR TITLE
Support overriding/extending Plaso formatter definitions

### DIFF
--- a/contrib/deploy_timesketch.sh
+++ b/contrib/deploy_timesketch.sh
@@ -97,6 +97,7 @@ curl -s $GITHUB_BASE_URL/data/intelligence_tag_metadata.yaml > timesketch/etc/ti
 curl -s $GITHUB_BASE_URL/data/sigma_config.yaml > timesketch/etc/timesketch/sigma_config.yaml
 curl -s $GITHUB_BASE_URL/data/sigma_rule_status.csv > timesketch/etc/timesketch/sigma_rule_status.csv
 curl -s $GITHUB_BASE_URL/data/sigma/rules/lnx_susp_zmap.yml > timesketch/etc/timesketch/sigma/rules/lnx_susp_zmap.yml
+curl -s $GITHUB_BASE_URL/data/plaso_formatters.yaml > timesketch/etc/plaso_formatters.yaml
 curl -s $GITHUB_BASE_URL/contrib/nginx.conf > timesketch/etc/nginx.conf
 echo "OK"
 

--- a/data/plaso_formatters.yaml
+++ b/data/plaso_formatters.yaml
@@ -1,0 +1,23 @@
+# Plaso uses formatter definitions to format events into a human readable format.
+# The formatter definitions are defined in YAML and loaded by Plaso at runtime.
+# This file overrides or extend the default formatter definitions.
+# For more information about the formatter definitions see: https://plaso.readthedocs.io/en/latest/sources/user/Windows-Event-Log-Files.html#event-log-message-formatters
+
+# Windows Event Log (EVTX) formatter definition.
+type: 'conditional'
+data_type: 'windows:evtx:record'
+custom_helpers:
+  - identifier: 'windows_eventlog_message'
+    output_attribute: 'message_string'
+message:
+  - '[{event_identifier}]'
+  - '{message_string}'
+  - 'Source Name: {source_name}'
+  - 'Strings: {strings}'
+short_message:
+  - '[{event_identifier} / 0x{event_identifier:04x}]'
+  - 'Source Name: {source_name}'
+  - 'Strings: {strings}'
+  - 'Provider identifier: {provider_identifier}'
+short_source: 'EVTX'
+source: 'WinEVTX'

--- a/data/timesketch.conf
+++ b/data/timesketch.conf
@@ -164,10 +164,13 @@ UPLOAD_FOLDER = '/tmp'
 CELERY_BROKER_URL = 'redis://127.0.0.1:6379'
 CELERY_RESULT_BACKEND = 'redis://127.0.0.1:6379'
 
-# File location to store the mappings used when Elastic indices are created
+# File location to store the mappings used when OpenSearch indices are created
 # for plaso files.
 PLASO_MAPPING_FILE = '/etc/timesketch/plaso.mappings'
 GENERIC_MAPPING_FILE = '/etc/timesketch/generic.mappings'
+
+# Override/extend Plaso default message string formatters.
+PLASO_FORMATTERS = '/etc/timesketch/plaso_formatters.yaml'
 
 # Upper limits for the process memory that psort.py is allocated when ingesting
 # plaso files. The size is in bytes, with the default value of

--- a/docker/dev/build/docker-entrypoint.sh
+++ b/docker/dev/build/docker-entrypoint.sh
@@ -22,7 +22,7 @@ if [ "$1" = 'timesketch' ]; then
   ln -s /usr/local/src/timesketch/data/sigma /etc/timesketch/
   ln -s /usr/local/src/timesketch/data/scenarios /etc/timesketch/
   ln -s /usr/local/src/timesketch/data/context_links.yaml /etc/timesketch/context_links.yaml
-
+  ln -s /usr/local/src/timesketch/data/plaso_formatters.yaml /etc/timesketch/plaso_formatters.yaml
 
   # Set SECRET_KEY in /etc/timesketch/timesketch.conf if it isn't already set
   if grep -q "SECRET_KEY = '<KEY_GOES_HERE>'" /etc/timesketch/timesketch.conf; then

--- a/docker/e2e/Dockerfile
+++ b/docker/e2e/Dockerfile
@@ -44,6 +44,7 @@ RUN cp /tmp/timesketch/data/sigma_config.yaml /etc/timesketch/
 RUN cp /tmp/timesketch/data/sigma_rule_status.csv /etc/timesketch/
 RUN cp /tmp/timesketch/data/data_finder.yaml /etc/timesketch/
 RUN cp /tmp/timesketch/data/bigquery_matcher.yaml /etc/timesketch/
+RUN cp /tmp/timesketch/data/plaso_formatters.yaml /etc/timesketch/
 RUN chmod -R go+r /etc/timesketch
 
 # Copy the entrypoint script into the container

--- a/docker/release/build/cloudbuild.yaml
+++ b/docker/release/build/cloudbuild.yaml
@@ -1,4 +1,4 @@
-# Google Cloud Build configuration for Turbinia server release
+# Google Cloud Build configuration for Timesketch server release
 steps:
   - name: gcr.io/cloud-builders/docker
     args:

--- a/timesketch/lib/tasks.py
+++ b/timesketch/lib/tasks.py
@@ -715,6 +715,10 @@ def run_plaso(file_path, events, timeline_name, index_name, source_type, timelin
     if opensearch_flush_interval:
         cmd.extend(["--flush_interval", str(opensearch_flush_interval)])
 
+    plaso_formatters_file_path = current_app.config.get("PLASO_FORMATTERS", "")
+    if plaso_formatters_file_path:
+        cmd.extend(["--custom_formatter_definitions", plaso_formatters_file_path])
+
     # Run psort.py
     try:
         subprocess.check_output(cmd, stderr=subprocess.STDOUT, encoding="utf-8")


### PR DESCRIPTION
Plaso has a new feature where it is possible to provide your own formatter definition file that will override/extend the build in formatters. This enable us to alter some message strings to better align with Timesketch UX goals.

For example: We can show Event Log message strings up front whenever they are available.

closes: #2880 