### PR TITLE
Fix CSV upload without timestamp_desc

### DIFF
--- a/timesketch/frontend-ng/src/components/UploadForm.vue
+++ b/timesketch/frontend-ng/src/components/UploadForm.vue
@@ -174,6 +174,7 @@ export default {
       mandatoryHeaders: [
         { name: 'datetime', columnsSelected: [] },
         { name: 'message', columnsSelected: [] },
+        { name: 'timestamp_desc', columnsSelected: [] },
       ],
       form: {
         name: '',


### PR DESCRIPTION
The `timestamp_desc` field is a mandatory field for all Timesketch data. However, when uploading via the web UI the upload form did not trigger the mapping functionality when the `timestamp_desc` field was missing. This resulted in a broken timeline with the error: 

> Error message: Missing mandatory CSV headers.
> Mandatory headers: datetime, message, timestamp_desc
> Headers found in the file: datetime, timestamp, packages, message, command, display_name, timestamp_descA, parser, filename, data_type, extra_field_1
> Headers provided in the mapping: None
> Headers missing: timestamp_desc


This PR adds `timestamp_desc` to the mandatory fields wich will therefore trigger the mapping feature in the upload dialog if the field is missing.

**Closing issues**

closes #2630 
