### PR TITLE
Fix #2908 tagger bug

### DIFF
--- a/timesketch/lib/analyzers/tagger.py
+++ b/timesketch/lib/analyzers/tagger.py
@@ -126,7 +126,8 @@ class TaggerSketchPlugin(interface.BaseAnalyzer):
             for attribute in dynamic_tags:
                 tag_value = event.source.get(attribute)
                 for mod in config.get("modifiers", []):
-                    tag_value = self.MODIFIERS[mod](tag_value)
+                    if isinstance(tag_value, str):
+                        tag_value = self.MODIFIERS[mod](tag_value)
                 if isinstance(tag_value, Iterable):
                     dynamic_tag_values.extend(tag_value)
                 else:


### PR DESCRIPTION
This PR fixes a bug in the `tagger.py` analyzer when it comes to splitting a list of tags. In the past those tags were displayed as a string but now they also can be a list. 
Therefore the split modifier is optional.

**Closing issues**

closes #2908 
