### PR TITLE
Move "old UI" button

### DIFF
--- a/timesketch/frontend-ng/src/views/Home.vue
+++ b/timesketch/frontend-ng/src/views/Home.vue
@@ -25,7 +25,6 @@ limitations under the License.
       <span style="font-size: 1.2em">timesketch</span>
 
       <v-spacer></v-spacer>
-      <v-btn small depressed v-on:click="switchUI"> Use the old UI </v-btn>
       <v-avatar color="grey lighten-1" size="25" class="ml-3">
         <span class="white--text">{{ currentUser | initialLetter }}</span>
       </v-avatar>
@@ -46,6 +45,14 @@ limitations under the License.
                 </v-list-item-icon>
                 <v-list-item-content>
                   <v-list-item-title>Toggle theme</v-list-item-title>
+                </v-list-item-content>
+              </v-list-item>
+              <v-list-item v-on:click="switchUI">
+                <v-list-item-icon>
+                  <v-icon>mdi-view-dashboard-outline</v-icon>
+                </v-list-item-icon>
+                <v-list-item-content>
+                  <v-list-item-title>Use the old UI</v-list-item-title>
                 </v-list-item-content>
               </v-list-item>
 

--- a/timesketch/frontend-ng/src/views/Sketch.vue
+++ b/timesketch/frontend-ng/src/views/Sketch.vue
@@ -101,7 +101,6 @@ limitations under the License.
           </div>
         </v-hover>
         <v-spacer></v-spacer>
-        <v-btn small rounded depressed v-on:click="switchUI"> Use the old UI </v-btn>
 
         <!-- Sharing dialog -->
         <v-dialog v-model="shareDialog" width="500">
@@ -190,6 +189,15 @@ limitations under the License.
                   </v-list-item-icon>
                   <v-list-item-content>
                     <v-list-item-title>Delete sketch</v-list-item-title>
+                  </v-list-item-content>
+                </v-list-item>
+
+                <v-list-item v-on:click="switchUI">
+                  <v-list-item-icon>
+                    <v-icon>mdi-view-dashboard-outline</v-icon>
+                  </v-list-item-icon>
+                  <v-list-item-content>
+                    <v-list-item-title>Use the old UI</v-list-item-title>
                   </v-list-item-content>
                 </v-list-item>
 


### PR DESCRIPTION
Moving the "Use the old UI" button into the three-dot menu on the top right.

On the overview: 
![image](https://github.com/google/timesketch/assets/99879757/bb87dedd-fd81-4106-a2b4-13b44561b480)

In a sketch:
![image](https://github.com/google/timesketch/assets/99879757/4d656276-b9c3-4686-bff8-267610292ff6)
