### PR TITLE
Tag list refactor & bug fixes

### DIFF
--- a/timesketch/frontend-ng/src/components/Explore/SearchDropdown.vue
+++ b/timesketch/frontend-ng/src/components/Explore/SearchDropdown.vue
@@ -57,44 +57,19 @@ limitations under the License.
 
       <v-col v-if="matches.labels.length || matches.tags.length" cols="4">
         <h5 class="mt-3 ml-5">Tags</h5>
-        <v-list dense style="height: 500px" class="overflow-y-auto" :class="scrollbarTheme">
-          <v-list-item
-            v-for="label in matches.labels"
-            :key="label.label"
-            v-on:click="searchForLabel(label.label)"
-            style="font-size: 0.9em"
-          >
-            <v-icon v-if="label.label === '__ts_star'" left small color="amber">mdi-star</v-icon>
-            <v-icon v-if="label.label === '__ts_comment'" left small>mdi-comment-multiple-outline</v-icon>
-
-            <v-list-item-content>
-              <span
-                >{{ label.label | formatLabelText }}
-                <span class="font-weight-bold" style="font-size: 0.8em">({{ label.count | compactNumber }})</span></span
-              >
-            </v-list-item-content>
-          </v-list-item>
-          <v-list-item
-            v-for="tag in matches.tags"
-            :key="tag.tag"
-            v-on:click="searchForTag(tag.tag)"
-            style="font-size: 0.9em"
-          >
-            <v-list-item-content>
-              <span
-                >{{ tag.tag }}
-                <span class="font-weight-bold" style="font-size: 0.8em">({{ tag.count | compactNumber }})</span></span
-              >
-            </v-list-item-content>
-          </v-list-item>
-        </v-list>
+        <ts-tags-list></ts-tags-list>
       </v-col>
     </v-row>
   </v-card>
 </template>
 
 <script>
+import TsTagsList from '../LeftPanel/TagsList.vue'
+
 export default {
+  components: {
+    TsTagsList,
+  },
   props: ['selectedLabels', 'queryString'],
   computed: {
     meta() {
@@ -150,26 +125,6 @@ export default {
     },
   },
   methods: {
-    searchForLabel(label) {
-      let eventData = {}
-      eventData.doSearch = true
-      eventData.queryString = '*'
-      let chip = {
-        field: '',
-        value: label,
-        type: 'label',
-        operator: 'must',
-        active: true,
-      }
-      eventData.chip = chip
-      this.$emit('setQueryAndFilter', eventData)
-    },
-    searchForTag(tag) {
-      let eventData = {}
-      eventData.doSearch = true
-      eventData.queryString = 'tag:' + tag
-      this.$emit('setQueryAndFilter', eventData)
-    },
     searchForDataType(dataType) {
       let eventData = {}
       eventData.doSearch = true

--- a/timesketch/frontend-ng/src/components/LeftPanel/Tags.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/Tags.vue
@@ -16,7 +16,7 @@ limitations under the License.
 <template>
   <div>
     <div
-      :style="tags && tags.length ? 'cursor: pointer' : ''"
+      :style="tags && tags.length || labels && labels.length ? 'cursor: pointer' : ''"
       class="pa-4"
       @click="expanded = !expanded"
       :class="$vuetify.theme.dark ? 'dark-hover' : 'light-hover'"
@@ -25,43 +25,14 @@ limitations under the License.
 
       <span class="float-right" style="margin-right: 10px">
         <small
-          ><strong>{{ tags.length }}</strong></small
+          ><strong>{{ tags.length + labels.length }}</strong></small
         >
       </span>
     </div>
 
     <v-expand-transition>
-      <div v-show="expanded && tags.length">
-        <div
-          v-for="label in labels"
-          :key="label.label"
-          @click="searchForLabel(label.label)"
-          style="cursor: pointer; font-size: 0.9em"
-        >
-          <v-row no-gutters class="pa-2 pl-5" :class="$vuetify.theme.dark ? 'dark-hover' : 'light-hover'">
-            <v-icon v-if="label.label === '__ts_star'" left small color="amber">mdi-star</v-icon>
-            <v-icon v-if="label.label === '__ts_comment'" left small>mdi-comment-multiple-outline</v-icon>
-            <span>
-              {{ label.label | formatLabelText }} (<small
-                ><strong>{{ label.count | compactNumber }}</strong></small
-              >)
-            </span>
-          </v-row>
-        </div>
-        <div
-          v-for="tag in tags"
-          :key="tag.tag"
-          @click="searchForTag(tag.tag)"
-          style="cursor: pointer; font-size: 0.9em"
-        >
-          <v-row no-gutters class="pa-2 pl-5" :class="$vuetify.theme.dark ? 'dark-hover' : 'light-hover'">
-            <span
-              >{{ tag.tag }} (<small
-                ><strong>{{ tag.count | compactNumber }}</strong></small
-              >)</span
-            >
-          </v-row>
-        </div>
+      <div v-show="expanded && (tags.length || labels.length)">
+        <ts-tags-list></ts-tags-list>
       </div>
     </v-expand-transition>
     <v-divider></v-divider>
@@ -69,9 +40,12 @@ limitations under the License.
 </template>
 
 <script>
-import EventBus from '../../main'
+import TsTagsList from './TagsList.vue'
 
 export default {
+  components: {
+    TsTagsList,
+  },
   props: [],
   data: function () {
     return {
@@ -90,28 +64,6 @@ export default {
     },
     labels() {
       return this.meta.filter_labels
-    },
-  },
-  methods: {
-    searchForTag(tag) {
-      let eventData = {}
-      eventData.doSearch = true
-      eventData.queryString = 'tag:' + '"' + tag + '"'
-      EventBus.$emit('setQueryAndFilter', eventData)
-    },
-    searchForLabel(label) {
-      let eventData = {}
-      eventData.doSearch = true
-      eventData.queryString = '*'
-      let chip = {
-        field: '',
-        value: label,
-        type: 'label',
-        operator: 'must',
-        active: true,
-      }
-      eventData.chip = chip
-      EventBus.$emit('setQueryAndFilter', eventData)
     },
   },
 }

--- a/timesketch/frontend-ng/src/components/LeftPanel/TagsList.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/TagsList.vue
@@ -1,0 +1,124 @@
+<!--
+Copyright 2023 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<template>
+  <div>
+    <div
+      v-for="label in labels"
+      :key="label.label"
+      @click="applyFilterChip(term=label.label, termType='label')"
+      style="cursor: pointer; font-size: 0.9em"
+    >
+      <v-row no-gutters class="pa-2 pl-5" :class="$vuetify.theme.dark ? 'dark-hover' : 'light-hover'">
+        <v-icon v-if="label.label === '__ts_star'" left small color="amber">mdi-star</v-icon>
+        <v-icon v-if="label.label === '__ts_comment'" left small>mdi-comment-multiple-outline</v-icon>
+        <span>
+          {{ label.label | formatLabelText }} (<small
+            ><strong>{{ label.count | compactNumber }}</strong></small
+          >)
+        </span>
+      </v-row>
+    </div>
+    <div
+      v-for="tag in assignedQuickTags"
+      :key="tag.tag"
+      @click="applyFilterChip(term=tag.tag, termField='tag', termType='term')"
+      style="cursor: pointer; font-size: 0.9em"
+    >
+      <v-row no-gutters class="pa-2 pl-5" :class="$vuetify.theme.dark ? 'dark-hover' : 'light-hover'">
+        <v-icon small left :color="getQuickTag(tag.tag).color">{{ getQuickTag(tag.tag).label }}</v-icon>
+        <span
+          >{{ tag.tag }} (<small
+            ><strong>{{ tag.count | compactNumber }}</strong></small
+          >)</span
+        >
+      </v-row>
+    </div>
+    <div
+      v-for="tag in customTags"
+      :key="tag.tag"
+      @click="searchForTag(tag.tag)"
+      style="cursor: pointer; font-size: 0.9em"
+    >
+      <v-row no-gutters class="pa-2 pl-5" :class="$vuetify.theme.dark ? 'dark-hover' : 'light-hover'">
+        <span
+          >{{ tag.tag }} (<small
+            ><strong>{{ tag.count | compactNumber }}</strong></small
+          >)</span
+        >
+      </v-row>
+    </div>
+  </div>
+</template>
+
+<script>
+import EventBus from '../../main'
+
+export default {
+  props: [],
+  data: function () {
+    return {
+      // TODO: Refactor this into a configurable option
+      quickTags: [
+        { tag: 'bad', color: 'red', textColor: 'white', label: 'mdi-alert-circle-outline' },
+        { tag: 'suspicious', color: 'orange', textColor: 'white', label: 'mdi-help-circle-outline' },
+        { tag: 'good', color: 'green', textColor: 'white', label: 'mdi-check-circle-outline' },
+      ],
+    }
+  },
+  computed: {
+    meta() {
+      return this.$store.state.meta
+    },
+    tags() {
+      return this.$store.state.tags
+    },
+    labels() {
+      return this.meta.filter_labels
+    },
+    customTags() {
+      return this.tags.filter((tag) => !this.getQuickTag(tag.tag))
+    },
+    assignedQuickTags() {
+      return this.tags.filter((tag) => this.getQuickTag(tag.tag))
+    },
+  },
+  methods: {
+    getQuickTag(tag) {
+      return this.quickTags.find((el) => el.tag === tag)
+    },
+    searchForTag(tag) {
+      let eventData = {}
+      eventData.doSearch = true
+      eventData.queryString = 'tag:' + '"' + tag + '"'
+      EventBus.$emit('setQueryAndFilter', eventData)
+    },
+    applyFilterChip(term, termField='', termType='label') {
+      let eventData = {}
+      eventData.doSearch = true
+      eventData.queryString = '*'
+      let chip = {
+        field: termField,
+        value: term,
+        type: termType,
+        operator: 'must',
+        active: true,
+      }
+      eventData.chip = chip
+      EventBus.$emit('setQueryAndFilter', eventData)
+    },
+  },
+}
+</script>

--- a/timesketch/frontend-ng/src/views/Explore.vue
+++ b/timesketch/frontend-ng/src/views/Explore.vue
@@ -236,6 +236,8 @@ limitations under the License.
             <v-chip outlined close close-icon="mdi-close" @click:close="removeChip(chip)">
               <v-icon v-if="chip.value === '__ts_star'" left small color="amber">mdi-star</v-icon>
               <v-icon v-if="chip.value === '__ts_comment'" left small>mdi-comment-multiple-outline</v-icon>
+              <v-icon v-if="getQuickTag(chip.value)" left small :color="getQuickTag(chip.value).color"
+                >{{ getQuickTag(chip.value).label }}</v-icon>
               {{ chip.value | formatLabelText }}
             </v-chip>
             <v-btn v-if="index + 1 < timeFilterChips.length" icon small style="margin-top: 2px" class="mr-2">AND</v-btn>
@@ -325,6 +327,12 @@ export default {
         x: 0,
         y: 0,
       },
+      // TODO: Refactor this into a configurable option
+      quickTags: [
+        { tag: 'bad', color: 'red', textColor: 'white', label: 'mdi-alert-circle-outline' },
+        { tag: 'suspicious', color: 'orange', textColor: 'white', label: 'mdi-help-circle-outline' },
+        { tag: 'good', color: 'green', textColor: 'white', label: 'mdi-check-circle-outline' },
+      ],
     }
   },
   computed: {
@@ -351,6 +359,9 @@ export default {
     },
   },
   methods: {
+    getQuickTag(tag) {
+      return this.quickTags.find((el) => el.tag === tag)
+    },
     updateCountPerIndex: function (count) {
       this.countPerIndex = count
     },


### PR DESCRIPTION
This PR refactors the tag list to use a single separate component, which makes maintenance more easy. It also introduces some UX improvements:

* Pin quick tags on top of the list, below the labels.
* Add quick tag icons from the quicktag config.
* Apply quick tags as filter chips.

![image](https://github.com/google/timesketch/assets/99879757/9e86cde9-c200-4ec7-9b57-6e1b6d55ca66)

closes #2795 
