### PR TITLE
Fix failing Plaso uploads after 6 months

### DIFF
--- a/timesketch/lib/tasks.py
+++ b/timesketch/lib/tasks.py
@@ -19,7 +19,6 @@ import os
 import logging
 import subprocess
 import traceback
-import re
 
 import codecs
 import io

--- a/timesketch/lib/tasks.py
+++ b/timesketch/lib/tasks.py
@@ -662,8 +662,12 @@ def run_plaso(file_path, events, timeline_name, index_name, source_type, timelin
     # Run pinfo on storage file
     try:
         pinfo = pinfo_tool.PinfoTool()
-        storage_reader = pinfo._GetStorageReader(file_path)
-        storage_counters = pinfo._CalculateStorageCounters(storage_reader)
+        storage_reader = pinfo._GetStorageReader(
+            file_path
+        )  # pylint: disable=protected-access
+        storage_counters = pinfo._CalculateStorageCounters(
+            storage_reader
+        )  # pylint: disable=protected-access
         total_file_events = storage_counters.get("parsers", {}).get("total")
         if not total_file_events:
             raise RuntimeError("Not able to get total event count from Plaso file.")

--- a/timesketch/lib/tasks.py
+++ b/timesketch/lib/tasks.py
@@ -661,12 +661,14 @@ def run_plaso(file_path, events, timeline_name, index_name, source_type, timelin
     # Run pinfo on storage file
     try:
         pinfo = pinfo_tool.PinfoTool()
-        storage_reader = pinfo._GetStorageReader(
+        storage_reader = pinfo._GetStorageReader(  # pylint: disable=protected-access
             file_path
-        )  # pylint: disable=protected-access
-        storage_counters = pinfo._CalculateStorageCounters(
-            storage_reader
-        )  # pylint: disable=protected-access
+        )
+        storage_counters = (
+            pinfo._CalculateStorageCounters(  # pylint: disable=protected-access
+                storage_reader
+            )
+        )
         total_file_events = storage_counters.get("parsers", {}).get("total")
         if not total_file_events:
             raise RuntimeError("Not able to get total event count from Plaso file.")


### PR DESCRIPTION
This PR fixes the problem described in #2895 . 

### Problem TL;DR: 
When using a Plaso version that was released > 180 days (e.g. when not updating Timesketch for 6 month) Plaso will print a [user warning to stdout](https://github.com/log2timeline/plaso/blob/4ca70601f28f62b04005fdd156ac589b44b2cade/plaso/cli/tools.py#L294): `WARNING: the version of plaso you are using is more than 6 months old. We strongly recommend to update it.`

This message on stdout does mess with the expected output format and options to process the output downstream in any automated way. 

Example: 
`pinfo.py --output_format json /tmp/evidence.plaso |  jq -r '.storage_counters.parsers'` would throw an error, since `jq` expects json input but plaso returns the warning + json on stdout.

Same happens when Timesketch tries to json load the `pinfo.py` stdout result while processing a timeline: https://github.com/google/timesketch/blob/f41e7d6e0a84135d9da3018fac48fe35de60d9e5/timesketch/lib/tasks.py#L649

### Proposed solution:
This PR does remove the subcommand for running pinfo and imports [plaso.cli.pinfo_tool.PinfoTool](https://plaso.readthedocs.io/en/latest/sources/api/plaso.cli.html#plaso.cli.pinfo_tool.PinfoTool) as python module instead. This allows to get the storage_counter stats calculated directly by using the `_CalculateStorageCounters()` method.

**Closing issues**

closes #2895 
