### PR TITLE
Fix missing sketchId in Search.vue

### DIFF
--- a/timesketch/frontend-ng/src/components/LeftPanel/Search.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/Search.vue
@@ -43,6 +43,9 @@ export default {
     isExploreRoute() {
       return this.$route.name === 'Explore'
     },
+    sketchId() {
+      return this.$store.state.sketch.id
+    }
   },
 }
 </script>


### PR DESCRIPTION
There was a small uncaught error introduced with PR #2929 where `Search.vue` does not have `sketchId` defined. This PR fixes this issue.

![image](https://github.com/google/timesketch/assets/99879757/b132e098-f162-46f9-94ab-a135b1e41869)
