### PR TITLE
Fix analyzers fetching active sessions

### DIFF
--- a/timesketch/frontend-ng/src/components/LeftPanel/AnalyzerResults.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/AnalyzerResults.vue
@@ -377,7 +377,7 @@ export default {
               return
             }
             const lastActiveCount = this.activeAnalyses.length
-            const activeAnalyses = await this.fetchActiveAnalyses(this.$store, this.sketch.id)
+            const activeAnalyses = await this.fetchActiveAnalyses(this.sketch.id)
 
             // Refetch analyzer results if some analyzer finished.
             if (lastActiveCount !== activeAnalyses.length) {


### PR DESCRIPTION
This PR fixes an issue that was discovered after releasing version 20240805 where an invalid API path that existed before is now returning a 404 error.

The problem was a unused parameter `this.store` in the `fetchActiveAnalyses` function. Removing the parameter from the function call fixes the URL path and even speeds up the analyzer UI 👍  

**Closing issues**

closes #3092 

