### PR TITLE
Truncate timeline names in analyzer results

### DIFF
--- a/timesketch/frontend-ng/src/components/LeftPanel/AnalyzerResultTimeline.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/AnalyzerResultTimeline.vue
@@ -23,7 +23,7 @@ limitations under the License.
       :class="getHoverTheme"
     >
       <v-icon class="mr-2" :color="'#' + timeline.color">mdi-circle</v-icon>
-      <span class="mr-2" style="color: grey">{{ timeline.name }}</span>
+      <span class="mr-2 timeline-name-ellipsis" style="color: grey; width:82% !important;">{{ timeline.name }}</span>
       <v-progress-circular :size="20" :width="1" indeterminate color="primary"></v-progress-circular>
     </div>
     <div
@@ -34,7 +34,7 @@ limitations under the License.
       :class="getHoverTheme"
     >
       <v-icon class="mr-2" :color="'#' + timeline.color">mdi-circle</v-icon>
-      <span>{{ timeline.name }}</span>
+      <span class="timeline-name-ellipsis" style="width:82% !important;">{{ timeline.name }}</span>
       <div v-if="timeline.analysis_status === 'ERROR'">
         <v-tooltip top>
           <template v-slot:activator="{ on }">


### PR DESCRIPTION
The timeline names in the analyzer results at the left panel were not truncated according to the width of the left panel. 
This PR adds this feature using CSS.

**Closing issues**

closes #2925 

**Screenshot**
![image](https://github.com/google/timesketch/assets/99879757/4de2b12f-0b96-4d13-8add-004aa1bfb7aa)
