### PR TITLE
Some changes to the Yeti Indicators analyzer

### DIFF
--- a/timesketch/lib/analyzers/yetiindicators.py
+++ b/timesketch/lib/analyzers/yetiindicators.py
@@ -128,9 +128,7 @@ class YetiBaseAnalyzer(interface.BaseAnalyzer):
             )
 
         access_token = response.json()["access_token"]
-        self._yeti_session.headers.update(
-            {"authorization": f"Bearer {access_token}"}
-        )
+        self._yeti_session.headers.update({"authorization": f"Bearer {access_token}"})
 
     def _get_neighbors_request(self, params: Dict) -> Dict:
         """Simple wrapper around requests call to make testing easier."""
@@ -287,16 +285,12 @@ class YetiBaseAnalyzer(interface.BaseAnalyzer):
                 return
 
             uri = f"{self.yeti_web_root}/indicators/{indicator['id']}"
-            intel_type = INDICATOR_LOCATION_MAPPING.get(
-                indicator["location"], "other"
-            )
+            intel_type = INDICATOR_LOCATION_MAPPING.get(indicator["location"], "other")
             tags = indicator["relevant_tags"]
 
         if indicator["root_type"] == "observable":
             match_in_sketch = indicator["value"]
-            intel_type = OBSERVABLE_INTEL_MAPPING.get(
-                indicator["type"], "other"
-            )
+            intel_type = OBSERVABLE_INTEL_MAPPING.get(indicator["type"], "other")
             uri = f"{self.yeti_web_root}/observables/{indicator['id']}"
             tags = list(indicator["tags"].keys())
 
@@ -331,9 +325,7 @@ class YetiBaseAnalyzer(interface.BaseAnalyzer):
     def get_intelligence_attribute(self) -> Tuple[Dict, Set[Tuple[str, str]]]:
         """Fetches the intelligence attribute from the database."""
         try:
-            intelligence_attribute = self.sketch.get_sketch_attributes(
-                "intelligence"
-            )
+            intelligence_attribute = self.sketch.get_sketch_attributes("intelligence")
 
             # In some cases, the intelligence attribute may be split into
             # multiple "values" due tu race conditions. Merge them if that's
@@ -468,9 +460,7 @@ class YetiBaseAnalyzer(interface.BaseAnalyzer):
                 str(exception),
             )
             return None
-        return {
-            "query": {"query_string": {"query": parsed_sigma["search_query"]}}
-        }
+        return {"query": {"query_string": {"query": parsed_sigma["search_query"]}}}
 
     def run(self):
         """Entry point for the analyzer.
@@ -519,9 +509,7 @@ class YetiBaseAnalyzer(interface.BaseAnalyzer):
                 elif indicator["type"] == "query":
                     if indicator["query_type"] == "opensearch":
                         query_dsl = {
-                            "query": {
-                                "query_string": {"query": indicator["pattern"]}
-                            }
+                            "query": {"query_string": {"query": indicator["pattern"]}}
                         }
                 if not query_dsl:
                     logging.warning(
@@ -544,9 +532,7 @@ class YetiBaseAnalyzer(interface.BaseAnalyzer):
                         if entity["type"] in HIGH_SEVERITY_TYPES:
                             priority = "HIGH"
                             if self._SAVE_INTELLIGENCE:
-                                self.add_intelligence_entry(
-                                    indicator, event, entity
-                                )
+                                self.add_intelligence_entry(indicator, event, entity)
 
                         entities_found.add(f"{entity['name']}:{entity['type']}")
                         indicator_match += 1

--- a/timesketch/lib/analyzers/yetiindicators.py
+++ b/timesketch/lib/analyzers/yetiindicators.py
@@ -39,8 +39,6 @@ OBSERVABLE_INTEL_MAPPING = {
     "md5": "hash_md5",
 }
 
-NEIGHBOR_CACHE = {}
-
 HIGH_SEVERITY_TYPES = {
     "malware",
     "threat-actor",
@@ -156,9 +154,6 @@ class YetiBaseAnalyzer(interface.BaseAnalyzer):
         Returns:
           A list of dictionaries describing a Yeti object.
         """
-        if yeti_object["id"] in NEIGHBOR_CACHE:
-            return NEIGHBOR_CACHE[yeti_object["id"]]
-
         extended_id = f"{yeti_object['root_type']}/{yeti_object['id']}"
         request = {
             "count": 0,
@@ -173,15 +168,11 @@ class YetiBaseAnalyzer(interface.BaseAnalyzer):
         results = self._get_neighbors_request(request)
         neighbors = {}
         for neighbor in results.get("vertices", {}).values():
-            # Yeti will return all vertices in the graph's path, not just
-            # the ones that are fo type target_types. We still want these
-            # in the cache.
             if (
                 neighbor["type"] in neighbor_types
                 or neighbor["root_type"] in neighbor_types
             ):
                 neighbors[neighbor["id"]] = neighbor
-            NEIGHBOR_CACHE[yeti_object["id"]] = neighbors
         return neighbors
 
     def _get_entities_request(self, params):

--- a/timesketch/lib/analyzers/yetiindicators.py
+++ b/timesketch/lib/analyzers/yetiindicators.py
@@ -4,7 +4,7 @@ import datetime
 import json
 import logging
 import re
-from typing import Dict, List, Optional, Union, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 import requests
 import yaml

--- a/timesketch/lib/analyzers/yetiindicators_test.py
+++ b/timesketch/lib/analyzers/yetiindicators_test.py
@@ -111,6 +111,7 @@ class TestYetiIndicators(BaseTest):
         "YetiBaseAnalyzer._get_entities_request"
     )
     def test_api_query(self, mock_get_entities, mock_get_neighbors):
+        """Tests that queries to the API are well-formed."""
         analyzer = YetiTestAnalyzer("test_index", 1, 123)
         analyzer.datastore.client = mock.Mock()
         mock_get_entities.return_value = MOCK_YETI_ENTITY_REQUEST

--- a/timesketch/lib/analyzers/yetiindicators_test.py
+++ b/timesketch/lib/analyzers/yetiindicators_test.py
@@ -78,6 +78,17 @@ MATCHING_PATH_MESSAGE = {
     "message": "/usr/bin/dhpcd",
 }
 
+class YetiTestAnalyzer(yetiindicators.YetiBaseAnalyzer):
+    NAME = "yetitest"
+    DISPLAY_NAME = "Test for yeti analyzer"
+    DESCRIPTION = "Just an analyzer for teting"
+
+    _TYPE_SELECTOR = ["investigation:tag1,tag2", "malware"]
+    _TARGET_NEIGHBOR_TYPE = ["sigma", "query", "regex", "observable"]
+    _SAVE_INTELLIGENCE = True
+    _DIRECTION = "any"
+    _MAX_HOPS = 1
+
 
 class TestYetiIndicators(BaseTest):
     """Tests the functionality of the YetiIndicators analyzer."""
@@ -89,7 +100,49 @@ class TestYetiIndicators(BaseTest):
         yetiindicators.NEIGHBOR_CACHE = {}
 
     # Mock the OpenSearch datastore.
-    @mock.patch("timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore)
+    @mock.patch(
+        "timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore
+    )
+    @mock.patch(
+        "timesketch.lib.analyzers.yetiindicators."
+        "YetiBaseAnalyzer._get_neighbors_request"
+    )
+    @mock.patch(
+        "timesketch.lib.analyzers.yetiindicators."
+        "YetiBaseAnalyzer._get_entities_request"
+    )
+    def test_api_query(self, mock_get_entities, mock_get_neighbors):
+        analyzer = YetiTestAnalyzer("test_index", 1, 123)
+        analyzer.datastore.client = mock.Mock()
+        mock_get_entities.return_value = MOCK_YETI_ENTITY_REQUEST
+        mock_get_neighbors.return_value = MOCK_YETI_NEIGHBORS_RESPONSE
+
+        analyzer.run()
+        mock_get_entities.assert_any_call(
+            {
+                "query": {
+                    "name": "",
+                    "tags": ["tag1", "tag2"],
+                    "type": "investigation",
+                },
+                "count": 0,
+            }
+        )
+        mock_get_entities.assert_any_call(
+            {
+                "query": {
+                    "name": "",
+                    "tags": [],
+                    "type": "malware",
+                },
+                "count": 0,
+            }
+        )
+
+    # Mock the OpenSearch datastore.
+    @mock.patch(
+        "timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore
+    )
     @mock.patch(
         "timesketch.lib.analyzers.yetiindicators."
         "YetiBaseAnalyzer._get_neighbors_request"
@@ -105,7 +158,9 @@ class TestYetiIndicators(BaseTest):
         mock_get_entities.return_value = MOCK_YETI_ENTITY_REQUEST
         mock_get_neighbors.return_value = MOCK_YETI_NEIGHBORS_RESPONSE
 
-        analyzer.datastore.import_event("test_index", MATCHING_PATH_MESSAGE, "0")
+        analyzer.datastore.import_event(
+            "test_index", MATCHING_PATH_MESSAGE, "0"
+        )
 
         message = json.loads(analyzer.run())
         self.assertEqual(
@@ -115,15 +170,17 @@ class TestYetiIndicators(BaseTest):
                 "Entities found: xmrig:malware"
             ),
         )
-        mock_get_entities.assert_called_once()
-        mock_get_neighbors.assert_called_once()
+        mock_get_entities.assert_called()
+        mock_get_neighbors.assert_called()
         self.assertEqual(
             sorted(analyzer.tagged_events["0"]["tags"]),
             sorted(["malware", "xmrig"]),
         )
 
     # Mock the OpenSearch datastore.
-    @mock.patch("timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore)
+    @mock.patch(
+        "timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore
+    )
     @mock.patch(
         "timesketch.lib.analyzers.yetiindicators."
         "YetiBaseAnalyzer._get_neighbors_request"
@@ -144,10 +201,12 @@ class TestYetiIndicators(BaseTest):
             message["result_summary"],
             "0/1 indicators were found in the timeline (0 failed)",
         )
-        mock_get_entities.assert_called_once()
-        mock_get_neighbors.asset_called_once()
+        mock_get_entities.assert_called()
+        mock_get_neighbors.asset_called()
 
-    @mock.patch("timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore)
+    @mock.patch(
+        "timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore
+    )
     def test_slug(self):
         """Tests that slugs are formed correctly."""
         analyzer = yetiindicators.YetiMalwareIndicators("test_index", 1, 123)
@@ -164,7 +223,9 @@ class TestYetiIndicators(BaseTest):
             [sorted(x) for x in mock_event.add_tags.call_args[0]],
         )
 
-    @mock.patch("timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore)
+    @mock.patch(
+        "timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore
+    )
     def test_build_query_from_regexp(self):
         """Tests that that queries are correctly built from regex indicators."""
         analyzer = yetiindicators.YetiMalwareIndicators("test_index", 1, 123)
@@ -214,7 +275,9 @@ class TestYetiIndicators(BaseTest):
             },
         )
 
-    @mock.patch("timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore)
+    @mock.patch(
+        "timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore
+    )
     def test_build_query_from_sigma(self):
         """Tests that that queries are correctly built from sigma indicators."""
         analyzer = yetiindicators.YetiMalwareIndicators("test_index", 1, 123)
@@ -272,7 +335,9 @@ tags:
             },
         )
 
-    @mock.patch("timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore)
+    @mock.patch(
+        "timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore
+    )
     def test_build_query_from_observable(self):
         """Tests that that queries are correctly built from regex indicators."""
         analyzer = yetiindicators.YetiMalwareIndicators("test_index", 1, 123)

--- a/timesketch/lib/analyzers/yetiindicators_test.py
+++ b/timesketch/lib/analyzers/yetiindicators_test.py
@@ -101,9 +101,7 @@ class TestYetiIndicators(BaseTest):
         yetiindicators.NEIGHBOR_CACHE = {}
 
     # Mock the OpenSearch datastore.
-    @mock.patch(
-        "timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore
-    )
+    @mock.patch("timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore)
     @mock.patch(
         "timesketch.lib.analyzers.yetiindicators."
         "YetiBaseAnalyzer._get_neighbors_request"
@@ -141,9 +139,7 @@ class TestYetiIndicators(BaseTest):
         )
 
     # Mock the OpenSearch datastore.
-    @mock.patch(
-        "timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore
-    )
+    @mock.patch("timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore)
     @mock.patch(
         "timesketch.lib.analyzers.yetiindicators."
         "YetiBaseAnalyzer._get_neighbors_request"
@@ -159,9 +155,7 @@ class TestYetiIndicators(BaseTest):
         mock_get_entities.return_value = MOCK_YETI_ENTITY_REQUEST
         mock_get_neighbors.return_value = MOCK_YETI_NEIGHBORS_RESPONSE
 
-        analyzer.datastore.import_event(
-            "test_index", MATCHING_PATH_MESSAGE, "0"
-        )
+        analyzer.datastore.import_event("test_index", MATCHING_PATH_MESSAGE, "0")
 
         message = json.loads(analyzer.run())
         self.assertEqual(
@@ -179,9 +173,7 @@ class TestYetiIndicators(BaseTest):
         )
 
     # Mock the OpenSearch datastore.
-    @mock.patch(
-        "timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore
-    )
+    @mock.patch("timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore)
     @mock.patch(
         "timesketch.lib.analyzers.yetiindicators."
         "YetiBaseAnalyzer._get_neighbors_request"
@@ -205,9 +197,7 @@ class TestYetiIndicators(BaseTest):
         mock_get_entities.assert_called()
         mock_get_neighbors.asset_called()
 
-    @mock.patch(
-        "timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore
-    )
+    @mock.patch("timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore)
     def test_slug(self):
         """Tests that slugs are formed correctly."""
         analyzer = yetiindicators.YetiBadnessIndicators("test_index", 1, 123)
@@ -224,9 +214,7 @@ class TestYetiIndicators(BaseTest):
             [sorted(x) for x in mock_event.add_tags.call_args[0]],
         )
 
-    @mock.patch(
-        "timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore
-    )
+    @mock.patch("timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore)
     def test_build_query_from_regexp(self):
         """Tests that that queries are correctly built from regex indicators."""
         analyzer = yetiindicators.YetiBadnessIndicators("test_index", 1, 123)
@@ -276,9 +264,7 @@ class TestYetiIndicators(BaseTest):
             },
         )
 
-    @mock.patch(
-        "timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore
-    )
+    @mock.patch("timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore)
     def test_build_query_from_sigma(self):
         """Tests that that queries are correctly built from sigma indicators."""
         analyzer = yetiindicators.YetiBadnessIndicators("test_index", 1, 123)
@@ -336,9 +322,7 @@ tags:
             },
         )
 
-    @mock.patch(
-        "timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore
-    )
+    @mock.patch("timesketch.lib.analyzers.interface.OpenSearchDataStore", MockDataStore)
     def test_build_query_from_observable(self):
         """Tests that that queries are correctly built from regex indicators."""
         analyzer = yetiindicators.YetiBadnessIndicators("test_index", 1, 123)

--- a/timesketch/lib/analyzers/yetiindicators_test.py
+++ b/timesketch/lib/analyzers/yetiindicators_test.py
@@ -78,6 +78,7 @@ MATCHING_PATH_MESSAGE = {
     "message": "/usr/bin/dhpcd",
 }
 
+
 class YetiTestAnalyzer(yetiindicators.YetiBaseAnalyzer):
     NAME = "yetitest"
     DISPLAY_NAME = "Test for yeti analyzer"
@@ -153,7 +154,7 @@ class TestYetiIndicators(BaseTest):
     )
     def test_indicator_match(self, mock_get_entities, mock_get_neighbors):
         """Test that ES queries for indicators are correctly built."""
-        analyzer = yetiindicators.YetiMalwareIndicators("test_index", 1, 123)
+        analyzer = yetiindicators.YetiBadnessIndicators("test_index", 1, 123)
         analyzer.datastore.client = mock.Mock()
         mock_get_entities.return_value = MOCK_YETI_ENTITY_REQUEST
         mock_get_neighbors.return_value = MOCK_YETI_NEIGHBORS_RESPONSE
@@ -191,7 +192,7 @@ class TestYetiIndicators(BaseTest):
     )
     def test_indicator_nomatch(self, mock_get_entities, mock_get_neighbors):
         """Test that ES queries for indicators are correctly built."""
-        analyzer = yetiindicators.YetiMalwareIndicators("test_index", 1, 123)
+        analyzer = yetiindicators.YetiBadnessIndicators("test_index", 1, 123)
         analyzer.datastore.client = mock.Mock()
         mock_get_entities.return_value = MOCK_YETI_ENTITY_REQUEST
         mock_get_neighbors.return_value = MOCK_YETI_NEIGHBORS_RESPONSE
@@ -209,7 +210,7 @@ class TestYetiIndicators(BaseTest):
     )
     def test_slug(self):
         """Tests that slugs are formed correctly."""
-        analyzer = yetiindicators.YetiMalwareIndicators("test_index", 1, 123)
+        analyzer = yetiindicators.YetiBadnessIndicators("test_index", 1, 123)
         mock_event = mock.Mock()
         mock_event.get_comments.return_value = []
         analyzer.mark_event(
@@ -228,7 +229,7 @@ class TestYetiIndicators(BaseTest):
     )
     def test_build_query_from_regexp(self):
         """Tests that that queries are correctly built from regex indicators."""
-        analyzer = yetiindicators.YetiMalwareIndicators("test_index", 1, 123)
+        analyzer = yetiindicators.YetiBadnessIndicators("test_index", 1, 123)
         query = analyzer.build_query_from_regexp(
             {
                 "name": "random regex",
@@ -280,7 +281,7 @@ class TestYetiIndicators(BaseTest):
     )
     def test_build_query_from_sigma(self):
         """Tests that that queries are correctly built from sigma indicators."""
-        analyzer = yetiindicators.YetiMalwareIndicators("test_index", 1, 123)
+        analyzer = yetiindicators.YetiBadnessIndicators("test_index", 1, 123)
         sigma_pattern = """id: asd
 title: test
 description: test
@@ -340,7 +341,7 @@ tags:
     )
     def test_build_query_from_observable(self):
         """Tests that that queries are correctly built from regex indicators."""
-        analyzer = yetiindicators.YetiMalwareIndicators("test_index", 1, 123)
+        analyzer = yetiindicators.YetiBadnessIndicators("test_index", 1, 123)
         query = analyzer.build_query_from_observable(
             {
                 "value": "C:\\ProgramFiles\\mimi.exe",


### PR DESCRIPTION
* Be a bit more flexible in the way entities are selected - they now take `<TYPE>:<TAGS>` pairs, allowing to be a bit more granular.
* Rename YetiMalwareAnalyzer to YetiBadnessAnalyzer (because it uses a new type selector: `["malware", "attack-pattern:exploit"]`)
* Disables caching functionality which introduced a bug and wasn't helpful at all
