### PR TITLE
fix #3107 - Add only tags created by an analyzer to the output

### DIFF
--- a/timesketch/lib/analyzers/interface.py
+++ b/timesketch/lib/analyzers/interface.py
@@ -257,7 +257,7 @@ class Event(object):
 
         # Add new tags to the analyzer output object
         if self._analyzer:
-            self._analyzer.output.add_created_tags(new_tags)
+            self._analyzer.output.add_created_tags(tags)
 
     def add_emojis(self, emojis):
         """Add emojis to the Event.
@@ -1432,7 +1432,12 @@ class AnalyzerOutput:
         Args:
             tags: The tags to add to the list of created_tags.
         """
-        self.add_meta_item("created_tags", tags)
+        existing_tags = self.platform_meta_data["created_tags"]
+        if existing_tags:
+            analyzer_tags = list(set().union(existing_tags, tags))
+        else:
+            analyzer_tags = tags
+        self.add_meta_item("created_tags", analyzer_tags)
 
     def add_created_attributes(self, attributes):
         """Adds a attributes to the list of created_attributes.

--- a/timesketch/lib/analyzers/interface.py
+++ b/timesketch/lib/analyzers/interface.py
@@ -1434,10 +1434,6 @@ class AnalyzerOutput:
         """
         existing_tags = self.platform_meta_data["created_tags"]
         analyzer_tags = list(set(existing_tags) | set(tags))
-        # if existing_tags:
-        #     analyzer_tags = list(set().union(existing_tags, tags))
-        # else:
-        #     analyzer_tags = tags
         self.add_meta_item("created_tags", analyzer_tags)
 
     def add_created_attributes(self, attributes):

--- a/timesketch/lib/analyzers/interface.py
+++ b/timesketch/lib/analyzers/interface.py
@@ -248,7 +248,7 @@ class Event(object):
                     "tags": existing_tags,
                 }
 
-        new_tags = list(set().union(existing_tags, tags))
+        new_tags = list(set(existing_tags) | set(tags))
         if self._analyzer:
             self._analyzer.tagged_events[self.event_id]["tags"] = new_tags
         else:
@@ -1389,7 +1389,7 @@ class AnalyzerOutput:
             item = [item]
         if key in self.platform_meta_data:
             self.platform_meta_data[key] = list(
-                set().union(self.platform_meta_data[key], item)
+                set(self.platform_meta_data[key]) | set(item)
             )
         else:
             self.platform_meta_data[key] = item
@@ -1433,10 +1433,11 @@ class AnalyzerOutput:
             tags: The tags to add to the list of created_tags.
         """
         existing_tags = self.platform_meta_data["created_tags"]
-        if existing_tags:
-            analyzer_tags = list(set().union(existing_tags, tags))
-        else:
-            analyzer_tags = tags
+        analyzer_tags = list(set(existing_tags) | set(tags))
+        # if existing_tags:
+        #     analyzer_tags = list(set().union(existing_tags, tags))
+        # else:
+        #     analyzer_tags = tags
         self.add_meta_item("created_tags", analyzer_tags)
 
     def add_created_attributes(self, attributes):


### PR DESCRIPTION
This PR fixes #3107 by adding only tags created by the analyzer itself to the analyzer output metadata field.

Before:
![image](https://github.com/google/timesketch/assets/99879757/ddef24d7-bf18-4004-aa92-e6660fa33e7a)

After:
![image](https://github.com/google/timesketch/assets/99879757/a208b989-19a0-4641-829f-0e0be65c31cf)


**Closing issues**

closes #3107 
