### PR TITLE
move the user message behind the actual drop command.

### DIFF
--- a/timesketch/tsctl.py
+++ b/timesketch/tsctl.py
@@ -175,8 +175,8 @@ def drop_db():
         if click.confirm(
             "Are you REALLLY sure you want to DROP ALL the database tables?"
         ):
-            print("All tables dropped. Database is now empty.")
             drop_all()
+            print("All tables dropped. Database is now empty.")
 
 
 @cli.command(name="list-sketches")


### PR DESCRIPTION
By working on https://github.com/google/timesketch/issues/2432 I discovered that we give the user a successful message, even if the command was not actually executed. So even if something failed, the user would have gotten the message all fine.

That is why I moved the user output after the actual command, so it can fail.