### PR TITLE
Support for Large Language Model (LLM) services

### DIFF
--- a/data/timesketch.conf
+++ b/data/timesketch.conf
@@ -341,3 +341,25 @@ INTELLIGENCE_TAG_METADATA = '/etc/timesketch/intelligence_tag_metadata.yaml'
 
 # Context links configuration
 CONTEXT_LINKS_CONFIG_PATH = '/etc/timesketch/context_links.yaml'
+
+# LLM provider configs
+LLM_PROVIDER_CONFIGS = {
+    # To use the Ollama provider you need to download and run an Ollama server.
+    # See instructions at: https://ollama.ai/
+    'ollama': {
+        'server_url': 'http://localhost:11434',
+        'model': 'mistral',
+    },
+    # To use the Vertex AI provider you need to:
+    # 1. Create and export a Service Account Key from the Google Cloud Console.
+    # 2. Set the GOOGLE_APPLICATION_CREDENTIALS environment variable to the full path
+    # to your service account private key file.
+    # 3. Install the python libraries: $ pip3 install google-cloud-aiplatform
+    #
+    # IMPORTANT: Private keys must be kept secret. If you expose your private key it is
+    # recommended to revoke it immediately from the Google Cloud Console.
+    'vertexai': {
+        'model': 'gemini-pro',
+        'project_id': '',
+    }
+}

--- a/timesketch/lib/llms/__init__.py
+++ b/timesketch/lib/llms/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2024 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from timesketch.lib.llms import ollama
+from timesketch.lib.llms import vertexai

--- a/timesketch/lib/llms/__init__.py
+++ b/timesketch/lib/llms/__init__.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""LLM module for Timesketch."""
 
 from timesketch.lib.llms import ollama
 from timesketch.lib.llms import vertexai

--- a/timesketch/lib/llms/interface.py
+++ b/timesketch/lib/llms/interface.py
@@ -1,0 +1,95 @@
+# Copyright 2024 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import string
+
+from flask import current_app
+
+DEFAULT_TEMPERATURE = 0.1
+DEFAULT_TOP_P = 0.1
+DEFAULT_TOP_K = 0
+DEFAULT_MAX_OUTPUT_TOKENS = 2048
+DEFAULT_STREAM = False
+
+
+class LLMProvider:
+    """Base class for LLM providers."""
+
+    NAME = "name"
+
+    def __init__(
+        self,
+        temperature: float = DEFAULT_TEMPERATURE,
+        top_p: float = DEFAULT_TOP_P,
+        top_k: int = DEFAULT_TOP_K,
+        max_output_tokens: int = DEFAULT_MAX_OUTPUT_TOKENS,
+        stream: bool = DEFAULT_STREAM,
+    ):
+        """Initialize the LLM provider.
+
+        Args:
+            temperature: The temperature to use for the response.
+            top_p: The top_p to use for the response.
+            top_k: The top_k to use for the response.
+            max_output_tokens: The maximum number of output tokens to generate.
+            stream: Whether to stream the response.
+
+        Attributes:
+            config: The configuration for the LLM provider.
+
+        Raises:
+            Exception: If the LLM provider is not configured.
+        """
+        config = {}
+        config["temperature"] = temperature
+        config["top_p"] = top_p
+        config["top_k"] = top_k
+        config["max_output_tokens"] = max_output_tokens
+        config["stream"] = stream
+
+        # Load the LLM provider config from the Flask app config
+        config_from_flask = current_app.config.get("LLM_PROVIDER_CONFIGS").get(
+            self.NAME
+        )
+        if not config_from_flask:
+            raise Exception(f"{self.NAME} config not found")
+
+        config.update(config_from_flask)
+        self.config = config
+
+    def prompt_from_template(self, template: str, kwargs: dict) -> str:
+        """Format a prompt from a template.
+
+        Args:
+            template: The template to format.
+            kwargs: The keyword arguments to format the template with.
+
+        Returns:
+            The formatted prompt.
+        """
+        formatter = string.Formatter()
+        return formatter.format(template, **kwargs)
+
+    def generate(self, prompt: str) -> str:
+        """Generate a response from the LLM provider.
+
+        Args:
+            prompt: The prompt to generate a response for.
+            temperature: The temperature to use for the response.
+            stream: Whether to stream the response.
+
+        Returns:
+            The generated response.
+        """
+        raise NotImplementedError()

--- a/timesketch/lib/llms/interface.py
+++ b/timesketch/lib/llms/interface.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Interface for LLM providers."""
 
 import string
 

--- a/timesketch/lib/llms/manager.py
+++ b/timesketch/lib/llms/manager.py
@@ -1,0 +1,66 @@
+# Copyright 2024 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This file contains a class for managing Large Language Model (LLM) providers."""
+
+
+class LLMManager:
+    """The manager for LLM providers."""
+
+    _class_registry = {}
+
+    @classmethod
+    def get_providers(cls):
+        """Get all registered providers.
+
+        Yields:
+            A tuple of (provider_name, provider_class)
+        """
+        for provider_name, provider_class in cls._class_registry.items():
+            yield provider_name, provider_class
+
+    @classmethod
+    def get_provider(cls, provider_name: str) -> type:
+        """Get a provider by name.
+
+        Args:
+            provider_name: The name of the provider.
+
+        Returns:
+            The provider class.
+        """
+        try:
+            provider_class = cls._class_registry[provider_name.lower()]
+        except KeyError:
+            raise KeyError(f"No such provider: {provider_name.lower()}")
+        return provider_class
+
+    @classmethod
+    def register_provider(cls, provider_class: type) -> None:
+        """Register a provider.
+
+        Args:
+            provider_class: The provider class to register.
+
+        Raises:
+            ValueError: If the provider is already registered.
+        """
+        provider_name = provider_class.NAME.lower()
+        if provider_name in cls._class_registry:
+            raise ValueError(f"Provider {provider_class.NAME} already registered")
+        cls._class_registry[provider_name] = provider_class
+
+    @classmethod
+    def clear_registration(cls):
+        """Clear all registered providers."""
+        cls._class_registry = {}

--- a/timesketch/lib/llms/manager.py
+++ b/timesketch/lib/llms/manager.py
@@ -41,8 +41,10 @@ class LLMManager:
         """
         try:
             provider_class = cls._class_registry[provider_name.lower()]
-        except KeyError:
-            raise KeyError(f"No such provider: {provider_name.lower()}")
+        except KeyError as no_such_provider:
+            raise KeyError(
+                f"No such provider: {provider_name.lower()}"
+            ) from no_such_provider
         return provider_class
 
     @classmethod

--- a/timesketch/lib/llms/manager_test.py
+++ b/timesketch/lib/llms/manager_test.py
@@ -22,10 +22,7 @@ class MockProvider:
 
     NAME = "mock"
 
-    def __init__(self):
-        pass
-
-    def generate_text(self, context: str, max_length: int) -> str:
+    def generate_text(self) -> str:
         """Generate text."""
         return "This is a mock LLM provider."
 
@@ -55,9 +52,6 @@ class TestLLMManager(BaseTest):
 
     def test_register_provider(self):
         """Test so we raise KeyError when provider is already registered."""
-        self.assertRaises(KeyError, manager.LLMManager.register_provider, MockProvider)
-
-    def test_clear_registration(self):
-        """Test to clear provider registry."""
-        manager.LLMManager.clear_registration()
-        self.assertRaises(KeyError, manager.LLMManager.get_provider, "mock")
+        self.assertRaises(
+            ValueError, manager.LLMManager.register_provider, MockProvider
+        )

--- a/timesketch/lib/llms/manager_test.py
+++ b/timesketch/lib/llms/manager_test.py
@@ -1,0 +1,63 @@
+# Copyright 2024 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for LLM provider manager."""
+
+from timesketch.lib.testlib import BaseTest
+from timesketch.lib.llms import manager
+
+
+class MockProvider:
+    """A mock LLM provider."""
+
+    NAME = "mock"
+
+    def __init__(self):
+        pass
+
+    def generate_text(self, context: str, max_length: int) -> str:
+        """Generate text."""
+        return "This is a mock LLM provider."
+
+
+class TestLLMManager(BaseTest):
+    """Tests for the functionality of the manager module."""
+
+    manager.LLMManager.clear_registration()
+    manager.LLMManager.register_provider(MockProvider)
+
+    def test_get_providers(self):
+        """Test to get provider class objects."""
+        providers = manager.LLMManager.get_providers()
+        provider_list = list(providers)
+        first_provider_tuple = provider_list[0]
+        provider_name, provider_class = first_provider_tuple
+        self.assertIsInstance(provider_list, list)
+        self.assertIsInstance(first_provider_tuple, tuple)
+        self.assertEqual(provider_class, MockProvider)
+        self.assertEqual(provider_name, "mock")
+
+    def test_get_provider(self):
+        """Test to get provider class from registry."""
+        provider_class = manager.LLMManager.get_provider("mock")
+        self.assertEqual(provider_class, MockProvider)
+        self.assertRaises(KeyError, manager.LLMManager.get_provider, "no_such_provider")
+
+    def test_register_provider(self):
+        """Test so we raise KeyError when provider is already registered."""
+        self.assertRaises(KeyError, manager.LLMManager.register_provider, MockProvider)
+
+    def test_clear_registration(self):
+        """Test to clear provider registry."""
+        manager.LLMManager.clear_registration()
+        self.assertRaises(KeyError, manager.LLMManager.get_provider, "mock")

--- a/timesketch/lib/llms/ollama.py
+++ b/timesketch/lib/llms/ollama.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """A LLM provider for the ollama server."""
+import json
+import requests
 
 from timesketch.lib.llms import interface
 from timesketch.lib.llms import manager
-
-import requests
-import json
 
 
 class Ollama(interface.LLMProvider):

--- a/timesketch/lib/llms/ollama.py
+++ b/timesketch/lib/llms/ollama.py
@@ -1,0 +1,73 @@
+# Copyright 2024 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A LLM provider for the ollama server."""
+
+from timesketch.lib.llms import interface
+from timesketch.lib.llms import manager
+
+import requests
+import json
+
+
+class Ollama(interface.LLMProvider):
+    """A LLM provider for the ollama server."""
+
+    NAME = "ollama"
+
+    def _post(self, request_body: str) -> requests.Response:
+        """
+        Make a POST request to the ollama server.
+
+        Args:
+            request_body: The body of the request in JSON format.
+
+        Returns:
+            The response from the server as a dictionary.
+        """
+        api_resource = "/api/generate/"
+        url = self.config.get("server_url") + api_resource
+        return requests.post(url, data=request_body)
+
+    def generate(self, prompt: str) -> str:
+        """
+        Generate text using the ollama server.
+
+        Args:
+            prompt: The prompt to use for the generation.
+            temperature: The temperature to use for the generation.
+            stream: Whether to stream the generation or not.
+
+        Raises:
+            ValueError: If the generation fails.
+
+        Returns:
+            The generated text as a string.
+        """
+        request_body = {
+            "prompt": prompt,
+            "model": self.config.get("model"),
+            "stream": self.config.get("stream"),
+            "options": {
+                "temperature": self.config.get("temperature"),
+                "num_predict": self.config.get("max_output_tokens"),
+            },
+        }
+        response = self._post(json.dumps(request_body))
+        if response.status_code != 200:
+            raise ValueError(f"Error generating text: {response.text}")
+
+        return response.json().get("response", "").strip()
+
+
+manager.LLMManager.register_provider(Ollama)

--- a/timesketch/lib/llms/vertexai.py
+++ b/timesketch/lib/llms/vertexai.py
@@ -1,0 +1,61 @@
+# Copyright 2024 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Vertex AI LLM provider."""
+
+from timesketch.lib.llms import interface
+from timesketch.lib.llms import manager
+
+# Check if the required dependencies are installed.
+has_required_deps = True
+try:
+    from google.cloud import aiplatform
+    from vertexai.preview.generative_models import GenerativeModel
+except ImportError:
+    has_required_deps = False
+
+
+class VertexAI(interface.LLMProvider):
+    NAME = "vertexai"
+
+    def generate(self, prompt: str) -> str:
+        """
+        Generate text using the Vertex AI service.
+
+        Args:
+            prompt: The prompt to use for the generation.
+            temperature: The temperature to use for the generation.
+            stream: Whether to stream the generation or not.
+
+        Returns:
+            The generated text as a string.
+        """
+        aiplatform.init(
+            project=self.config.get("project_id"),
+        )
+        model = GenerativeModel(self.config.get("model"))
+        response = model.generate_content(
+            prompt,
+            generation_config={
+                "max_output_tokens": self.config.get("max_output_tokens"),
+                "temperature": self.config.get("temperature"),
+            },
+            stream=self.config.get("stream"),
+        )
+
+        return response.text
+
+
+# Only register the provider if the required dependencies are installed.
+if has_required_deps:
+    manager.LLMManager.register_provider(VertexAI)

--- a/timesketch/lib/llms/vertexai.py
+++ b/timesketch/lib/llms/vertexai.py
@@ -26,6 +26,8 @@ except ImportError:
 
 
 class VertexAI(interface.LLMProvider):
+    """Vertex AI LLM provider."""
+
     NAME = "vertexai"
 
     def generate(self, prompt: str) -> str:


### PR DESCRIPTION
This PR adds a plugin system for Large Language Model (LLM) services. Build a lightweight plugin based framework to connect to third-party LLM services (e.g. VortexAI) to Timesketch using a common interface for prompt based communication.

Initial support for:
* Ollama - Open models running locally
* VertexAI from Google

closes #3021 