### PR TITLE
Fix: Handle special characters in queries and filter chips

### DIFF
--- a/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
@@ -41,12 +41,18 @@ limitations under the License.
                     </v-btn>
 
                     <!-- Include field:value as filter chip -->
-                    <v-btn @click.stop="applyFilterChip(key, value, 'must')" icon x-small class="mr-1">
+                    <v-btn
+                      v-if="!ignoreFilterChips.has(key)"
+                      @click.stop="applyFilterChip(key, value, 'must')"
+                      icon
+                      x-small
+                      class="mr-1">
                       <v-icon title="Filter for value">mdi-filter-plus-outline</v-icon>
                     </v-btn>
 
                     <!-- Exclude field:value as filter chip -->
                     <v-btn
+                      v-if="!ignoreFilterChips.has(key)"
                       @click.stop="applyFilterChip(key, value, 'must_not')"
                       icon
                       x-small
@@ -197,8 +203,11 @@ export default {
         'path_spec',
         'strings',
         'timestamp',
-        'timestamp_desc',
         'xml_string',
+      ]),
+      ignoreFilterChips: new Set([
+        'datetime',
+        'tag',
       ]),
       eventKey: '',
       eventValue: '',


### PR DESCRIPTION
This PR addresses an issue where OpenSearch incorrectly interpreted special characters in queries and filter chips.

- Special character-only queries are now handled as `term` queries on the `.keyword` sub-field, ensuring accurate matching without analysis.
- Filter chips of type "term" consistently use the `.keyword` sub-field if they are of type String.
- Removed include/exclude icons for `datetime` and `tag` fields to avoid user confusion.

This change improves query accuracy and filter chip functionality, providing a more intuitive user experience.

**Closing issues**

closes #3103 
