### PR TITLE
"Add to Threat Intelligence" via context links

### DIFF
--- a/data/context_links.yaml
+++ b/data/context_links.yaml
@@ -77,6 +77,29 @@ hardcoded_modules:
       - uri
       - original_url
 
+### Add Threat Intel
+  threat_intel:
+    short_name: 'Add to Threat Intel'
+    match_fields:
+      - url
+      - uri
+      - original_url
+      - ip
+      - ip_address
+      - domain
+      - domain_name
+      - host
+      - hostname
+      - email
+      - email_address
+      - hash
+      - sha256_hash
+      - sha256
+      - sha1_hash
+      - sha1
+      - md5_hash
+      - md5
+
 ## External Services
 linked_services:
 ### Virustotal Example:

--- a/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
@@ -324,6 +324,10 @@ export default {
               this.contextValue = value
               return
             }
+            if (confItem['module'] === 'threat_intel') {
+              EventBus.$emit('addIndicator', value)
+              return
+            }
           } else {
             if (confItem['redirect_warning']) {
               this.redirectWarnDialog = true

--- a/timesketch/frontend-ng/src/components/ThreatIntel/IndicatorDialog.vue
+++ b/timesketch/frontend-ng/src/components/ThreatIntel/IndicatorDialog.vue
@@ -53,7 +53,7 @@ const newIndicator = () => {
 }
 
 export default {
-  props: ['dialog', 'tagInfo', 'index'],
+  props: ['dialog', 'tagInfo', 'index', 'ioc'],
   data() {
     return {
       IOCTypes: IOCTypes,
@@ -85,6 +85,9 @@ export default {
   },
   methods: {
     closeDialog: function () {
+      if (this.index < 0) {
+        this.newIndicator.ioc = ''
+      }
       this.$emit('close-dialog')
     },
     autoSelectIndicatorType: function (value) {
@@ -109,6 +112,12 @@ export default {
         this.newIndicator = this.intelligenceAttribute.value.data[this.index]
       }
     },
+    ioc() {
+      if (this.ioc !== '') {
+        this.newIndicator.ioc = this.ioc
+        this.autoSelectIndicatorType(this.ioc)
+      }
+    }
   },
 }
 </script>

--- a/timesketch/frontend-ng/src/views/ThreatIntel.vue
+++ b/timesketch/frontend-ng/src/views/ThreatIntel.vue
@@ -19,6 +19,7 @@ limitations under the License.
       :dialog.sync="indicatorDialog"
       :index="currentIndex"
       :tag-info="tagInfo"
+      :ioc="indicator"
       @open-dialog="indicatorDialog = true"
       @close-dialog="
         indicatorDialog = false
@@ -117,6 +118,7 @@ export default {
       tagInfo: {},
       indicatorDialog: false,
       currentIndex: -1,
+      indicator: '',
     }
   },
   computed: {
@@ -227,8 +229,9 @@ export default {
           console.error(e)
         })
     },
-    showIndicatorDialog() {
-      this.indicatorDialog = true
+    showIndicatorDialog(payload) {
+        this.indicator = payload
+        this.indicatorDialog = true
     },
   },
   mounted() {


### PR DESCRIPTION
This PR adds the functionality for context links to add a `value` to the Threat Intelligence collection in Timesketch directly from the event details.

See the GIF below for a demo:
![Send2TIDemo](https://github.com/google/timesketch/assets/99879757/4a3739ec-9657-412f-9aa9-fae39a1f10b9)

**Closing issues**
closes #2453 
