### PR TITLE
Use subqueryload to make loading events with comments faster

### DIFF
--- a/timesketch/api/v1/resources/explore.py
+++ b/timesketch/api/v1/resources/explore.py
@@ -321,7 +321,7 @@ class ExploreResource(resources.ResourceMixin, Resource):
 
         comments = {}
         if "comment" in return_fields:
-            events = Event.query.filter_by(sketch=sketch).all()
+            events = Event.get_with_comments(sketch=sketch)
             for event in events:
                 for comment in event.comments:
                     comments.setdefault(event.document_id, [])

--- a/timesketch/models/annotations.py
+++ b/timesketch/models/annotations.py
@@ -27,6 +27,7 @@ from sqlalchemy import Unicode
 from sqlalchemy import UnicodeText
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import relationship
+from sqlalchemy.orm import subqueryload
 
 from timesketch.models import BaseModel
 from timesketch.models import db_session
@@ -222,6 +223,10 @@ class CommentMixin(object):
             ),
         )
         return relationship(self.Comment)
+
+    @classmethod
+    def get_with_comments(cls, **kwargs):
+        return cls.query.filter_by(**kwargs).options(subqueryload(cls.comments))
 
     def remove_comment(self, comment_id):
         """Remove a comment from an event.

--- a/timesketch/models/annotations.py
+++ b/timesketch/models/annotations.py
@@ -226,6 +226,17 @@ class CommentMixin(object):
 
     @classmethod
     def get_with_comments(cls, **kwargs):
+        """Eagerly loads comments for a given object query using subquery.
+
+        subqueryload is more efficient than joinedload for many-to-one
+        references on large datasets.
+
+        Args:
+            kwargs: Keyword arguments passed to filter_by.
+
+        Returns:
+            List of objects with comments eagerly loaded.
+        """
         return cls.query.filter_by(**kwargs).options(subqueryload(cls.comments))
 
     def remove_comment(self, comment_id):


### PR DESCRIPTION
When a sketch has a lot of commented events, performance starts to seriously degrade. In my dev environment, a sketch (450k total events) with 1 comment on 3k events would take 14 seconds to load.

The bottleneck was in the way comments are queried from the database via the `CommentMixin` class, which AFAIU dynamically creates a SQLAlchemy table definition. The Explore API goes through all events in a sketch to populate their comment dictionary. Using `subqueryload` to eagerly load comments in one go turned out to speed the queries up *a lot* (went from 14 seconds to 0.5 seconds for the same sketch).