### PR TITLE
Run analyzers only once per timeline

### DIFF
--- a/timesketch/api/v1/resources/analysis.py
+++ b/timesketch/api/v1/resources/analysis.py
@@ -262,6 +262,10 @@ class AnalyzerRunResource(resources.ResourceMixin, Resource):
                     "Kwargs needs to be a dictionary of parameters.",
                 )
 
+        analyzer_force_run = False
+        if form.get("analyzer_force_run"):
+            analyzer_force_run = True
+
         analyzers = []
         all_analyzers = [x for x, _ in analyzer_manager.AnalysisManager.get_analyzers()]
         for analyzer in analyzer_names:
@@ -296,6 +300,7 @@ class AnalyzerRunResource(resources.ResourceMixin, Resource):
                     analyzer_names=analyzers,
                     analyzer_kwargs=analyzer_kwargs,
                     timeline_id=timeline_id,
+                    analyzer_force_run=analyzer_force_run,
                 )
             except KeyError as e:
                 logger.warning(
@@ -308,6 +313,7 @@ class AnalyzerRunResource(resources.ResourceMixin, Resource):
                 pipeline = tasks.run_sketch_init.s([searchindex_name]) | analyzer_group
                 pipeline.apply_async()
 
-            sessions.append(session)
+            if session:
+                sessions.append(session)
 
         return self.to_json(sessions)

--- a/timesketch/frontend-ng/src/utils/RestApiClient.js
+++ b/timesketch/frontend-ng/src/utils/RestApiClient.js
@@ -311,6 +311,7 @@ export default {
     let formData = {
       timeline_ids: timelineIds,
       analyzer_names: analyzers,
+      analyzer_force_run: false,
     }
     return RestApiClient.post('/sketches/' + sketchId + /analyzer/, formData)
   },

--- a/timesketch/frontend-ng/src/utils/RestApiClient.js
+++ b/timesketch/frontend-ng/src/utils/RestApiClient.js
@@ -307,11 +307,11 @@ export default {
   getAnalyzers(sketchId) {
     return RestApiClient.get('/sketches/' + sketchId + '/analyzer/')
   },
-  runAnalyzers(sketchId, timelineIds, analyzers) {
+  runAnalyzers(sketchId, timelineIds, analyzers, forceRun = false) {
     let formData = {
       timeline_ids: timelineIds,
       analyzer_names: analyzers,
-      analyzer_force_run: false,
+      analyzer_force_run: forceRun,
     }
     return RestApiClient.post('/sketches/' + sketchId + /analyzer/, formData)
   },

--- a/timesketch/lib/tasks.py
+++ b/timesketch/lib/tasks.py
@@ -24,6 +24,7 @@ import re
 import codecs
 import io
 import json
+from hashlib import sha1
 import six
 import yaml
 
@@ -35,7 +36,6 @@ from celery import chain
 from celery import group
 from celery import signals
 from sqlalchemy import create_engine
-from hashlib import sha1
 
 # To be able to determine plaso's version.
 try:
@@ -402,6 +402,8 @@ def build_sketch_analysis_pipeline(
         if not kwargs_list:
             kwargs_list = [base_kwargs]
 
+        # Create a hash of the analyzer arguments to compare with later analyzer
+        # executions if the analyzer arguments / config changed.
         kwargs_list_hash = sha1(
             json.dumps(kwargs_list, sort_keys=True).encode("utf-8")
         ).hexdigest()
@@ -434,7 +436,7 @@ def build_sketch_analysis_pipeline(
                 sketch=sketch,
                 timeline=timeline,
             )
-            analysis.add_attribute(name='kwargs_hash', value=kwargs_list_hash)
+            analysis.add_attribute(name="kwargs_hash", value=kwargs_list_hash)
             analysis.set_status("PENDING")
             analysis_session.analyses.append(analysis)
             db_session.add(analysis)

--- a/timesketch/lib/tasks.py
+++ b/timesketch/lib/tasks.py
@@ -376,10 +376,8 @@ def build_sketch_analysis_pipeline(
     sketch = Sketch.query.get(sketch_id)
     analysis_session = AnalysisSession(user, sketch)
 
-    logger.info("TASKS: Building analysis pipeline for: {0}".format(analyzer_names))
     analyzers = manager.AnalysisManager.get_analyzers(analyzer_names)
     for analyzer_name, analyzer_class in analyzers:
-        logger.info("TASKS: running analyzer {0}".format(analyzer_name))
         base_kwargs = analyzer_kwargs.get(analyzer_name, {})
         searchindex = SearchIndex.query.get(searchindex_id)
 
@@ -407,9 +405,6 @@ def build_sketch_analysis_pipeline(
         kwargs_list_hash = sha1(
             json.dumps(kwargs_list, sort_keys=True).encode("utf-8")
         ).hexdigest()
-        logger.info(
-            "TASKS: kwargs_hash: {0}".format("kwargs_hash: " + kwargs_list_hash)
-        )
 
         if not analyzer_force_run:
             skip_analysis = False
@@ -421,9 +416,6 @@ def build_sketch_analysis_pipeline(
                 ):
                     for attribute in past_analysis.get_attributes:
                         if attribute.value == kwargs_list_hash:
-                            logger.info(
-                                "TASK: hash matched: {}".format(attribute.value)
-                            )
                             skip_analysis = True
                             break
                     if skip_analysis:

--- a/timesketch/models/sketch.py
+++ b/timesketch/models/sketch.py
@@ -580,7 +580,7 @@ class AggregationGroup(
         self.view = view
 
 
-class Analysis(LabelMixin, StatusMixin, CommentMixin, BaseModel):
+class Analysis(GenericAttributeMixin, LabelMixin, StatusMixin, CommentMixin, BaseModel):
     """Implements the analysis model."""
 
     name = Column(Unicode(255))


### PR DESCRIPTION
* Update the analyzer backend to not run an analyzer on the same timeline again by default, if the timeline was not updated and the analyzer configuration did not change.
* Update to the analyzer frontend, to let people force another run of the analyzer.
* This update will save plenty of celery task resources, since especially multi analyzers like the feature extractor are now only run once and not every time some other analyzer depends on them.

**Closing issues**
closes #2871 