### PR TITLE
Refactor base layout

### DIFF
--- a/timesketch/frontend-ng/src/App.vue
+++ b/timesketch/frontend-ng/src/App.vue
@@ -23,10 +23,8 @@ limitations under the License.
       </template>
     </v-snackbar>
 
-    <v-main class="notransition">
-      <!-- Main view -->
-      <router-view></router-view>
-    </v-main>
+    <!-- Main router view -->
+    <router-view></router-view>
   </v-app>
 </template>
 

--- a/timesketch/frontend-ng/src/components/LeftPanel/Search.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/Search.vue
@@ -1,0 +1,49 @@
+<!--
+Copyright 2023 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<template>
+  <div>
+    <router-link
+      :to="{ name: 'Explore', params: { sketchId: sketchId } }"
+      custom
+      v-slot="{ navigate }"
+      class="pa-4"
+      :class="
+        $vuetify.theme.dark
+          ? isExploreRoute
+            ? 'dark-highlight'
+            : 'dark-hover'
+          : isExploreRoute
+          ? 'light-highlight'
+          : 'light-hover'
+      "
+      style="cursor: pointer"
+    >
+      <div @click="navigate" @keypress.enter="navigate" role="link"><v-icon left>mdi-magnify</v-icon> Search</div>
+    </router-link>
+    <v-divider></v-divider>
+  </div>
+</template>
+
+<script>
+export default {
+  computed: {
+    isExploreRoute() {
+      return this.$route.name === 'Explore'
+    },
+  },
+}
+</script>
+

--- a/timesketch/frontend-ng/src/router.js
+++ b/timesketch/frontend-ng/src/router.js
@@ -72,13 +72,6 @@ const routes = [
         ]
       },
       {
-        path: 'sigma/edit',
-        name: 'SigmaEdit',
-        component: Canvas,
-        props: true,
-      },
-
-      {
         path: 'graph',
         name: 'Graph',
         component: Canvas,

--- a/timesketch/frontend-ng/src/views/Home.vue
+++ b/timesketch/frontend-ng/src/views/Home.vue
@@ -66,35 +66,38 @@ limitations under the License.
       </v-menu>
     </v-toolbar>
 
-    <v-container fluid pa-0>
-      <v-sheet class="pa-5" :color="$vuetify.theme.dark ? 'grey darken-4' : 'grey lighten-3'" min-height="200">
-        <h2>Start new investigation</h2>
-        <v-row no-gutters class="mt-5">
-          <v-dialog v-model="createSketchDialog" width="500">
-            <template v-slot:activator="{ on, attrs }">
-              <v-btn depressed small class="mr-5" color="primary" v-bind="attrs" v-on="on"> Blank sketch </v-btn>
-            </template>
-            <v-card class="pa-4">
-              <h3>New sketch</h3>
-              <br />
-              <v-form @submit.prevent="createSketch()">
-                <v-text-field v-model="sketchForm.name" outlined dense placeholder="Name your sketch" autofocus>
-                </v-text-field>
-                <v-card-actions>
-                  <v-spacer></v-spacer>
-                  <v-btn text @click="createSketchDialog = false"> Cancel </v-btn>
-                  <v-btn :disabled="!sketchForm.name" @click="createSketch()" color="primary" text> Create </v-btn>
-                </v-card-actions>
-              </v-form>
-            </v-card>
-          </v-dialog>
-        </v-row>
-      </v-sheet>
-      <div class="pa-5">
-        <h2>Your recent work</h2>
-        <ts-sketch-list></ts-sketch-list>
-      </div>
-    </v-container>
+    <!-- Main view -->
+    <v-main class="notransition">
+      <v-container fluid pa-0>
+        <v-sheet class="pa-5" :color="$vuetify.theme.dark ? 'grey darken-4' : 'grey lighten-3'" min-height="200">
+          <h2>Start new investigation</h2>
+          <v-row no-gutters class="mt-5">
+            <v-dialog v-model="createSketchDialog" width="500">
+              <template v-slot:activator="{ on, attrs }">
+                <v-btn depressed small class="mr-5" color="primary" v-bind="attrs" v-on="on"> Blank sketch </v-btn>
+              </template>
+              <v-card class="pa-4">
+                <h3>New sketch</h3>
+                <br />
+                <v-form @submit.prevent="createSketch()">
+                  <v-text-field v-model="sketchForm.name" outlined dense placeholder="Name your sketch" autofocus>
+                  </v-text-field>
+                  <v-card-actions>
+                    <v-spacer></v-spacer>
+                    <v-btn text @click="createSketchDialog = false"> Cancel </v-btn>
+                    <v-btn :disabled="!sketchForm.name" @click="createSketch()" color="primary" text> Create </v-btn>
+                  </v-card-actions>
+                </v-form>
+              </v-card>
+            </v-dialog>
+          </v-row>
+        </v-sheet>
+        <div class="pa-5">
+          <h2>Your recent work</h2>
+          <ts-sketch-list></ts-sketch-list>
+        </div>
+      </v-container>
+    </v-main>
   </div>
 </template>
 

--- a/timesketch/frontend-ng/src/views/Sketch.vue
+++ b/timesketch/frontend-ng/src/views/Sketch.vue
@@ -247,17 +247,7 @@ limitations under the License.
       <v-divider></v-divider>
       <v-tabs-items v-model="leftPanelTab">
         <v-tab-item :transition="false">
-          <router-link
-            :to="{ name: 'Explore', params: { sketchId: sketchId } }"
-            tag="div"
-            class="pa-4"
-            style="cursor: pointer"
-            :class="$vuetify.theme.dark ? 'dark-hover' : 'light-hover'"
-          >
-            <span> <v-icon left>mdi-magnify</v-icon> Search </span>
-          </router-link>
-          <v-divider></v-divider>
-
+          <ts-search></ts-search>
           <ts-saved-searches v-if="meta.views"></ts-saved-searches>
           <ts-data-types></ts-data-types>
           <ts-tags></ts-tags>
@@ -376,6 +366,7 @@ import TsSigmaRules from '../components/LeftPanel/SigmaRules'
 import TsIntelligence from '../components/LeftPanel/ThreatIntel'
 import TsGraphs from '../components/LeftPanel/Graphs'
 import TsStories from '../components/LeftPanel/Stories'
+import TsSearch from '../components/LeftPanel/Search'
 import TsUploadTimelineForm from '../components/UploadForm'
 import TsShareCard from '../components/ShareCard'
 import TsRenameSketch from '../components/RenameSketch'
@@ -397,6 +388,7 @@ export default {
     TsIntelligence,
     TsGraphs,
     TsStories,
+    TsSearch,
     TsAnalyzerResults,
     TsEventList,
   },


### PR DESCRIPTION
This PR cleans up our base layout, moving the nav drawer (left pane) under the main bar. This gives us a correct way to use the layout system. Earlier we were using the `app` parameter on the drawer and the top bar inside of the `v-main` element and this is discoraged by the framework and can introduce subtle bugs.

* Move top bar and left panel outside of the main component
* Each root component view (home and sketch) implements the top bar and left panel
* Removed the `Back to explore` button and added a section in the left panel at the top called `Search` that will always take you back to the main search interface.

<img width="1788" alt="Screenshot 2023-10-09 at 12 37 41" src="https://github.com/google/timesketch/assets/316362/542a6b48-1ca0-4879-9dcf-082df5787a57">
