### PR TITLE
tsdev.sh update

### DIFF
--- a/contrib/tsdev.sh
+++ b/contrib/tsdev.sh
@@ -44,7 +44,7 @@ fi
 
 # Set variables required to execute commands
 CONTAINER_ID="$("$s" docker container list --filter name='timesketch-dev' --quiet)"
-frontend=${2:-"frontend"}
+frontend="frontend-ng"
 
 # Run the provided command
 case "$1" in

--- a/contrib/tsdev.sh
+++ b/contrib/tsdev.sh
@@ -1,29 +1,79 @@
 #!/bin/bash
 
-CONTAINER_ID="$(docker container list -f name=timesketch-dev -q)"
+# Display a help message and exit
+help(){
+	echo
+	echo "Usage: tsdev.sh [OPTIONS] COMMAND"
+	echo
+	echo "Run commands to manage resources on your Timesketch development docker container"
+	echo
+	echo "Options:"
+	echo "  -h, --help        Display this help message"
+	echo
+	echo "Commands:"
+	echo "  build-api-cli     Build and install API and CLI clients"
+	echo "  celery            Start a celery worker"
+	echo "  logs              Follow docker container logs "
+	echo "  shell             Open a shell in the docker container"
+	echo "  test              Execute run_tests.py --coverage"
+	echo "  vue-build         Build the vue frontend"
+	echo "  vue-dev           Serve the vue frontend"
+	echo "  vue-install-deps  Install vue frontend dependencies"
+	echo "  vue-test          Test the vue frontend"
+	echo "  web               Start the web frontend bound to port 5000"
+	echo
+	echo "Examples:"
+	echo "  tsdev.sh logs"
+	echo "  tsdev.sh test"
+	exit 0
+}
+
+# Display the help message if there is no command or if the help option is present
+if [ $# -eq 0 ] || [ "$1" == "-h" ]  || [ "$1" == "--help" ]; then
+	help
+fi
+
+# Set variables required to execute commands
+CONTAINER_ID="$(sudo docker container list --filter name='timesketch-dev' --quiet)"
 frontend=${2:-"frontend"}
 
-if [ $1 == "web" ]; then
-  docker exec -it $CONTAINER_ID gunicorn --reload -b 0.0.0.0:5000 --log-level debug --capture-output --timeout 600 timesketch.wsgi:application
-elif [ $1 == "celery" ]; then
-  docker exec -it $CONTAINER_ID celery -A timesketch.lib.tasks worker --loglevel=info
-elif [ $1 == "vue-install-deps" ]; then
-  docker exec -it $CONTAINER_ID yarn install --cwd=/usr/local/src/timesketch/timesketch/$frontend
-elif [ $1 == "vue-dev" ]; then
-  docker exec -it $CONTAINER_ID yarn run --cwd=/usr/local/src/timesketch/timesketch/$frontend serve
-elif [ $1 == "vue-build" ]; then
-  docker exec -it $CONTAINER_ID yarn run --cwd=/usr/local/src/timesketch/timesketch/$frontend build
-elif [ $1 == "vue-test" ]; then
-  docker exec -it $CONTAINER_ID yarn run --cwd=/usr/local/src/timesketch/timesketch/frontend-ng test
-elif [ $1 == "test" ]; then
-  docker exec -w /usr/local/src/timesketch -it $CONTAINER_ID python3 run_tests.py --coverage
-elif [ $1 == "shell" ]; then
-  docker exec -it $CONTAINER_ID /bin/bash
-elif [ $1 == "logs" ]; then
-  docker logs -f $CONTAINER_ID
-elif [ $1 == "build_api_cli" ]; then
-    docker exec -w '/usr/local/src/timesketch/cli_client/python' -it $CONTAINER_ID python3 setup.py build
-    docker exec -w '/usr/local/src/timesketch/cli_client/python' -it $CONTAINER_ID python3 setup.py install
-    docker exec -w '/usr/local/src/timesketch/api_client/python' -it $CONTAINER_ID python3 setup.py build
-    docker exec -w '/usr/local/src/timesketch/api_client/python' -it $CONTAINER_ID python3 setup.py install
-fi
+# Run the provided command
+case "$1" in
+ 	build-api-cli)
+		# CLI client
+		sudo docker exec --workdir '/usr/local/src/timesketch/cli_client/python' --interactive --tty $CONTAINER_ID python3 setup.py build
+		sudo docker exec --workdir '/usr/local/src/timesketch/cli_client/python' --interactive --tty $CONTAINER_ID python3 setup.py install
+		# API client
+		sudo docker exec --workdir '/usr/local/src/timesketch/api_client/python' --interactive --tty $CONTAINER_ID python3 setup.py build
+		sudo docker exec --workdir '/usr/local/src/timesketch/api_client/python' --interactive --tty $CONTAINER_ID python3 setup.py install
+		;;
+ 	celery)
+		sudo docker exec --interactive --tty $CONTAINER_ID celery --app timesketch.lib.tasks worker --loglevel=info
+		;;
+	logs)
+		sudo docker logs --follow $CONTAINER_ID
+		;;
+	shell)
+		sudo docker exec --interactive --tty $CONTAINER_ID /bin/bash
+		;;
+	test)
+		sudo docker exec --workdir /usr/local/src/timesketch --interactive --tty $CONTAINER_ID python3 run_tests.py --coverage
+		;;
+	vue-build)
+		sudo docker exec --interactive --tty $CONTAINER_ID yarn run --cwd=/usr/local/src/timesketch/timesketch/$frontend build
+		;;
+	vue-dev)
+		sudo docker exec --interactive --tty $CONTAINER_ID yarn run --cwd=/usr/local/src/timesketch/timesketch/$frontend serve
+		;;
+	vue-install-deps)
+		sudo docker exec --interactive --tty $CONTAINER_ID yarn install --cwd=/usr/local/src/timesketch/timesketch/$frontend
+		;;
+	vue-test)
+		sudo docker exec --interactive --tty $CONTAINER_ID yarn run --cwd=/usr/local/src/timesketch/timesketch/frontend-ng test
+		;;
+	web)
+		sudo docker exec --interactive --tty $CONTAINER_ID gunicorn --reload --bind 0.0.0.0:5000 --log-level debug --capture-output --timeout 600 timesketch.wsgi:application
+		;;
+	*)
+		echo \""$1"\" is not a valid command.; help
+esac

--- a/contrib/tsdev.sh
+++ b/contrib/tsdev.sh
@@ -43,7 +43,7 @@ else
 fi
 
 # Set variables required to execute commands
-CONTAINER_ID="$("$s" docker container list --filter name='timesketch-dev' --quiet)"
+CONTAINER_ID="$($s docker container list --filter name='timesketch-dev' --quiet)"
 frontend="frontend-ng"
 
 # Run the provided command


### PR DESCRIPTION
* Add sudo to commands that require root to execute successfully
* Add a help() function to display a useful help message
* Check for arguments, display the help message if no arguments are provided
* Use cases instead of if/elif statements (faster)
  * Organise cases by alphabetical order
  * Add a * case to catch when there is no valid input and display a help message
* Use long format (-- vs -) command options to improve readability
* Standardise on “-“ command naming convention over a mix of “-“ and “_”
  * Specifically: change “build_api_cli” to “build-api-cli” as there is already a strong precedent among the "vue" commands and the "-h, --help" option
* Verified that all commands are still functioning the same


