### PR TITLE
Fix tsctl on a prod deployment

### DIFF
--- a/timesketch/tsctl.py
+++ b/timesketch/tsctl.py
@@ -495,24 +495,39 @@ def info():
         print("psort.py not installed")
 
     # Get installed node version
-    output = subprocess.check_output(["node", "--version"]).decode("utf-8")
-    print(f"Node version: {output} ")
+    try:
+        output = subprocess.check_output(["node", "--version"]).decode("utf-8")
+        print(f"Node version: {output} ")
+    except FileNotFoundError:
+        print("Node not installed. Node is only used in the dev environment.")
 
-    # Get installed npm version
-    output = subprocess.check_output(["npm", "--version"]).decode("utf-8")
-    print(f"npm version: {output}")
+    try:
+        # Get installed npm version
+        output = subprocess.check_output(["npm", "--version"]).decode("utf-8")
+        print(f"npm version: {output}")
+    except FileNotFoundError:
+        print("npm not installed. npm is only used in the dev environment.")
 
-    # Get installed yarn version
-    output = subprocess.check_output(["yarn", "--version"]).decode("utf-8")
-    print(f"yarn version: {output} ")
+    try:
+        # Get installed yarn version
+        output = subprocess.check_output(["yarn", "--version"]).decode("utf-8")
+        print(f"yarn version: {output} ")
+    except FileNotFoundError:
+        print("yarn not installed. Yarn is only used in the dev environment.")
 
-    # Get installed python version
-    output = subprocess.check_output(["python3", "--version"]).decode("utf-8")
-    print(f"Python version: {output} ")
+    try:
+        # Get installed python version
+        output = subprocess.check_output(["python3", "--version"]).decode("utf-8")
+        print(f"Python version: {output} ")
+    except FileNotFoundError:
+        print("Python3 not installed")
 
-    # Get installed pip version
-    output = subprocess.check_output(["pip", "--version"]).decode("utf-8")
-    print(f"pip version: {output} ")
+    try:
+        # Get installed pip version
+        output = subprocess.check_output(["pip", "--version"]).decode("utf-8")
+        print(f"pip version: {output} ")
+    except FileNotFoundError:
+        print("pip not installed")
 
 
 def print_table(table_data):


### PR DESCRIPTION
The command `tsctl info` checks for the version of certain tools used for the deployment. However, packages like `node`, `npm` and `yarn` are only used in the development container and not in the prod deployments. Hence running the command did crash when it did not find the binaries to check the version.

This PR adds a try/catch to those checks and returns the necessary information to the user.

**Closing issues**

closes #3080 
