### PR TITLE
Improvements to the sigma handling

### DIFF
--- a/timesketch/lib/analyzers/yetiindicators.py
+++ b/timesketch/lib/analyzers/yetiindicators.py
@@ -111,9 +111,7 @@ class YetiBaseAnalyzer(interface.BaseAnalyzer):
             )
 
         access_token = response.json()["access_token"]
-        self._yeti_session.headers.update(
-            {"authorization": f"Bearer {access_token}"}
-        )
+        self._yeti_session.headers.update({"authorization": f"Bearer {access_token}"})
 
     def _get_neighbors_request(self, params):
         """Simple wrapper around requests call to make testing easier."""
@@ -216,9 +214,7 @@ class YetiBaseAnalyzer(interface.BaseAnalyzer):
         event.add_tags(list(tags))
         event.commit()
 
-        msg = (
-            f'Indicator match: "{indicator["name"]}" (ID: {indicator["id"]})\n'
-        )
+        msg = f'Indicator match: "{indicator["name"]}" (ID: {indicator["id"]})\n'
         if neighbors:
             msg += f'Related entities: {[neighbor["name"] for neighbor in neighbors]}'
 
@@ -262,9 +258,7 @@ class YetiBaseAnalyzer(interface.BaseAnalyzer):
                 for ioc in self._intelligence_attribute["data"]
             }
         except ValueError:
-            print(
-                "Intelligence not set on sketch, will be created from scratch."
-            )
+            print("Intelligence not set on sketch, will be created from scratch.")
 
     def save_intelligence(self):
         self.sketch.add_sketch_attribute(
@@ -336,9 +330,7 @@ class YetiBaseAnalyzer(interface.BaseAnalyzer):
                 str(exception),
             )
             return None
-        return {
-            "query": {"query_string": {"query": parsed_sigma["search_query"]}}
-        }
+        return {"query": {"query_string": {"query": parsed_sigma["search_query"]}}}
 
     def run(self):
         """Entry point for the analyzer.
@@ -358,9 +350,7 @@ class YetiBaseAnalyzer(interface.BaseAnalyzer):
         if self._SAVE_INTELLIGENCE:
             self.get_intelligence_attribute()
 
-        entities = self.get_entities(
-            _type=self._TYPE_SELECTOR, tags=self._TAG_SELECTOR
-        )
+        entities = self.get_entities(_type=self._TYPE_SELECTOR, tags=self._TAG_SELECTOR)
         for entity in entities.values():
             indicators = self.get_neighbors(
                 entity,
@@ -378,9 +368,7 @@ class YetiBaseAnalyzer(interface.BaseAnalyzer):
                     and indicator["query_type"] == "opensearch"
                 ):
                     query_dsl = {
-                        "query": {
-                            "query_string": {"query": indicator["pattern"]}
-                        }
+                        "query": {"query_string": {"query": indicator["pattern"]}}
                     }
                 if not query_dsl:
                     continue
@@ -395,9 +383,7 @@ class YetiBaseAnalyzer(interface.BaseAnalyzer):
                     if entity["type"] in HIGH_SEVERITY_TYPES:
                         priority = "HIGH"
                         if self._SAVE_INTELLIGENCE:
-                            self.add_intelligence_entry(
-                                indicator, event, entity
-                            )
+                            self.add_intelligence_entry(indicator, event, entity)
 
                     entities_found.add(f"{entity['name']}:{entity['type']}")
 

--- a/timesketch/lib/analyzers/yetiindicators.py
+++ b/timesketch/lib/analyzers/yetiindicators.py
@@ -468,4 +468,4 @@ class YetiLOLBASIndicators(YetiBaseAnalyzer):
 
 manager.AnalysisManager.register_analyzer(YetiTriageIndicators)
 manager.AnalysisManager.register_analyzer(YetiMalwareIndicators)
-manager.AnalysisManager.register_analyzer(YetiSigmaIndicators)
+manager.AnalysisManager.register_analyzer(YetiLOLBASIndicators)

--- a/timesketch/lib/analyzers/yetiindicators.py
+++ b/timesketch/lib/analyzers/yetiindicators.py
@@ -111,7 +111,9 @@ class YetiBaseAnalyzer(interface.BaseAnalyzer):
             )
 
         access_token = response.json()["access_token"]
-        self._yeti_session.headers.update({"authorization": f"Bearer {access_token}"})
+        self._yeti_session.headers.update(
+            {"authorization": f"Bearer {access_token}"}
+        )
 
     def _get_neighbors_request(self, params):
         """Simple wrapper around requests call to make testing easier."""
@@ -214,7 +216,9 @@ class YetiBaseAnalyzer(interface.BaseAnalyzer):
         event.add_tags(list(tags))
         event.commit()
 
-        msg = f'Indicator match: "{indicator["name"]}" (ID: {indicator["id"]})\n'
+        msg = (
+            f'Indicator match: "{indicator["name"]}" (ID: {indicator["id"]})\n'
+        )
         if neighbors:
             msg += f'Related entities: {[neighbor["name"] for neighbor in neighbors]}'
 
@@ -258,7 +262,9 @@ class YetiBaseAnalyzer(interface.BaseAnalyzer):
                 for ioc in self._intelligence_attribute["data"]
             }
         except ValueError:
-            print("Intelligence not set on sketch, will be created from scratch.")
+            print(
+                "Intelligence not set on sketch, will be created from scratch."
+            )
 
     def save_intelligence(self):
         self.sketch.add_sketch_attribute(
@@ -325,10 +331,14 @@ class YetiBaseAnalyzer(interface.BaseAnalyzer):
             )
         except yaml.scanner.ScannerError as exception:
             logging.error(
-                "Error parsing Sigma rule %s: %s", indicator["id"], str(exception)
+                "Error parsing Sigma rule %s: %s",
+                indicator["id"],
+                str(exception),
             )
             return None
-        return {"query": {"query_string": {"query": parsed_sigma["search_query"]}}}
+        return {
+            "query": {"query_string": {"query": parsed_sigma["search_query"]}}
+        }
 
     def run(self):
         """Entry point for the analyzer.
@@ -348,7 +358,9 @@ class YetiBaseAnalyzer(interface.BaseAnalyzer):
         if self._SAVE_INTELLIGENCE:
             self.get_intelligence_attribute()
 
-        entities = self.get_entities(_type=self._TYPE_SELECTOR, tags=self._TAG_SELECTOR)
+        entities = self.get_entities(
+            _type=self._TYPE_SELECTOR, tags=self._TAG_SELECTOR
+        )
         for entity in entities.values():
             indicators = self.get_neighbors(
                 entity,
@@ -366,7 +378,9 @@ class YetiBaseAnalyzer(interface.BaseAnalyzer):
                     and indicator["query_type"] == "opensearch"
                 ):
                     query_dsl = {
-                        "query": {"query_string": {"query": indicator["pattern"]}}
+                        "query": {
+                            "query_string": {"query": indicator["pattern"]}
+                        }
                     }
                 if not query_dsl:
                     continue
@@ -381,7 +395,9 @@ class YetiBaseAnalyzer(interface.BaseAnalyzer):
                     if entity["type"] in HIGH_SEVERITY_TYPES:
                         priority = "HIGH"
                         if self._SAVE_INTELLIGENCE:
-                            self.add_intelligence_entry(indicator, event, entity)
+                            self.add_intelligence_entry(
+                                indicator, event, entity
+                            )
 
                     entities_found.add(f"{entity['name']}:{entity['type']}")
 

--- a/timesketch/lib/analyzers/yetiindicators.py
+++ b/timesketch/lib/analyzers/yetiindicators.py
@@ -1,19 +1,16 @@
 """Index analyzer plugin for Yeti indicators."""
 
 import json
-import re
-
-from typing import Dict, List, Union, Optional
-
-from flask import current_app
 import logging
+import re
+from typing import Dict, List, Optional, Union
+
 import requests
 import yaml
+from flask import current_app
 
-from timesketch.lib.analyzers import interface
-from timesketch.lib.analyzers import manager
-from timesketch.lib import emojis
-from timesketch.lib import sigma_util
+from timesketch.lib import emojis, sigma_util
+from timesketch.lib.analyzers import interface, manager
 
 TYPE_TO_EMOJI = {
     "malware": "SPIDER",
@@ -327,7 +324,9 @@ class YetiBaseAnalyzer(interface.BaseAnalyzer):
                 indicator["pattern"], sanitize=False
             )
         except yaml.scanner.ScannerError as exception:
-            logging.error(f"Error parsing Sigma rule {indicator['id']}: {exception}")
+            logging.error(
+                "Error parsing Sigma rule %s: %s", indicator["id"], str(exception)
+            )
             return None
         return {"query": {"query_string": {"query": parsed_sigma["search_query"]}}}
 

--- a/timesketch/lib/analyzers/yetiindicators_test.py
+++ b/timesketch/lib/analyzers/yetiindicators_test.py
@@ -89,7 +89,9 @@ class TestYetiIndicators(BaseTest):
         yetiindicators.NEIGHBOR_CACHE = {}
 
     # Mock the OpenSearch datastore.
-    @mock.patch("timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore)
+    @mock.patch(
+        "timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore
+    )
     @mock.patch(
         "timesketch.lib.analyzers.yetiindicators."
         "YetiBaseAnalyzer._get_neighbors_request"
@@ -105,7 +107,9 @@ class TestYetiIndicators(BaseTest):
         mock_get_entities.return_value = MOCK_YETI_ENTITY_REQUEST
         mock_get_neighbors.return_value = MOCK_YETI_NEIGHBORS_RESPONSE
 
-        analyzer.datastore.import_event("test_index", MATCHING_PATH_MESSAGE, "0")
+        analyzer.datastore.import_event(
+            "test_index", MATCHING_PATH_MESSAGE, "0"
+        )
 
         message = json.loads(analyzer.run())
         self.assertEqual(
@@ -123,7 +127,9 @@ class TestYetiIndicators(BaseTest):
         )
 
     # Mock the OpenSearch datastore.
-    @mock.patch("timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore)
+    @mock.patch(
+        "timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore
+    )
     @mock.patch(
         "timesketch.lib.analyzers.yetiindicators."
         "YetiBaseAnalyzer._get_neighbors_request"
@@ -141,12 +147,15 @@ class TestYetiIndicators(BaseTest):
 
         message = json.loads(analyzer.run())
         self.assertEqual(
-            message["result_summary"], "No indicators were found in the timeline."
+            message["result_summary"],
+            "No indicators were found in the timeline.",
         )
         mock_get_entities.assert_called_once()
         mock_get_neighbors.asset_called_once()
 
-    @mock.patch("timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore)
+    @mock.patch(
+        "timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore
+    )
     def test_slug(self):
         analyzer = yetiindicators.YetiMalwareIndicators("test_index", 1, 123)
         mock_event = mock.Mock()
@@ -162,7 +171,9 @@ class TestYetiIndicators(BaseTest):
             [sorted(x) for x in mock_event.add_tags.call_args[0]],
         )
 
-    @mock.patch("timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore)
+    @mock.patch(
+        "timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore
+    )
     def test_build_query_from_regexp(self):
         analyzer = yetiindicators.YetiMalwareIndicators("test_index", 1, 123)
         query = analyzer.build_query_from_regexp(
@@ -211,7 +222,9 @@ class TestYetiIndicators(BaseTest):
             },
         )
 
-    @mock.patch("timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore)
+    @mock.patch(
+        "timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore
+    )
     def test_build_query_from_sigma(self):
         sigma_pattern = """id: asd
 title: test

--- a/timesketch/lib/analyzers/yetiindicators_test.py
+++ b/timesketch/lib/analyzers/yetiindicators_test.py
@@ -149,6 +149,7 @@ class TestYetiIndicators(BaseTest):
 
     @mock.patch("timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore)
     def test_slug(self):
+        """Tests that slugs are formed correctly."""
         analyzer = yetiindicators.YetiMalwareIndicators("test_index", 1, 123)
         mock_event = mock.Mock()
         mock_event.get_comments.return_value = []
@@ -165,6 +166,7 @@ class TestYetiIndicators(BaseTest):
 
     @mock.patch("timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore)
     def test_build_query_from_regexp(self):
+        """Tests that that queries are correctly built from regex indicators."""
         analyzer = yetiindicators.YetiMalwareIndicators("test_index", 1, 123)
         query = analyzer.build_query_from_regexp(
             {
@@ -214,6 +216,8 @@ class TestYetiIndicators(BaseTest):
 
     @mock.patch("timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore)
     def test_build_query_from_sigma(self):
+        """Tests that that queries are correctly built from sigma indicators."""
+        analyzer = yetiindicators.YetiMalwareIndicators("test_index", 1, 123)
         sigma_pattern = """id: asd
 title: test
 description: test
@@ -236,7 +240,6 @@ level: medium
 tags:
     - blah
 """
-        analyzer = yetiindicators.YetiMalwareIndicators("test_index", 1, 123)
         query = analyzer.build_query_from_sigma(
             {
                 "name": "random sigma",
@@ -260,7 +263,10 @@ tags:
             {
                 "query": {
                     "query_string": {
-                        "query": '(data_type:"windows\\:prefetch\\:execution" AND message:("\\\\rundll32.exe"))'
+                        "query": (
+                            '(data_type:"windows\\:prefetch\\:execution" '
+                            'AND message:("\\\\rundll32.exe"))'
+                        )
                     }
                 }
             },

--- a/timesketch/lib/analyzers/yetiindicators_test.py
+++ b/timesketch/lib/analyzers/yetiindicators_test.py
@@ -89,9 +89,7 @@ class TestYetiIndicators(BaseTest):
         yetiindicators.NEIGHBOR_CACHE = {}
 
     # Mock the OpenSearch datastore.
-    @mock.patch(
-        "timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore
-    )
+    @mock.patch("timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore)
     @mock.patch(
         "timesketch.lib.analyzers.yetiindicators."
         "YetiBaseAnalyzer._get_neighbors_request"
@@ -107,9 +105,7 @@ class TestYetiIndicators(BaseTest):
         mock_get_entities.return_value = MOCK_YETI_ENTITY_REQUEST
         mock_get_neighbors.return_value = MOCK_YETI_NEIGHBORS_RESPONSE
 
-        analyzer.datastore.import_event(
-            "test_index", MATCHING_PATH_MESSAGE, "0"
-        )
+        analyzer.datastore.import_event("test_index", MATCHING_PATH_MESSAGE, "0")
 
         message = json.loads(analyzer.run())
         self.assertEqual(
@@ -127,9 +123,7 @@ class TestYetiIndicators(BaseTest):
         )
 
     # Mock the OpenSearch datastore.
-    @mock.patch(
-        "timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore
-    )
+    @mock.patch("timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore)
     @mock.patch(
         "timesketch.lib.analyzers.yetiindicators."
         "YetiBaseAnalyzer._get_neighbors_request"
@@ -153,9 +147,7 @@ class TestYetiIndicators(BaseTest):
         mock_get_entities.assert_called_once()
         mock_get_neighbors.asset_called_once()
 
-    @mock.patch(
-        "timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore
-    )
+    @mock.patch("timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore)
     def test_slug(self):
         analyzer = yetiindicators.YetiMalwareIndicators("test_index", 1, 123)
         mock_event = mock.Mock()
@@ -171,9 +163,7 @@ class TestYetiIndicators(BaseTest):
             [sorted(x) for x in mock_event.add_tags.call_args[0]],
         )
 
-    @mock.patch(
-        "timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore
-    )
+    @mock.patch("timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore)
     def test_build_query_from_regexp(self):
         analyzer = yetiindicators.YetiMalwareIndicators("test_index", 1, 123)
         query = analyzer.build_query_from_regexp(
@@ -222,9 +212,7 @@ class TestYetiIndicators(BaseTest):
             },
         )
 
-    @mock.patch(
-        "timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore
-    )
+    @mock.patch("timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore)
     def test_build_query_from_sigma(self):
         sigma_pattern = """id: asd
 title: test

--- a/timesketch/lib/sigma_util.py
+++ b/timesketch/lib/sigma_util.py
@@ -276,7 +276,7 @@ def parse_sigma_rule_by_text(rule_text, sigma_config=None):
 
     assert parsed_sigma_rules is not None
 
-    sigma_search_query = parsed_sigma_rules[0].replace("*.keyword:", "message:")
+    sigma_search_query = list(parsed_sigma_rules)[0].replace("*.keyword:", "message:")
 
     if not isinstance(rule_return.get("title"), str):
         error_msg = "Missing value: 'title' from the YAML data."

--- a/timesketch/lib/sigma_util.py
+++ b/timesketch/lib/sigma_util.py
@@ -278,9 +278,10 @@ def parse_sigma_rule_by_text(rule_text, sigma_config=None, sanitize=True):
 
     assert parsed_sigma_rules is not None
 
-    sigma_search_query = list(parsed_sigma_rules)[0].replace("*.keyword:", "message:")
+    sigma_search_query = list(parsed_sigma_rules)[0]
     if sanitize:
         sigma_search_query = _sanitize_query(sigma_search_query)
+    sigma_search_query = sigma_search_query.replace("*.keyword:", "message.keyword:")
 
     if not isinstance(rule_return.get("title"), str):
         error_msg = "Missing value: 'title' from the YAML data."

--- a/timesketch/lib/sigma_util.py
+++ b/timesketch/lib/sigma_util.py
@@ -135,9 +135,9 @@ def get_all_sigma_rules(parse_yaml: bool = False):
 
 
 def _sanitize_query(sigma_rule_query: str) -> str:
-    """DEPRECATED: Returns a sanitized query.
+    """Returns a sanitized query.
 
-    DEPRECATION NOTICE: This function requires more thorough testing as it
+    This function requires more thorough testing as it
     generated OpenSearch queries with an invalid syntax. The Sigma library
     does a good enough job at generating compatible (albeit maybe inefficient)
     queries.
@@ -211,12 +211,14 @@ def sanitize_incoming_sigma_rule_text(rule_text: string):
 
 
 @lru_cache(maxsize=8)
-def parse_sigma_rule_by_text(rule_text, sigma_config=None):
+def parse_sigma_rule_by_text(rule_text, sigma_config=None, sanitize=True):
     """Returns a JSON representation for a rule
 
     Args:
         rule_text: Text of the sigma rule to be parsed
         sigma_config: config file object
+        sanitize: If set to True, sanitization rules will be ran over the
+            resulting Lucene query.
 
     Returns:
         JSON representation of the parsed rule
@@ -277,6 +279,8 @@ def parse_sigma_rule_by_text(rule_text, sigma_config=None):
     assert parsed_sigma_rules is not None
 
     sigma_search_query = list(parsed_sigma_rules)[0].replace("*.keyword:", "message:")
+    if sanitize:
+        sigma_search_query = _sanitize_query(sigma_search_query)
 
     if not isinstance(rule_return.get("title"), str):
         error_msg = "Missing value: 'title' from the YAML data."

--- a/timesketch/lib/sigma_util.py
+++ b/timesketch/lib/sigma_util.py
@@ -135,7 +135,13 @@ def get_all_sigma_rules(parse_yaml: bool = False):
 
 
 def _sanitize_query(sigma_rule_query: str) -> str:
-    """Returns a sanitized query
+    """DEPRECATED: Returns a sanitized query.
+
+    DEPRECATION NOTICE: This function requires more thorough testing as it
+    generated OpenSearch queries with an invalid syntax. The Sigma library
+    does a good enough job at generating compatible (albeit maybe inefficient)
+    queries.
+
     Args:
         sigma_rule_query: path to the sigma rule to be parsed
     Returns:
@@ -270,10 +276,7 @@ def parse_sigma_rule_by_text(rule_text, sigma_config=None):
 
     assert parsed_sigma_rules is not None
 
-    sigma_search_query = ""
-
-    for sigma_rule in parsed_sigma_rules:
-        sigma_search_query = _sanitize_query(sigma_rule)
+    sigma_search_query = parsed_sigma_rules[0].replace("*.keyword:", "message:")
 
     if not isinstance(rule_return.get("title"), str):
         error_msg = "Missing value: 'title' from the YAML data."

--- a/timesketch/lib/sigma_util_test.py
+++ b/timesketch/lib/sigma_util_test.py
@@ -192,7 +192,7 @@ level: high
 
         self.assertIsNotNone(rule)
         self.assertEqual(
-            '("Whitespace at" OR " beginning " OR " and extra text ")',
+            'message:("Whitespace at" OR " beginning " OR " and extra text ")',
             rule.get("search_query"),
         )
 
@@ -284,7 +284,7 @@ detection:
         self.assertIsNotNone(rule)
         self.assertEqual("67b9a11a-03ae-490a-9156-9be9900aaaaa", rule.get("id"))
         self.assertEqual(
-            r'("aaa:bbb" OR "ccc\:\:ddd")',
+            'message:("aaa:bbb" OR "ccc\\:\\:ddd")',
             rule.get("search_query"),
         )
 
@@ -462,7 +462,7 @@ detection:
         )
         self.assertIsNotNone(rule)
         self.assertEqual(
-            r'("onlyoneterm" OR "two words" OR "completely new term")',
+            'message("onlyoneterm" OR "two words" OR "completely new term")',
             rule.get("search_query"),
         )
 

--- a/timesketch/lib/sigma_util_test.py
+++ b/timesketch/lib/sigma_util_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for sigma_util score."""
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/timesketch/lib/sigma_util_test.py
+++ b/timesketch/lib/sigma_util_test.py
@@ -43,8 +43,6 @@ detection:
     selection:
         EventID: 4624
         ProcessName|endswith: '\WmiPrvSE.exe'
-        CommandLine|contains:
-            - '-AddInRoot:.'
     condition: selection
 falsepositives:
     - Monitoring tools

--- a/timesketch/lib/sigma_util_test.py
+++ b/timesketch/lib/sigma_util_test.py
@@ -189,10 +189,9 @@ falsepositives:
 level: high
 """
         )
-
         self.assertIsNotNone(rule)
         self.assertEqual(
-            'message:("Whitespace at" OR " beginning " OR " and extra text ")',
+            '("Whitespace at" OR " beginning " OR " and extra text ")',
             rule.get("search_query"),
         )
 
@@ -284,7 +283,7 @@ detection:
         self.assertIsNotNone(rule)
         self.assertEqual("67b9a11a-03ae-490a-9156-9be9900aaaaa", rule.get("id"))
         self.assertEqual(
-            'message:("aaa:bbb" OR "ccc\\:\\:ddd")',
+            '("aaa:bbb" OR "ccc\\:\\:ddd")',
             rule.get("search_query"),
         )
 
@@ -462,7 +461,7 @@ detection:
         )
         self.assertIsNotNone(rule)
         self.assertEqual(
-            'message("onlyoneterm" OR "two words" OR "completely new term")',
+            '("onlyoneterm" OR "two words" OR "completely new term")',
             rule.get("search_query"),
         )
 

--- a/timesketch/lib/sigma_util_test.py
+++ b/timesketch/lib/sigma_util_test.py
@@ -42,6 +42,8 @@ detection:
     selection:
         EventID: 4624
         ProcessName|endswith: '\WmiPrvSE.exe'
+        CommandLine|contains:
+            - '-AddInRoot:.'
     condition: selection
 falsepositives:
     - Monitoring tools


### PR DESCRIPTION
This PR brings in some changes to the way Sigma is handled in Timesketch.

* Make sanitization optional

* New version of the Yeti analyzer: `YetiLOLBASIndicators`. This takes in Tools that are tagged `lolbas` in Yeti, traverses the graph looking for Sigma queries, and runs them on a sketch, tagging relevant events.