### PR TITLE
[cli] timeline delete

### DIFF
--- a/cli_client/python/timesketch_cli_client/commands/timelines.py
+++ b/cli_client/python/timesketch_cli_client/commands/timelines.py
@@ -110,3 +110,29 @@ def rename_timeline(ctx, timeline_id, new_name):
         click.echo(f'Unsupported output format: "{output}" - using "text" instead')
     else:
         click.echo(f"New name: {timeline.name}")
+
+
+@timelines_group.command("delete")
+@click.argument("timeline-id", type=int, required=True)
+@click.pass_context
+def delete_timeline(ctx, timeline_id):
+    """Delete a timeline.
+    (Will mark a timeline as deleted, but the Opensearch Index will remain)
+
+    Args:
+        ctx: Click CLI context object.
+        timeline-id: Timeline ID from argument to be deleted.
+    """
+    sketch = ctx.obj.sketch
+    timeline = sketch.get_timeline(timeline_id=timeline_id)
+    if not timeline:
+        click.echo("No such timeline")
+        return
+    timeline.lazyload_data()
+    if click.confirm(
+        f"Do you really want to mark the timeline as deleted: {timeline_id} {timeline.name}?"
+    ):
+        timeline.delete()
+
+    click.echo("Deleted")
+    return

--- a/docs/guides/user/cli-client.md
+++ b/docs/guides/user/cli-client.md
@@ -528,3 +528,14 @@ To rename a single timeline in a sketch, the command `timelines rename` can be u
 timesketch --sketch 1 timelines rename 1 foobar23
 ```
 
+### Delete a timeline
+
+The cli client is using the API to delete a timeline.
+
+As of August 2024, the API method to delete a timeline does only mark the reference in the database as deleted, the data will remain in Opensearch.
+
+```bash
+timesketch --sketch 1 timelines delete 1
+Do you really want to mark the timeline as deleted: 1 foobar23? [y/N]: y
+Deleted
+```

--- a/timesketch/api/v1/resources/searchindex.py
+++ b/timesketch/api/v1/resources/searchindex.py
@@ -214,6 +214,7 @@ class SearchIndexResource(resources.ResourceMixin, Resource):
             abort(HTTP_STATUS_CODE_FORBIDDEN, "\n".join(error_strings))
 
         searchindex.set_status(status="deleted")
+        # TODO: Actually implement to delete the index
         db_session.commit()
 
         other_indexes = SearchIndex.query.filter_by(


### PR DESCRIPTION
Introduce a new method in timesketch cli to delete timelines.

At the moment they are only marked as deleted. But moving forward that will change.

(It simply mimics what is already possible via API and UI).