### PR TITLE
Adding a dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/.github/workflows"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    allow:
+      - dependency-type: "direct"
+  - package-ecosystem: "pip"
+    directory: "/test_requirements.txt"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    allow:
+      - dependency-type: "direct"
+  - package-ecosystem: "npm"
+    directory: "/timesketch/frontend-ng"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    allow:
+      - dependency-type: "direct"
+# ignore dependencies of the legacy front-end since it is deprecated
+  - package-ecosystem: "npm"
+    directory: "/timesketch/frontend"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-type: "*"


### PR DESCRIPTION
Following up on #3131 - adding a dependabot config that ignores the legacy/deprecated frontend but still manages all other dependencies.

Based on the [dependabot.yml config docu](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)

This `dependabot.yml` file now effectively manages dependencies for:

* GitHub Actions: Weekly updates
* Main pip dependencies: Weekly updates, limited to 3 open PRs, direct dependencies only
* Test pip dependencies (in test_requirements.txt): Weekly updates, limited to 3 open PRs, direct dependencies only
* Vuetify frontend dependencies: Weekly updates, limited to 3 open PRs, direct dependencies only
* Legacy frontend dependencies: No updates (ignored)