### PR TITLE
Fix vue dependency issues with "v-calendar"

### DIFF
--- a/timesketch/frontend-ng/package.json
+++ b/timesketch/frontend-ng/package.json
@@ -20,7 +20,7 @@
     "lodash": "^4.17.11",
     "marked": ">=2.0.0 <5.0.0",
     "moment": "^2.24.0",
-    "v-calendar": "^2.4.0",
+    "v-calendar": "2.4.1",
     "vega": "^5.4.0",
     "vega-embed": "^4.2.2",
     "vega-lite": "3.4.0",


### PR DESCRIPTION
This PR is pinning the `v-calendar` version to `2.4.1` to fix dependency issues described in #2988 and https://github.com/google/timesketch/discussions/2987 .

**Closing issues**

closes #2988
