### PR TITLE
API Search Client max entries bug and standardize property usage

### DIFF
--- a/api_client/python/timesketch_api_client/search.py
+++ b/api_client/python/timesketch_api_client/search.py
@@ -504,16 +504,16 @@ class Search(resource.SketchResource):
         if not isinstance(query_filter, dict):
             raise ValueError("Unable to query with a query filter that isn't a dict.")
 
-        stop_size = self._max_entries
+        stop_size = self.max_entries
         scrolling = not bool(stop_size and (stop_size < self.DEFAULT_SIZE_LIMIT))
 
         if self.scrolling is not None:
             scrolling = self.scrolling
 
         form_data = {
-            "query": self._query_string,
+            "query": self.query_string,
             "filter": query_filter,
-            "dsl": self._query_dsl,
+            "dsl": self.query_dsl,
             "count": count,
             "fields": self.return_fields,
             "enable_scroll": scrolling,
@@ -546,7 +546,7 @@ class Search(resource.SketchResource):
         count = len(response_json.get("objects", []))
         total_count = count
         while count > 0:
-            if self._max_entries and total_count >= self._max_entries:
+            if self.max_entries and total_count >= self.max_entries:
                 break
 
             if not scroll_id:
@@ -740,14 +740,14 @@ class Search(resource.SketchResource):
             if "fields" in filter_dict:
                 fields = filter_dict.pop("fields")
                 return_fields = [x.get("field") for x in fields]
-                self._return_fields = ",".join(return_fields)
+                self.return_fields = ",".join(return_fields)
 
             indices = filter_dict.get("indices", [])
             if indices:
                 self.indices = indices
 
             self.query_filter = filter_dict
-        self._query_string = data.get("query_string", "")
+        self.query_string = data.get("query_string", "")
         self._resource_id = search_id
         self._searchtemplate = data.get("searchtemplate", 0)
         self._updated_at = data.get("updated_at", "")

--- a/api_client/python/timesketch_api_client/search.py
+++ b/api_client/python/timesketch_api_client/search.py
@@ -697,7 +697,7 @@ class Search(resource.SketchResource):
         self._return_fields = return_fields
 
         if max_entries:
-            self._max_entries = max_entries
+            self.max_entries = max_entries
 
         # TODO: Make use of search templates and aggregations.
         # self._searchtemplate = data.get('searchtemplate', 0)

--- a/api_client/python/timesketch_api_client/search.py
+++ b/api_client/python/timesketch_api_client/search.py
@@ -692,9 +692,9 @@ class Search(resource.SketchResource):
         if query_filter:
             self.query_filter = query_filter
 
-        self._query_string = query_string
+        self.query_string = query_string
         self.query_dsl = query_dsl
-        self._return_fields = return_fields
+        self.return_fields = return_fields
 
         if max_entries:
             self.max_entries = max_entries


### PR DESCRIPTION
**IMPORTANT: All Pull Requests should be connected to an issue, if you don't
have an issue, please start by creating an issue and link it to the PR.**

Please provide enough information so that others can review your pull request:
Fixes issue: #3100 

There is currently a bug in how `max_entries` is set in the `from_manual` function, causing the `query_filter` not to be set properly. I've also standardized a bit more to use the explicitly create properties, as I believe those were intended to be used over the `_propertyNames` ones.


**Checks**

- [x] All tests succeed.
- [ ] Unit tests added.
- [ ] e2e tests added.
- [ ] Documentation updated.

**Closing issues**
Closes #3100 
