### PR TITLE
Remove duplicative flush() call to address issue 2796.

### DIFF
--- a/importer_client/python/tools/timesketch_importer.py
+++ b/importer_client/python/tools/timesketch_importer.py
@@ -140,9 +140,6 @@ def upload_file(
 
         streamer.add_file(file_path)
 
-        # Force a flush.
-        streamer.flush()
-
         timeline = streamer.timeline
         task_id = streamer.celery_task_id
 


### PR DESCRIPTION
+ What existing problem does this PR solve?
Issue #2796 
+ What new feature is being introduced with this PR?
N/A
+ Overview of changes to existing functions if required.
Removes duplicative call to `flush()` from the `upload_file` function in `timesketch_importer.py`

<!-- Example: This PR adds a function to do X, which adds the ability to do Y.
-->

**Checks**

- [ ] All tests succeed.
- [ ] Unit tests added.
- [ ] e2e tests added.

**Closing issues**
Closes #2796 
