### PR TITLE
Event attribute include / exclude filters

### DIFF
--- a/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
@@ -59,7 +59,7 @@ limitations under the License.
                           <v-icon>mdi-filter-plus-outline</v-icon>
                         </v-btn>
                       </template>
-                      <span>'include' filter</span>
+                      <span>Filter for value</span>
                     </v-tooltip>
 
                     <!-- Exclude field:value as filter chip -->

--- a/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
@@ -75,7 +75,7 @@ limitations under the License.
                           <v-icon>mdi-filter-minus-outline</v-icon>
                         </v-btn>
                       </template>
-                      <span>'exclude' filter</span>
+                      <span>Filter out value</span>
                     </v-tooltip>
 
                     <!-- Copy field name -->

--- a/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
@@ -28,24 +28,76 @@ limitations under the License.
                   @mouseleave="c_key = -1"
                 >
                   <!-- Event field name actions -->
-                  <td v-if="key == c_key" class="text-right">
+                  <td v-if="key == c_key" class="text-right" style="min-width: 105px;">
+                    <!-- Open aggregation dialog for this field -->
+                    <v-tooltip top open-delay="500">
+                      <template v-slot:activator="{ on }">
+                        <v-btn
+                          v-if="!ignoredAggregatorFields.has(key)"
+                          @click.stop="loadAggregation(key, value)"
+                          icon
+                          x-small
+                          class="mr-1"
+                          v-on="on"
+                        >
+                          <v-icon>mdi-chart-bar</v-icon>
+                        </v-btn>
+                      </template>
+                      <span>Aggregation dialog</span>
+                    </v-tooltip>
+
+                    <!-- Include field:value as filter chip -->
+                    <v-tooltip top open-delay="500">
+                      <template v-slot:activator="{ on }">
+                        <v-btn
+                          @click.stop="applyFilterChip(key, value, 'must')"
+                          icon
+                          x-small
+                          class="mr-1"
+                          v-on="on"
+                        >
+                          <v-icon>mdi-plus</v-icon>
+                        </v-btn>
+                      </template>
+                      <span>'include' filter</span>
+                    </v-tooltip>
+
+                    <!-- Exclude field:value as filter chip -->
+                    <v-tooltip top open-delay="500">
+                      <template v-slot:activator="{ on }">
+                        <v-btn
+                          @click.stop="applyFilterChip(key, value, 'must_not')"
+                          icon
+                          x-small
+                          class="mr-1"
+                          v-on="on"
+                        >
+                          <v-icon>mdi-minus</v-icon>
+                        </v-btn>
+                      </template>
+                      <span>'exclude' filter</span>
+                    </v-tooltip>
+
                     <!-- Copy field name -->
-                    <v-btn
-                      v-if="key == c_key && key != '' && !ignoredAggregatorFields.has(key)"
-                      @click.stop="loadAggregation(key, value)"
-                      icon
-                      x-small
-                      class="mr-1"
-                    >
-                      <v-icon>mdi-chart-bar</v-icon>
-                    </v-btn>
-                    <v-btn icon x-small style="cursor: pointer" @click="copyToClipboard(key)" class="pr-1">
-                      <v-icon small>mdi-content-copy</v-icon>
-                    </v-btn>
+                    <v-tooltip top open-delay="500">
+                      <template v-slot:activator="{ on }">
+                        <v-btn
+                          icon
+                          x-small
+                          style="cursor: pointer"
+                          @click="copyToClipboard(key)"
+                          class="pr-1"
+                          v-on="on"
+                        >
+                          <v-icon small>mdi-content-copy</v-icon>
+                        </v-btn>
+                      </template>
+                      <span>copy field name</span>
+                    </v-tooltip>
                   </td>
 
                   <td v-else>
-                    <div class="px-6"></div>
+                    <div class="px-12"></div>
                   </td>
 
                   <!-- Event field name -->
@@ -157,6 +209,7 @@ limitations under the License.
 </template>
 
 <script>
+import EventBus from '../../main'
 import ApiClient from '../../utils/RestApiClient'
 import TsAggregateDialog from './AggregateDialog.vue'
 import TsFormatXmlString from './FormatXMLString.vue'
@@ -302,6 +355,19 @@ export default {
         this.errorSnackBar('Failed copying to the clipboard!')
         console.error(error)
       }
+    },
+    applyFilterChip(key, value, operator) {
+      let eventData = {}
+      eventData.doSearch = true
+      let chip = {
+        field: key,
+        value: value,
+        type: 'term',
+        operator: operator,
+        active: true,
+      }
+      eventData.chip = chip
+      EventBus.$emit('setQueryAndFilter', eventData)
     },
   },
   created: function () {

--- a/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
@@ -56,7 +56,7 @@ limitations under the License.
                           class="mr-1"
                           v-on="on"
                         >
-                          <v-icon>mdi-plus</v-icon>
+                          <v-icon>mdi-filter-plus-outline</v-icon>
                         </v-btn>
                       </template>
                       <span>'include' filter</span>
@@ -72,7 +72,7 @@ limitations under the License.
                           class="mr-1"
                           v-on="on"
                         >
-                          <v-icon>mdi-minus</v-icon>
+                          <v-icon>mdi-filter-minus-outline</v-icon>
                         </v-btn>
                       </template>
                       <span>'exclude' filter</span>

--- a/timesketch/frontend-ng/src/views/Explore.vue
+++ b/timesketch/frontend-ng/src/views/Explore.vue
@@ -236,7 +236,9 @@ limitations under the License.
             <v-chip outlined close close-icon="mdi-close" @click:close="removeChip(chip)">
               <v-icon v-if="chip.value === '__ts_star'" left small color="amber">mdi-star</v-icon>
               <v-icon v-if="chip.value === '__ts_comment'" left small>mdi-comment-multiple-outline</v-icon>
-              {{ chip.value | formatLabelText }}
+              <v-icon v-if="chip.operator === 'must' && chip.type === 'term'" left small>mdi-plus-circle-outline</v-icon>
+              <v-icon v-if="chip.operator === 'must_not' && chip.type === 'term'" left small>mdi-minus-circle-outline</v-icon>
+              {{ (chip.field ? `${chip.field} : ${chip.value}` : chip.value) | formatLabelText }}
             </v-chip>
             <v-btn v-if="index + 1 < timeFilterChips.length" icon small style="margin-top: 2px" class="mr-2">AND</v-btn>
           </span>
@@ -367,7 +369,9 @@ export default {
       if (this.$route.name !== 'Explore') {
         this.$router.push({ name: 'Explore', params: { sketchId: this.sketch.id } })
       }
-      this.currentQueryString = searchEvent.queryString
+      if (searchEvent.queryString) {
+        this.currentQueryString = searchEvent.queryString
+      }
 
       // Preserve user defined filter instead of resetting, if it exist.
       if (!searchEvent.queryFilter) {

--- a/timesketch/frontend-ng/src/views/Explore.vue
+++ b/timesketch/frontend-ng/src/views/Explore.vue
@@ -233,16 +233,23 @@ limitations under the License.
       <div v-if="filterChips.length" class="mt-1">
         <v-chip-group column>
           <span v-for="(chip, index) in filterChips" :key="index + chip.value">
-            <v-chip outlined close close-icon="mdi-close" @click:close="removeChip(chip)">
-              <v-icon v-if="chip.value === '__ts_star'" left small color="amber">mdi-star</v-icon>
-              <v-icon v-if="chip.value === '__ts_comment'" left small>mdi-comment-multiple-outline</v-icon>
-              <v-icon v-if="chip.operator === 'must' && chip.type === 'term'" left small>mdi-plus-circle-outline</v-icon>
-              <v-icon v-if="chip.operator === 'must_not' && chip.type === 'term'" left small>mdi-minus-circle-outline</v-icon>
-              {{ (chip.field ? `${chip.field} : ${chip.value}` : chip.value) | formatLabelText }}
-              <v-icon v-if="getQuickTag(chip.value)" left small :color="getQuickTag(chip.value).color"
-                >{{ getQuickTag(chip.value).label }}</v-icon>
-              {{ chip.value | formatLabelText }}
-            </v-chip>
+            <v-tooltip top :disabled="chip.value.length < 33" open-delay="300">
+              <template v-slot:activator="{ on: onTooltip, attrs }">
+              <v-chip outlined close close-icon="mdi-close" @click:close="removeChip(chip)" v-bind="attrs" v-on="onTooltip">
+                <v-icon v-if="chip.value === '__ts_star'" left small color="amber">mdi-star</v-icon>
+                <v-icon v-if="chip.value === '__ts_comment'" left small>mdi-comment-multiple-outline</v-icon>
+                <v-icon v-if="getQuickTag(chip.value)" left small :color="getQuickTag(chip.value).color"
+                  >{{ getQuickTag(chip.value).label }}</v-icon>
+                <span v-if="chip.operator === 'must_not' && chip.type === 'term'">
+                  <span style="color: red;">NOT </span>{{ (chip.field ? `${chip.field} : ${getTruncatedString(chip.value)}` : getTruncatedString(chip.value)) | formatLabelText }}
+                </span>
+                <span v-else>
+                  {{ (chip.field ? `${chip.field} : ${getTruncatedString(chip.value)}` : getTruncatedString(chip.value)) | formatLabelText }}
+                </span>
+              </v-chip>
+              </template>
+              <span>{{ chip.value }}</span>
+            </v-tooltip>
             <v-btn v-if="index + 1 < timeFilterChips.length" icon small style="margin-top: 2px" class="mr-2">AND</v-btn>
           </span>
         </v-chip-group>
@@ -362,6 +369,12 @@ export default {
     },
   },
   methods: {
+    getTruncatedString(value) {
+      if (value.length > 33) {
+        return value.substring(0, 30) + '...'
+      }
+      return value
+    },
     getQuickTag(tag) {
       return this.quickTags.find((el) => el.tag === tag)
     },


### PR DESCRIPTION
This PR ports over the include & exclude feature for event attributes from the old UI. It also updates the formatting and handling of search queries when filter chips are applied.

![image](https://github.com/google/timesketch/assets/99879757/fb240667-597b-4a4c-9793-0bf5ac2c9392)


I think this should close the issue below: 
closes #2573 