### PR TITLE
[CLI+APIclient] Change timeline color for a given timeline

### DIFF
--- a/api_client/python/timesketch_api_client/timeline.py
+++ b/api_client/python/timesketch_api_client/timeline.py
@@ -79,6 +79,12 @@ class Timeline(resource.BaseResource):
             self._color = timeline["objects"][0]["color"]
         return self._color
 
+    @color.setter
+    def color(self, color):
+        """Change the color of the timeline."""
+        self._color = color
+        self._commit()
+
     @property
     def data_sources(self):
         """Property that returns the timeline data sources."""

--- a/cli_client/python/timesketch_cli_client/commands/timelines.py
+++ b/cli_client/python/timesketch_cli_client/commands/timelines.py
@@ -35,7 +35,7 @@ def list_timelines(ctx):
 
 
 @timelines_group.command("describe")
-@click.argument("timeline-id", type=int, required=False)
+@click.argument("timeline-id", type=int, required=True)
 @click.pass_context
 def describe_timeline(ctx, timeline_id):
     """Show details for a timeline.
@@ -62,6 +62,7 @@ def describe_timeline(ctx, timeline_id):
     click.echo(f"Status: {timeline.status}")
     lines_indexed = timeline.resource_data.get("meta").get("lines_indexed", 0)
     click.echo(f"Event count: {lines_indexed or 0}")
+    click.echo(f"Color: {timeline.color}")
 
     for timeline_object in timeline.resource_data.get("objects", None):
         name = timeline_object.get("name", "no name")
@@ -135,4 +136,30 @@ def delete_timeline(ctx, timeline_id):
         timeline.delete()
 
     click.echo("Deleted")
+    return
+
+
+@timelines_group.command("color")
+@click.argument("timeline-id", type=int, required=True)
+@click.argument("color", type=str, required=True)
+@click.pass_context
+def timeline_change_color(ctx, timeline_id, color):
+    """Change the color of a timeline (in HEX color code)
+
+    Args:
+        ctx: Click CLI context object.
+        timeline-id: Timeline ID from argument to be modified.
+        color: Hex value of color to be used for the timeline
+    """
+    sketch = ctx.obj.sketch
+    timeline = sketch.get_timeline(timeline_id=timeline_id)
+    if not timeline:
+        click.echo("No such timeline")
+        return
+    if not (len(color) == 4 or len(color) == 6):
+        click.echo("Color must be hex without leading # e.g. AAAA or AABB11")
+        return
+    timeline.lazyload_data()
+    timeline.color = color
+
     return

--- a/docs/guides/user/cli-client.md
+++ b/docs/guides/user/cli-client.md
@@ -520,6 +520,25 @@ timesketch --sketch 1 timelines list
 
 It is also possible to get all the output as JSON.
 
+### Describe a timeline
+
+The command `timelines describe` will provide several variables, names and settings for a given timeline.
+
+```
+timesketch --sketch 1 --output-format text timelines describe 2
+Name: foobar3
+Index: 41dde394812d44c1ac1784997d05efed
+Status: ready
+Event count: 260454
+Color: AAAAAA
+Name: foobar3
+Created: 2024-08-20T14:57:59.047015
+Datasources:
+	Original filename: win7-x86.plaso
+	File on disk: /tmp/4c3c1c5c351b4db285453bff0ecad51e
+	Error:
+```
+
 ### Rename timeline
 
 To rename a single timeline in a sketch, the command `timelines rename` can be used.
@@ -539,3 +558,47 @@ timesketch --sketch 1 timelines delete 1
 Confirm to mark the timeline deleted:: 1 foobar23? [y/N]: y
 Deleted
 ```
+
+### Change timeline color
+
+The color is an important setting for a timeline when using the WebUI. To change the color using the CLI `timelines color` can be used.
+
+Before:
+```bash
+timesketch --sketch 1 --output-format text timelines describe 2
+Name: foobar3
+Index: 41dde394812d44c1ac1784997d05efed
+Status: ready
+Event count: 260454
+Color: AAAAAA
+Name: foobar3
+Created: 2024-08-20T14:57:59.047015
+Datasources:
+	Original filename: win7-x86.plaso
+	File on disk: /tmp/4c3c1c5c351b4db285453bff0ecad51e
+	Error:
+```
+
+Using it:
+
+```bash
+timesketch --sketch 1 timelines color 2 BBBBBB
+```
+
+After:
+
+```bash
+timesketch --sketch 1 --output-format text timelines describe 2
+Name: foobar3
+Index: 41dde394812d44c1ac1784997d05efed
+Status: ready
+Event count: 260454
+Color: BBBBBB
+Name: foobar3
+Created: 2024-08-20T14:57:59.047015
+Datasources:
+	Original filename: win7-x86.plaso
+	File on disk: /tmp/4c3c1c5c351b4db285453bff0ecad51e
+	Error:
+```
+


### PR DESCRIPTION
# Change timeline color

The color is an important setting for a timeline when using the WebUI. To change the color using the CLI `timelines color` can be used.

This change also adds a setter for `timeline.color` in the API client that has not been present so far.


Before:
```bash
timesketch --sketch 1 --output-format text timelines describe 2
Name: foobar3
Index: 41dde394812d44c1ac1784997d05efed
Status: ready
Event count: 260454
Color: AAAAAA
Name: foobar3
Created: 2024-08-20T14:57:59.047015
Datasources:
	Original filename: win7-x86.plaso
	File on disk: /tmp/4c3c1c5c351b4db285453bff0ecad51e
	Error:
```

Using it:

```bash
timesketch --sketch 1 timelines color 2 BBBBBB
```

After:

```bash
timesketch --sketch 1 --output-format text timelines describe 2
Name: foobar3
Index: 41dde394812d44c1ac1784997d05efed
Status: ready
Event count: 260454
Color: BBBBBB
Name: foobar3
Created: 2024-08-20T14:57:59.047015
Datasources:
	Original filename: win7-x86.plaso
	File on disk: /tmp/4c3c1c5c351b4db285453bff0ecad51e
	Error:
```


This is the last feature request for https://github.com/google/timesketch/issues/2877