### PR TITLE
Add timeline selection to visualization editor

### DIFF
--- a/timesketch/frontend-ng/src/components/Analyzer/TimelineSearch.vue
+++ b/timesketch/frontend-ng/src/components/Analyzer/TimelineSearch.vue
@@ -27,7 +27,7 @@ limitations under the License.
       v-model="selectedTimelines"
       :items="allReadyTimelines"
       outlined
-      label="Select timelines for analysis"
+      :label="`Select timelines for ${componentName}`"
       item-text="name"
       item-value="id"
       multiple
@@ -63,7 +63,7 @@ export default {
   components:{
     TsAnalyzerTimelineChip,
   },
-  props: ['analyzerTimelineId'],
+  props: ['analyzerTimelineId', 'componentName'],
   data() {
     return {
       selectedTimelines: [],

--- a/timesketch/frontend-ng/src/components/Visualization/VisualizationEditor.vue
+++ b/timesketch/frontend-ng/src/components/Visualization/VisualizationEditor.vue
@@ -39,7 +39,7 @@ limitations under the License.
     <v-row class="mt-3">
       <v-col >
         <v-container class="ma-0">
-          <ts-timeline-search @selectedTimelines="selectedTimelineIDs = $event"></ts-timeline-search>
+          <ts-timeline-search componentName="visualization" @selectedTimelines="selectedTimelineIDs = $event"></ts-timeline-search>
         </v-container>
       </v-col>
     </v-row>

--- a/timesketch/frontend-ng/src/components/Visualization/VisualizationEditor.vue
+++ b/timesketch/frontend-ng/src/components/Visualization/VisualizationEditor.vue
@@ -46,6 +46,7 @@ limitations under the License.
     <v-row class="mt-3">
       <v-col>
         <TsAggregationConfig
+          v-if="selectedTimelineIDs.length > 0"
           :field="selectedField"
           @updateField="selectedField = $event"
           :aggregator="selectedAggregator"
@@ -62,6 +63,7 @@ limitations under the License.
           @updateSplitByTimeline="selectedSplitByTimeline = $event"
         ></TsAggregationConfig>
         <TsChartConfig
+          v-if="selectedTimelineIDs.length > 0"
           :aggregatorType="selectedAggregator"
           :chartType="selectedChartType"
           @updateChartType="selectedChartType = $event"
@@ -85,7 +87,7 @@ limitations under the License.
         </v-col>
         <v-col cols="8">
           <TsChartCard
-            v-if="chartSeries && selectedChartType"
+            v-if="selectedTimelineIDs.length > 0 && chartSeries && selectedChartType"
             :fieldName="selectedField.field"
             :metricName="selectedMetric"
             :is-time-series="selectedAggregator ? selectedAggregator.endsWith('date_histogram') : false"
@@ -105,6 +107,7 @@ limitations under the License.
       <v-divider class="mx-3"></v-divider>
       <div class="mt-4">
         <v-btn
+          v-if="selectedTimelineIDs.length > 0"
           class="ml-3"
           color="primary"
           :disabled="response == null || !selectedChartTitle"
@@ -114,6 +117,7 @@ limitations under the License.
         </v-btn>
 
         <v-btn
+          v-if="selectedTimelineIDs.length > 0"
           text
           color="primary"
           @click="loadAggregationData"
@@ -128,6 +132,7 @@ limitations under the License.
         </v-btn>
 
         <v-btn
+          v-if="selectedTimelineIDs.length > 0"
           text
           @click="clear"
           :disabled="!(
@@ -139,6 +144,7 @@ limitations under the License.
           Clear
         </v-btn>
         <v-btn
+          v-if="selectedTimelineIDs.length > 0"
           text
           @click="clear"
           :to="{ name: 'Explore' }"

--- a/timesketch/frontend-ng/src/components/Visualization/VisualizationEditor.vue
+++ b/timesketch/frontend-ng/src/components/Visualization/VisualizationEditor.vue
@@ -39,14 +39,17 @@ limitations under the License.
     <v-row class="mt-3">
       <v-col >
         <v-container class="ma-0">
-          <ts-timeline-search componentName="visualization" @selectedTimelines="selectedTimelineIDs = $event"></ts-timeline-search>
+          <ts-timeline-search 
+            componentName="visualization" 
+            :analyzerTimelineId="selectedTImelineIDs"
+            @selectedTimelines="selectedTimelineIDs = $event"></ts-timeline-search>
         </v-container>
       </v-col>
     </v-row>
     <v-row class="mt-3">
       <v-col>
         <TsAggregationConfig
-          v-if="selectedTimelineIDs.length > 0"
+          @enabled="selectedTimelineIDs.length > 0"
           :field="selectedField"
           @updateField="selectedField = $event"
           :aggregator="selectedAggregator"
@@ -63,7 +66,6 @@ limitations under the License.
           @updateSplitByTimeline="selectedSplitByTimeline = $event"
         ></TsAggregationConfig>
         <TsChartConfig
-          v-if="selectedTimelineIDs.length > 0"
           :aggregatorType="selectedAggregator"
           :chartType="selectedChartType"
           @updateChartType="selectedChartType = $event"
@@ -87,7 +89,7 @@ limitations under the License.
         </v-col>
         <v-col cols="8">
           <TsChartCard
-            v-if="selectedTimelineIDs.length > 0 && chartSeries && selectedChartType"
+            v-if="chartSeries && selectedChartType"
             :fieldName="selectedField.field"
             :metricName="selectedMetric"
             :is-time-series="selectedAggregator ? selectedAggregator.endsWith('date_histogram') : false"
@@ -107,21 +109,19 @@ limitations under the License.
       <v-divider class="mx-3"></v-divider>
       <div class="mt-4">
         <v-btn
-          v-if="selectedTimelineIDs.length > 0"
           class="ml-3"
           color="primary"
-          :disabled="response == null || !selectedChartTitle"
+          :disabled="selectedTimelineIDs.length == 0 || response == null || !selectedChartTitle"
           @click="saveVisualization"
         >
           Save
         </v-btn>
 
         <v-btn
-          v-if="selectedTimelineIDs.length > 0"
           text
           color="primary"
           @click="loadAggregationData"
-          :disabled="!(
+          :disabled="selectedTimelineIDs.length == 0 || !(
             selectedField &&
             selectedAggregator &&
             selectedChartType
@@ -132,7 +132,6 @@ limitations under the License.
         </v-btn>
 
         <v-btn
-          v-if="selectedTimelineIDs.length > 0"
           text
           @click="clear"
           :disabled="!(
@@ -144,7 +143,6 @@ limitations under the License.
           Clear
         </v-btn>
         <v-btn
-          v-if="selectedTimelineIDs.length > 0"
           text
           @click="clear"
           :to="{ name: 'Explore' }"

--- a/timesketch/frontend-ng/src/components/Visualization/VisualizationEditor.vue
+++ b/timesketch/frontend-ng/src/components/Visualization/VisualizationEditor.vue
@@ -37,6 +37,13 @@ limitations under the License.
     </v-toolbar>
     <v-divider class="mx-3"></v-divider>
     <v-row class="mt-3">
+      <v-col >
+        <v-container class="ma-0">
+          <ts-timeline-search @selectedTimelines="selectedTimelineIDs = $event"></ts-timeline-search>
+        </v-container>
+      </v-col>
+    </v-row>
+    <v-row class="mt-3">
       <v-col>
         <TsAggregationConfig
           :field="selectedField"
@@ -147,12 +154,14 @@ import ApiClient from '../../utils/RestApiClient'
 import TsAggregationConfig from './AggregationConfig.vue'
 import TsChartConfig from './ChartConfig.vue'
 import TsChartCard from './ChartCard.vue'
+import TsTimelineSearch from '../Analyzer/TimelineSearch.vue'
 
 export default {
   components: {
     TsAggregationConfig,
     TsChartConfig,
     TsChartCard,
+    TsTimelineSearch,
   },
   props: {
     aggregator: {

--- a/timesketch/frontend-ng/src/components/Visualization/VisualizationEditor.vue
+++ b/timesketch/frontend-ng/src/components/Visualization/VisualizationEditor.vue
@@ -41,7 +41,6 @@ limitations under the License.
         <v-container class="ma-0">
           <ts-timeline-search 
             componentName="visualization" 
-            :analyzerTimelineId="selectedTImelineIDs"
             @selectedTimelines="selectedTimelineIDs = $event"></ts-timeline-search>
         </v-container>
       </v-col>

--- a/timesketch/frontend-ng/src/views/Analyze.vue
+++ b/timesketch/frontend-ng/src/views/Analyze.vue
@@ -17,7 +17,7 @@ limitations under the License.
   <v-container fluid>
     <v-card flat class="pa-3 pt-0 mt-n3" color="transparent">
       <div class="mt-2">
-        <ts-timeline-search :analyzer-timeline-id="analyzerTimelineId" @selectedTimelines="timelineSelection = $event"></ts-timeline-search>
+        <ts-timeline-search componentName="analysis" :analyzer-timeline-id="analyzerTimelineId" @selectedTimelines="timelineSelection = $event"></ts-timeline-search>
       </div>
       <v-divider></v-divider>
       <div>


### PR DESCRIPTION
This PR adds a timeline selection component to the visualization editor to allow the user to select specific timelines when creating aggregations/charts.

- [x] All tests succeed.
- [x] Unit tests added.
- [ ] e2e tests added.
- [ ] Documentation updated.

