### PR TITLE
Adjust default example text for yeti endpoint

### DIFF
--- a/data/timesketch.conf
+++ b/data/timesketch.conf
@@ -254,7 +254,7 @@ SAFEBROWSING_THREATTYPES = ['MALWARE']
 # HASHR_ADD_SOURCE_ATTRIBUTE = True
 
 # Threatintel Yeti analyzer-specific configuration
-# URI root to Yeti's API, e.g. 'https://localhost:8080/api'
+# URI root to Yeti's API, e.g. 'https://localhost:8000/api/v2'
 YETI_API_ROOT = ''
 
 # API key to authenticate requests


### PR DESCRIPTION
Small example text adjustment in timesketch.conf

hopefully fixes https://github.com/google/timesketch/issues/2953