### PR TITLE
Fix error handling in the API client

### DIFF
--- a/api_client/python/timesketch_api_client/client.py
+++ b/api_client/python/timesketch_api_client/client.py
@@ -368,23 +368,22 @@ class TimesketchApi:
             Dictionary with the response data.
 
         Raises:
-            RuntimeError: If response could not be JSON-decoded after
-                DEFAULT_RETRY_COUNT attempts.
+            RuntimeError: If response cannot be interpreted or is empty.
         """
         resource_url = "{0:s}/{1:s}".format(self.api_root, resource_uri)
         response = self.session.get(resource_url, params=params)
 
-        retry_count = 0
-        while True:
-            result = error.get_response_json(response, logger)
-            # Any dict with content is good enough for us to return.
-            if result:
-                return result
-            retry_count += 1
-            if retry_count >= self.DEFAULT_RETRY_COUNT:
-                raise RuntimeError(
-                    f"Unable to fetch JSON resource data. Response: {str(result)}"
-                )
+        result = error.get_response_json(response, logger, url=resource_url)
+        if result:
+            return result
+        else:
+            error.error_message(
+                response,
+                message="The response for the URL '{0:s}' returned by the "
+                "Timesketch API was empty or false. Result: '{1:s}'".format(
+                    resource_url, result
+                ),
+            )
 
     def create_sketch(self, name, description=None):
         """Create a new sketch.

--- a/api_client/python/timesketch_api_client/error.py
+++ b/api_client/python/timesketch_api_client/error.py
@@ -70,36 +70,34 @@ def _get_reason(response):
     return reason
 
 
-def get_response_json(response, logger, url=None):
+def get_response_json(response, logger):
     """Return the JSON object from a response, logging any errors.
 
     Args:
-        response (requests.Response): a response object from a HTTP
-            request.
-        logger (logging.Logger): a logger object that can be used to
-            write log messages.
-        url (String): The url used for the request.
+        response (requests.Response): a response object from a HTTP request.
+        logger (logging.Logger): a logger object that can be used to write log
+          messages.
 
     Returns:
         dict: a dict with the decoded JSON object within the HTTP
             response object.
+
+    Raises:
+        RuntimeError: if the API returns an HTTP error.
+        ValueError: if the API response cannot be JSON decoded.
     """
     status = response.status_code in definitions.HTTP_STATUS_CODE_20X
     if not status:
         error_message(
             response,
-            message="Error response from the Timesketch API for request: "
-            "'{0:s}'".format(url),
+            message=("Failed to get a valid response json from Timesketch API"),
         )
 
     try:
         return response.json()
     except json.JSONDecodeError as e:
-        logger.error("Unable to decode response: {0!s}".format(e), exc_info=True)
-        raise RuntimeError(
-            "Unable to json decode the Timesketch API response for request "
-            "'{0:s}'! JSONDecodeError: {1!s}".format(url, e)
-        )
+        logger.warning("Unable to json decode the Timesketch API response!")
+        raise ValueError("Unable to json decode the Timesketch API response!") from e
 
 
 def error_message(response, message=None, error=RuntimeError):

--- a/api_client/python/timesketch_api_client/error.py
+++ b/api_client/python/timesketch_api_client/error.py
@@ -70,7 +70,7 @@ def _get_reason(response):
     return reason
 
 
-def get_response_json(response, logger):
+def get_response_json(response, logger, url=None):
     """Return the JSON object from a response, logging any errors.
 
     Args:
@@ -78,6 +78,7 @@ def get_response_json(response, logger):
             request.
         logger (logging.Logger): a logger object that can be used to
             write log messages.
+        url (String): The url used for the request.
 
     Returns:
         dict: a dict with the decoded JSON object within the HTTP
@@ -85,19 +86,20 @@ def get_response_json(response, logger):
     """
     status = response.status_code in definitions.HTTP_STATUS_CODE_20X
     if not status:
-        reason = _get_reason(response)
-        logger.warning(
-            "Failed response: [{0:d}] {2:s} {1:s}".format(
-                response.status_code, reason, _get_message(response)
-            )
+        error_message(
+            response,
+            message="Error response from the Timesketch API for request: "
+            "'{0:s}'".format(url),
         )
 
     try:
         return response.json()
     except json.JSONDecodeError as e:
         logger.error("Unable to decode response: {0!s}".format(e), exc_info=True)
-
-    return {}
+        raise RuntimeError(
+            "Unable to json decode the Timesketch API response for request "
+            "'{0:s}'! JSONDecodeError: {1!s}".format(url, e)
+        )
 
 
 def error_message(response, message=None, error=RuntimeError):


### PR DESCRIPTION
This PR is an attempt to fix the error handling in the API client when requesting API resources.
* If the API returns any other status than `20X` (variations of OK), raise an error. 
* If the API client cannot json decode the API response, raise an error.
* The function `get_response_json()` now does not return empty dicts on error anymore, which was unexpected by users.
* Fixed the API client side re-try.
* The user now can handle the raised errors e.g. by sleep & retry.


