### PR TITLE
Fix aggregator endpoints in RestApiClient 

### DIFF
--- a/timesketch/frontend-ng/src/utils/RestApiClient.js
+++ b/timesketch/frontend-ng/src/utils/RestApiClient.js
@@ -275,10 +275,10 @@ export default {
     return RestApiClient.get('/sketches/' + sketchId + '/aggregation/')
   },
   getAggregationById(sketchId, aggregationId) {
-    return RestApiClient.get('/sketches/' + sketchId + '/aggregation/' + aggregationId)
+    return RestApiClient.get('/sketches/' + sketchId + '/aggregation/' + aggregationId + '/')
   },
   deleteAggregationById(sketchId, aggregationId) {
-    return RestApiClient.delete('/sketches/' + sketchId + '/aggregation/' + aggregationId)
+    return RestApiClient.delete('/sketches/' + sketchId + '/aggregation/' + aggregationId + '/')
   },
   getAggregationGroups(sketchId) {
     return RestApiClient.get('/sketches/' + sketchId + '/aggregation/group/')


### PR DESCRIPTION
Api calls via getAggregationById result in HTTP redirects.   This PR adds trailing slashes to prevent the redirects

**Checks**

- [ ] All tests succeed.
- [ ] Unit tests added.
- [ ] e2e tests added.
- [ ] Documentation updated.

**Closing issues**

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes
(if such).
