### PR TITLE
Bump nginx version

### DIFF
--- a/docker/release/config.env
+++ b/docker/release/config.env
@@ -42,7 +42,7 @@ POSTGRES_PASSWORD=
 REDIS_VERSION=6.0.8-alpine
 
 # Nginx webserver version to run.
-NGINX_VERSION=1.19.3-alpine
+NGINX_VERSION=1.25.5-alpine-slim
 
 # Nginx PATH local conf
 NGINX_CONFIG_PATH=./etc/nginx.conf


### PR DESCRIPTION
As recommended in #3069 this PR bumps the nginx version for the release deployment to version [1.25.5-alpine-slim](https://hub.docker.com/layers/library/nginx/1.25.5-alpine-slim/images/sha256-99453d9d4b0df77ce6e1ec81e2b4712a48d9cd5073a4541b3afaaf5d8896a566?context=explore). This version has no listed/known vulnerabilities and works with the latest Timesketch release.


