### PR TITLE
Fix double escaping in sigma_util causing yaml.parser.ParserError

### DIFF
--- a/timesketch/lib/sigma_util.py
+++ b/timesketch/lib/sigma_util.py
@@ -251,7 +251,7 @@ def parse_sigma_rule_by_text(rule_text, sigma_config=None):
 
         for doc in rule_yaml_data:
             parser = sigma_collection.SigmaCollectionParser(
-                str(doc), sigma_conf_obj, None
+                str(rule_text), sigma_conf_obj, None
             )
             parsed_sigma_rules = parser.generate(sigma_backend)
             rule_return.update(doc)

--- a/timesketch/lib/sigma_util_test.py
+++ b/timesketch/lib/sigma_util_test.py
@@ -383,7 +383,11 @@ level: medium
         self.assertIsNotNone(rule)
         self.assertEqual("5d2c62fe-3cbb-47c3-88e1-88ef73503a9f", rule.get("id"))
         self.assertIn(
-            'event_identifier:"10" AND (xml_string:"\\\\foobar.exe" AND xml_string:"10"',  # pylint: disable=line-too-long
+            'event_identifier:"10"',  # pylint: disable=line-too-long
+            rule.get("search_query"),
+        )
+        self.assertIn(
+            'xml_string:"\\\\foobar.exe" AND xml_string:"10"',  # pylint: disable=line-too-long
             rule.get("search_query"),
         )
 
@@ -460,3 +464,50 @@ detection:
             r'("onlyoneterm" OR "two words" OR "completely new term")',
             rule.get("search_query"),
         )
+
+    def test_get_rule_by_text_specialchar(self):
+        """
+        Testing rules, that contain special characters (like "'") in their description
+        """
+        rule = sigma_util.parse_sigma_rule_by_text(r"""
+title: Vim GTFOBin Abuse - Linux
+id: 7ab8f73a-fcff-428b-84aa-6a5ff7877dea
+status: test
+description: Detects usage of "vim" and it's siblings as a GTFOBin to execute and proxy command and binary execution
+references:
+    - https://gtfobins.github.io/gtfobins/vim/
+    - https://gtfobins.github.io/gtfobins/rvim/
+    - https://gtfobins.github.io/gtfobins/vimdiff/
+author: Nasreddine Bencherchali (Nextron Systems)
+date: 2022/12/28
+tags:
+    - attack.discovery
+    - attack.t1083
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection_img:
+        Image|endswith:
+            - '/vim'
+            - '/rvim'
+            - '/vimdiff'
+        CommandLine|contains:
+            - ' -c '
+            - ' --cmd'
+    selection_cli:
+        CommandLine|contains:
+            - ':!/'
+            - ':py '
+            - ':lua '
+            - '/bin/sh'
+            - '/bin/bash'
+            - '/bin/dash'
+            - '/bin/zsh'
+            - '/bin/fish'
+    condition: all of selection_*
+falsepositives:
+    - Unknown
+level: high
+""")
+        self.assertIsNotNone(rule)


### PR DESCRIPTION
This PR fixes the issue https://github.com/google/timesketch/issues/3027, by simply passing the text of a sigma rule (`rule_text` instead of it's already escaped version `doc`) to `sigmatools`. `sigmatools` does the parsing and escaping of yaml by itself.

`yaml.safe_load_all` is still used for yaml-parsing (making sure, that the format is right) within this function, before calling the `sigmatools` library.

Like mentioned in the issue, the previous version led to ParserErrors, due to "double escaping" via `yaml.safe_load_all` in specific cases. 

The PR also fixes one `sigma_util.py` test, which was failing mistakenly.

**Checks**
- [x] All tests succeed.
- [x] Unit tests added.

**Closing issues**
closes #3027 