### PR TITLE
Fix: get and use access token for Yeti

### DIFF
--- a/timesketch/lib/analyzers/yetiindicators.py
+++ b/timesketch/lib/analyzers/yetiindicators.py
@@ -84,13 +84,13 @@ class YetiIndicators(interface.BaseAnalyzer):
                 "hops": 1,
                 "direction": "any",
                 "include_original": False,
-            }
+            },
         )
         if results.status_code != 200:
             return []
         neighbors = []
         for neighbor in results.json().get("vertices", {}).values():
-            if neighbor['root_type'] == 'entity':
+            if neighbor["root_type"] == "entity":
                 neighbors.append(neighbor)
         return neighbors
 
@@ -183,7 +183,7 @@ class YetiIndicators(interface.BaseAnalyzer):
             events = self.event_stream(query_dsl=query_dsl, return_fields=["message"])
             neighbors = self.get_neighbors(indicator)
             for n in neighbors:
-                if n['root_type'] == 'entity':
+                if n["root_type"] == "entity":
                     entities_found.add(f"{n['name']}:{n['type']}")
 
             uri = f"{self.yeti_web_root}/indicators/{indicator['id']}"

--- a/timesketch/lib/analyzers/yetiindicators.py
+++ b/timesketch/lib/analyzers/yetiindicators.py
@@ -38,6 +38,33 @@ class YetiIndicators(interface.BaseAnalyzer):
         self.yeti_api_root = root
         self.yeti_web_root = root.replace("/api/v2", "")
         self.yeti_api_key = current_app.config.get("YETI_API_KEY")
+        self._yeti_session = requests.Session()
+
+    @property
+    def authenticated_session(self) -> requests.Session:
+        """Returns a requests.Session object with an authenticated Yeti session.
+
+        Returns:
+          A requests.Session object with an authenticated Yeti session.
+        """
+        if not self._yeti_session.headers.get("authorization"):
+            self.authenticate_session()
+        return self._yeti_session
+
+    def authenticate_session(self) -> None:
+        """Fetches an access token for Yeti."""
+
+        response = requests.post(
+            f"{self.yeti_api_root}/auth/api-token",
+            headers={"x-yeti-apikey": self.yeti_api_key},
+        )
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"Error {response.status_code} authenticating with Yeti API"
+            )
+
+        access_token = response.json()["access_token"]
+        self._yeti_session.headers.update({"authorization": f"Bearer {access_token}"})
 
     def get_neighbors(self, yeti_object: Dict) -> List[Dict]:
         """Retrieves a list of neighbors associated to a given entity.
@@ -49,7 +76,7 @@ class YetiIndicators(interface.BaseAnalyzer):
           A list of JSON objects describing a Yeti entity.
         """
         extended_id = f"{yeti_object['root_type']}/{yeti_object['id']}"
-        results = requests.post(
+        results = self.authenticated_session.post(
             f"{self.yeti_api_root}/graph/search",
             json={
                 "source": extended_id,
@@ -57,15 +84,14 @@ class YetiIndicators(interface.BaseAnalyzer):
                 "hops": 1,
                 "direction": "any",
                 "include_original": False,
-            },
-            headers={"X-Yeti-API": self.yeti_api_key},
+            }
         )
         if results.status_code != 200:
             return []
         neighbors = []
         for neighbor in results.json().get("vertices", {}).values():
-            neighbors.append(neighbor)
-
+            if neighbor['root_type'] == 'entity':
+                neighbors.append(neighbor)
         return neighbors
 
     def get_indicators(self, indicator_type: str) -> Dict[str, dict]:
@@ -75,10 +101,9 @@ class YetiIndicators(interface.BaseAnalyzer):
             A dictionary of indicators obtained from yeti, keyed by indicator
             ID.
         """
-        response = requests.post(
+        response = self.authenticated_session.post(
             self.yeti_api_root + "/indicators/search",
             json={"query": {"name": ""}, "type": indicator_type},
-            headers={"X-Yeti-API": self.yeti_api_key},
         )
         data = response.json()
         if response.status_code != 200:
@@ -157,9 +182,9 @@ class YetiIndicators(interface.BaseAnalyzer):
 
             events = self.event_stream(query_dsl=query_dsl, return_fields=["message"])
             neighbors = self.get_neighbors(indicator)
-
             for n in neighbors:
-                entities_found.add(f"{n['name']}:{n['type']}")
+                if n['root_type'] == 'entity':
+                    entities_found.add(f"{n['name']}:{n['type']}")
 
             uri = f"{self.yeti_web_root}/indicators/{indicator['id']}"
 

--- a/timesketch/lib/analyzers/yetiindicators_test.py
+++ b/timesketch/lib/analyzers/yetiindicators_test.py
@@ -16,7 +16,7 @@ MOCK_YETI_INTEL = {
         "pattern": "[0-9a-f]",
         "compiled_regexp": re.compile(r"[0-9a-f]+\.com"),
         "type": "regex",
-        "root_type": "indicator"
+        "root_type": "indicator",
     }
 }
 
@@ -25,7 +25,7 @@ MOCK_YETI_NEIGHBORS = [
         "id": "98765",
         "name": "Bad malware",
         "type": "malware",
-        "root_type": "entity"
+        "root_type": "entity",
     }
 ]
 

--- a/timesketch/lib/analyzers/yetiindicators_test.py
+++ b/timesketch/lib/analyzers/yetiindicators_test.py
@@ -16,6 +16,7 @@ MOCK_YETI_INTEL = {
         "pattern": "[0-9a-f]",
         "compiled_regexp": re.compile(r"[0-9a-f]+\.com"),
         "type": "regex",
+        "root_type": "indicator"
     }
 }
 
@@ -24,6 +25,7 @@ MOCK_YETI_NEIGHBORS = [
         "id": "98765",
         "name": "Bad malware",
         "type": "malware",
+        "root_type": "entity"
     }
 ]
 


### PR DESCRIPTION
Authentication via Yeti now needs fetching an access token. This change fixes the yeti analyzer to account for this.