### PR TITLE
API client: Update scenario handling for dfiq 1.1 schema

### DIFF
--- a/api_client/python/timesketch_api_client/scenario.py
+++ b/api_client/python/timesketch_api_client/scenario.py
@@ -31,15 +31,17 @@ class Scenario(resource.BaseResource):
         api: An instance of TimesketchApi object.
     """
 
-    def __init__(self, sketch_id, scenario_id, api):
+    def __init__(self, sketch_id, scenario_id, uuid, api):
         """Initializes the Scenario object.
 
         Args:
             scenario_id: Primary key ID of the scenario.
             api: An instance of TiscmesketchApi object.
+            uuid: UUID of the scenario.
             sketch_id: ID of a sketch.
         """
         self.id = scenario_id
+        self.uuid = uuid
         self.api = api
         self.sketch_id = sketch_id
         super().__init__(
@@ -57,21 +59,11 @@ class Scenario(resource.BaseResource):
         return scenario["objects"][0]["name"]
 
     @property
-    def scenario_id(self):
-        """Property that returns the scenario id.
+    def dfiq_identifier(self):
+        """Property that returns the dfiq identifier.
 
         Returns:
-            Scenario id as integer.
-        """
-        scenario = self.lazyload_data()
-        return scenario["objects"][0]["id"]
-
-    @property
-    def dfiq_id(self):
-        """Property that returns the dfiq id.
-
-        Returns:
-            dfiq id as string.
+            dfiq identifier as string.
         """
         scenario = self.lazyload_data()
         return scenario["objects"][0]["dfiq_identifier"]
@@ -91,36 +83,6 @@ class Scenario(resource.BaseResource):
         return self.lazyload_data()
 
 
-class ScenarioTemplateList(resource.BaseResource):
-    """Timesketch scenario template list.
-
-    Attributes:
-        api: An instance of TimesketchApi object.
-    """
-
-    def __init__(self, api):
-        """Initializes the ScenarioList object.
-
-        Args:
-            api: An instance of TimesketchApi object.
-        """
-        self.api = api
-        super().__init__(api=api, resource_uri="scenarios/")
-
-    def get(self):
-        """
-        Retrieves a list of scenario templates.
-
-        Returns:
-            list: A list of Scenario tempaltes.
-        """
-        resource_url = f"{self.api.api_root}/scenarios/"
-        response = self.api.session.get(resource_url)
-        response_json = error.get_response_json(response, logger)
-        scenario_objects = response_json.get("objects", [])
-        return scenario_objects
-
-
 class Question(resource.BaseResource):
     """Timesketch question object.
 
@@ -129,7 +91,7 @@ class Question(resource.BaseResource):
         api: An instance of TimesketchApi object.
     """
 
-    def __init__(self, sketch_id, question_id, api):
+    def __init__(self, sketch_id, question_id, uuid, api):
         """Initializes the question object.
 
         Args:
@@ -138,6 +100,7 @@ class Question(resource.BaseResource):
             sketch_id: ID of a sketch.
         """
         self.id = question_id
+        self.uuid = uuid
         self.api = api
         self.sketch_id = sketch_id
         super().__init__(
@@ -155,21 +118,11 @@ class Question(resource.BaseResource):
         return question["objects"][0]["name"]
 
     @property
-    def question_id(self):
-        """Property that returns the question id.
-
-        Returns:
-            Question id as integer.
-        """
-        question = self.lazyload_data()
-        return question["objects"][0]["id"]
-
-    @property
-    def dfiq_id(self):
+    def dfiq_identifier(self):
         """Property that returns the question template id.
 
         Returns:
-            Question ID as string.
+            Question DFIQ identifier as string.
         """
         question = self.lazyload_data()
         return question["objects"][0]["dfiq_identifier"]
@@ -199,31 +152,33 @@ class Question(resource.BaseResource):
         return self.lazyload_data()
 
 
-class QuestionTemplateList(resource.BaseResource):
-    """Timesketch question template list.
+def getScenarioTemplateList(api):
+    """Retrieves a list of scenario templates.
 
-    Attributes:
+    Args:
         api: An instance of TimesketchApi object.
+
+    Returns:
+        list: A list of Scenario tempaltes.
     """
+    resource_url = f"{api.api_root}/scenarios/"
+    response = api.session.get(resource_url)
+    response_json = error.get_response_json(response, logger)
+    scenario_objects = response_json.get("objects", [])
+    return scenario_objects
 
-    def __init__(self, api):
-        """Initializes the QuestionList object.
 
-        Args:
-            api: An instance of TimesketchApi object.
-        """
-        self.api = api
-        super().__init__(api=api, resource_uri="questions/")
+def getQuestionTemplateList(api):
+    """Retrieves a list of question templates.
 
-    def get(self):
-        """
-        Retrieves a list of question templates.
+    Args:
+        api: An instance of TimesketchApi object.
 
-        Returns:
-            list: A list of question tempaltes.
-        """
-        resource_url = f"{self.api.api_root}/questions/"
-        response = self.api.session.get(resource_url)
-        response_json = error.get_response_json(response, logger)
-        scenario_objects = response_json.get("objects", [])
-        return scenario_objects
+    Returns:
+        list: A list of Question tempaltes.
+    """
+    resource_url = f"{api.api_root}/questions/"
+    response = api.session.get(resource_url)
+    response_json = error.get_response_json(response, logger)
+    question_objects = response_json.get("objects", [])
+    return question_objects

--- a/api_client/python/timesketch_api_client/scenario_test.py
+++ b/api_client/python/timesketch_api_client/scenario_test.py
@@ -46,7 +46,7 @@ class ScenarioListTest(unittest.TestCase):
 
     def test_scenario_list(self):
         """Test ScenarioList object."""
-        scenario_list = scenario_lib.ScenarioTemplateList(self.api_client).get()
+        scenario_list = scenario_lib.getScenarioTemplateList(self.api_client)
         self.assertIsInstance(scenario_list, list)
         self.assertEqual(len(scenario_list), 2)
         self.assertEqual(scenario_list[0]["name"], "Test Scenario")
@@ -78,7 +78,7 @@ class QuestionListTest(unittest.TestCase):
 
     def test_question_list(self):
         """Test QuestionList object."""
-        question_list = scenario_lib.QuestionTemplateList(self.api_client).get()
+        question_list = scenario_lib.getQuestionTemplateList(self.api_client)
         self.assertIsInstance(question_list, list)
         self.assertEqual(len(question_list), 2)
         self.assertEqual(question_list[0]["name"], "Test question?")

--- a/api_client/python/timesketch_api_client/sketch_test.py
+++ b/api_client/python/timesketch_api_client/sketch_test.py
@@ -106,8 +106,8 @@ class SketchTest(unittest.TestCase):
         self.assertIsInstance(scenario, scenario_lib.Scenario)
         self.assertEqual(scenario.id, 1)
         self.assertEqual(scenario.name, "Test Scenario")
-        self.assertEqual(scenario.scenario_id, 1)
-        self.assertEqual(scenario.dfiq_id, "S0001")
+        self.assertEqual(scenario.uuid, "1234a567-b89c-123d-e45f-g6h7ijk8l910")
+        self.assertEqual(scenario.dfiq_identifier, "S0001")
         self.assertEqual(scenario.description, "Scenario description!")
 
     def test_add_scenario(self):
@@ -116,8 +116,8 @@ class SketchTest(unittest.TestCase):
         self.assertIsInstance(scenario, scenario_lib.Scenario)
         self.assertEqual(scenario.id, 1)
         self.assertEqual(scenario.name, "Test Scenario")
-        self.assertEqual(scenario.scenario_id, 1)
-        self.assertEqual(scenario.dfiq_id, "S0001")
+        self.assertEqual(scenario.uuid, "1234a567-b89c-123d-e45f-g6h7ijk8l910")
+        self.assertEqual(scenario.dfiq_identifier, "S0001")
         self.assertEqual(scenario.description, "Scenario description!")
 
     def test_list_questions(self):
@@ -129,8 +129,8 @@ class SketchTest(unittest.TestCase):
         self.assertIsInstance(question, scenario_lib.Question)
         self.assertEqual(question.id, 1)
         self.assertEqual(question.name, "Test Question?")
-        self.assertEqual(question.question_id, 1)
-        self.assertEqual(question.dfiq_id, "Q0001")
+        self.assertEqual(question.uuid, "1234a567-b89c-123d-e45f-g6h7ijk8l910")
+        self.assertEqual(question.dfiq_identifier, "Q0001")
         self.assertEqual(question.description, "Test Question Description")
 
     def test_add_question(self):
@@ -139,6 +139,6 @@ class SketchTest(unittest.TestCase):
         self.assertIsInstance(question, scenario_lib.Question)
         self.assertEqual(question.id, 1)
         self.assertEqual(question.name, "Test Question?")
-        self.assertEqual(question.question_id, 1)
-        self.assertEqual(question.dfiq_id, "Q0001")
+        self.assertEqual(question.uuid, "1234a567-b89c-123d-e45f-g6h7ijk8l910")
+        self.assertEqual(question.dfiq_identifier, "Q0001")
         self.assertEqual(question.description, "Test Question Description")

--- a/api_client/python/timesketch_api_client/test_lib.py
+++ b/api_client/python/timesketch_api_client/test_lib.py
@@ -646,6 +646,7 @@ def mock_response(*args, **kwargs):
         "objects": [
             [
                 {
+                    "uuid": "1234a567-b89c-123d-e45f-g6h7ijk8l910",
                     "description": "Scenario description!",
                     "dfiq_identifier": "S0001",
                     "display_name": "Test Scenario",
@@ -660,6 +661,7 @@ def mock_response(*args, **kwargs):
         "meta": {},
         "objects": [
             {
+                "uuid": "1234a567-b89c-123d-e45f-g6h7ijk8l910",
                 "description": "Scenario description!",
                 "dfiq_identifier": "S0001",
                 "display_name": "Test Scenario",
@@ -672,6 +674,7 @@ def mock_response(*args, **kwargs):
     mock_scenario_templates_response = {
         "objects": [
             {
+                "uuid": "1234a567-b89c-123d-e45f-g6h7ijk8l910",
                 "child_ids": ["F0001", "F0002"],
                 "description": "Scenario description!",
                 "id": "S0001",
@@ -680,6 +683,7 @@ def mock_response(*args, **kwargs):
                 "tags": ["test"],
             },
             {
+                "uuid": "1234a567-123d-b89c-e45f-g6h7ijk8l910",
                 "child_ids": ["F1007"],
                 "description": "Scenario description 2!",
                 "id": "S0002",
@@ -704,6 +708,7 @@ def mock_response(*args, **kwargs):
                             "search_templates": [],
                         }
                     ],
+                    "uuid": "1234a567-b89c-123d-e45f-g6h7ijk8l910",
                     "conclusions": [],
                     "description": "Test Question Description",
                     "dfiq_identifier": "Q0001",
@@ -728,6 +733,7 @@ def mock_response(*args, **kwargs):
                         "search_templates": [],
                     }
                 ],
+                "uuid": "1234a567-b89c-123d-e45f-g6h7ijk8l910",
                 "conclusions": [],
                 "description": "Test Question Description",
                 "dfiq_identifier": "Q0001",
@@ -741,6 +747,7 @@ def mock_response(*args, **kwargs):
     mock_question_templates_response = {
         "objects": [
             {
+                "uuid": "1234a567-b89c-123d-e45f-g6h7ijk8l910",
                 "child_ids": ["Q0001.01"],
                 "description": "Test Question Description",
                 "id": "Q0001",
@@ -749,6 +756,7 @@ def mock_response(*args, **kwargs):
                 "tags": ["test"],
             },
             {
+                "uuid": "1234a567-123d-b89c-e45f-g6h7ijk8l910",
                 "child_ids": ["Q0002.01"],
                 "description": "Second Test Question Description",
                 "id": "Q0002",


### PR DESCRIPTION
This PR updates the Timesketch API client scenario handling.
* Support for the dfiq 1.1 schema
* Allow to add scenarios or questions based on dfiq_identifier, name or uuid
* Improved efficiency of the code

**Checks**

- [x] All tests succeed.
- [x] Unit tests added.
