### PR TITLE
bug-fix for context links

### DIFF
--- a/data/context_links.yaml
+++ b/data/context_links.yaml
@@ -80,9 +80,8 @@ hardcoded_modules:
 ## External Services
 linked_services:
 ### Virustotal Example:
-  # virustotal_hash_lookup:
-  #   short_name: 'VirusTotal'
-  #   match_fields: ['hash', 'sha256_hash', 'sha256', 'sha1_hash', 'sha1', 'md5_hash', 'md5', 'url']
-  #   validation_regex: '/^[0-9a-f]{64}$|^[0-9a-f]{40}$|^[0-9a-f]{32}$/i'
-  #   context_link: 'https://www.virustotal.com/gui/search/<ATTR_VALUE>'
-  #   redirect_warning: TRUE
+  virustotal_hash_lookup:
+    short_name: 'VirusTotal'
+    match_fields: ['hash', 'sha256_hash', 'sha256', 'sha1_hash', 'sha1', 'md5_hash', 'md5']
+    context_link: 'https://www.virustotal.com/gui/search/<ATTR_VALUE>'
+    redirect_warning: TRUE

--- a/timesketch/api/v1/resources/contextlinks.py
+++ b/timesketch/api/v1/resources/contextlinks.py
@@ -48,7 +48,7 @@ class ContextLinkConfigResource(resources.ResourceMixin, Resource):
             return jsonify(response)
 
         # Support for earlier version format of context links without hardcoded modules:
-        if not context_link_yaml.get("linked_services"):
+        if not "linked_services" in context_link_yaml.keys():
             context_link_yaml = {
                 "linked_services": context_link_yaml,
             }

--- a/timesketch/api/v1/resources/contextlinks.py
+++ b/timesketch/api/v1/resources/contextlinks.py
@@ -48,7 +48,7 @@ class ContextLinkConfigResource(resources.ResourceMixin, Resource):
             return jsonify(response)
 
         # Support for earlier version format of context links without hardcoded modules:
-        if not "linked_services" in context_link_yaml.keys():
+        if 'linked_services' not in context_link_yaml.keys():
             context_link_yaml = {
                 "linked_services": context_link_yaml,
             }

--- a/timesketch/api/v1/resources/contextlinks.py
+++ b/timesketch/api/v1/resources/contextlinks.py
@@ -48,7 +48,7 @@ class ContextLinkConfigResource(resources.ResourceMixin, Resource):
             return jsonify(response)
 
         # Support for earlier version format of context links without hardcoded modules:
-        if 'linked_services' not in context_link_yaml.keys():
+        if "linked_services" not in context_link_yaml.keys():
             context_link_yaml = {
                 "linked_services": context_link_yaml,
             }

--- a/timesketch/frontend-ng/src/components/Explore/UnfurlDialog.vue
+++ b/timesketch/frontend-ng/src/components/Explore/UnfurlDialog.vue
@@ -17,12 +17,11 @@ limitations under the License.
     </v-toolbar>
 
     <v-card-subtitle class="pt-1">
-      <div class="mb-2"><b>Input:</b> {{ url }}</div>
-      <div v-if="nodeContext">
+      <div class="mb-2"><b>Input: </b><code class="code">{{ url }}</code></div>
+      <div v-if="unfurlReady">
         <b>Selected node info: </b>
-        <span v-html="sanitizeHtml(nodeContext)"></span>
+        <code class="code" v-html="sanitizeHtml(nodeContext)"></code>
       </div>
-      <div v-else>Select a node in the graph below to get more information.</div>
     </v-card-subtitle>
 
     <v-card-text>
@@ -260,6 +259,7 @@ export default {
   mounted() {
     window.addEventListener('resize', this.resizeCanvasWithDelay)
     this.unfurlReady = false
+    this.nodeContext = this.nodeContextDefault
     this.getUnfurlData(this.url)
     this.cy = cytoscape({
       container: this.$refs.cy,


### PR DESCRIPTION
This PR fixes some minor bugs introduced in the new context link handling and with the unfurl dialog UI.
* Activate context link VT hash lookup by default in the configuration for a better user experience.
  * This will also prevent new Timesketch setups with v20231025 to crash the `contextlinks.py` api endpoint. 
* Fix a bug in the `contextlinks.py` API endpoint. When the new configuration was applied but no `linked_service` was defined, the API endpoint threw an exception!
* Fix UI bug and formatting in the unfurl dialog. 
  * The unfurl dialog now shows the call to action `Select a node in the graph below to get more information.` only after the graph loaded successfully.
  * The Node context and input URL are now displayed as code blocks for better readability and consistency with the redirect warning dialog URLs.