### PR TITLE
Correct timeline_name length error message

### DIFF
--- a/timesketch/api/v1/resources/upload.py
+++ b/timesketch/api/v1/resources/upload.py
@@ -355,7 +355,7 @@ class UploadFileResource(resources.ResourceMixin, Resource):
         if len(timeline_name) > 255:
             abort(
                 HTTP_STATUS_CODE_BAD_REQUEST,
-                "Timeline name needs to be less than 255 characters.",
+                "Timeline name must not exceed 255 characters.",
             )
 
         # We do not need a human readable filename or


### PR DESCRIPTION
The error message suggests that the timeline name needs to be less than 255 characters, but this is incorrect. The actual requirement is that the timeline name should not exceed 255 characters, meaning it can be up to and including 255 characters long.