### PR TITLE
Enable/Disable Scenarios via system settings

### DIFF
--- a/data/timesketch.conf
+++ b/data/timesketch.conf
@@ -338,6 +338,7 @@ SIGMA_TAG_DELAY = 5
 
 #-------------------------------------------------------------------------------
 # DFIQ - Digital Forensics Investigation Questions
+DFIQ_ENABLED = False
 DFIQ_PATH = '/etc/timesketch/dfiq/'
 
 # Intelligence tag metadata configuration

--- a/timesketch/api/v1/resources/settings.py
+++ b/timesketch/api/v1/resources/settings.py
@@ -30,7 +30,7 @@ class SystemSettingsResource(Resource):
             JSON object with system settings.
         """
         # Settings from timesketch.conf to expose to the frontend clients.
-        settings_to_return = ["LLM_PROVIDER"]
+        settings_to_return = ["LLM_PROVIDER", "DFIQ_ENABLED"]
         result = {}
 
         for setting in settings_to_return:

--- a/timesketch/api/v1/resources_test.py
+++ b/timesketch/api/v1/resources_test.py
@@ -1401,5 +1401,5 @@ class SystemSettingsResourceTest(BaseTest):
         """Authenticated request to get system settings."""
         self.login()
         response = self.client.get(self.resource_url)
-        expected_response = {"LLM_PROVIDER": "test"}
+        expected_response = {"DFIQ_ENABLED": False, "LLM_PROVIDER": "test"}
         self.assertEqual(response.json, expected_response)

--- a/timesketch/frontend-ng/src/components/Scenarios/QuestionCard.vue
+++ b/timesketch/frontend-ng/src/components/Scenarios/QuestionCard.vue
@@ -15,7 +15,7 @@ limitations under the License.
 -->
 <template>
   <v-container fluid>
-    <v-card class="mx-3 mt-3 mb-7" outlined :class="$vuetify.theme.dark ? '' : 'context-card-light-grey-background'">
+    <v-card class="mx-3 mt-3 mb-3" outlined :class="$vuetify.theme.dark ? '' : 'context-card-light-grey-background'">
       <v-toolbar flat dense style="background-color: transparent">
         <span v-if="isLoading">
           <v-progress-circular :size="20" :width="1" indeterminate color="primary" class="mr-3"></v-progress-circular>

--- a/timesketch/frontend-ng/src/views/Sketch.vue
+++ b/timesketch/frontend-ng/src/views/Sketch.vue
@@ -278,12 +278,12 @@ limitations under the License.
       <v-main class="notransition">
         <!-- Scenario context -->
         <!--<ts-scenario-navigation v-if="sketch.status && hasTimelines && !isArchived"></ts-scenario-navigation>-->
-        <ts-question-card v-if="sketch.status && hasTimelines && !isArchived"></ts-question-card>
+        <ts-question-card v-if="sketch.status && hasTimelines && !isArchived && systemSettings.DFIQ_ENABLED"></ts-question-card>
 
         <router-view
           v-if="sketch.status && hasTimelines && !isArchived"
           @setTitle="(title) => (this.title = title)"
-          class="mt-n3"
+          class="mt-4"
         ></router-view>
       </v-main>
 
@@ -464,6 +464,9 @@ export default {
     },
     currentRouteName() {
       return this.$route.name
+    },
+    systemSettings() {
+      return this.$store.state.systemSettings
     },
   },
   methods: {

--- a/timesketch/lib/testlib.py
+++ b/timesketch/lib/testlib.py
@@ -81,6 +81,7 @@ class TestConfig(object):
     INTELLIGENCE_TAG_METADATA = "./data/intelligence_tag_metadata.yaml"
     CONTEXT_LINKS_CONFIG_PATH = "./test_tools/test_events/mock_context_links.yaml"
     LLM_PROVIDER = "test"
+    DFIQ_ENABLED = False
     DATA_TYPES_PATH = "./test_data/nl2q/test_data_types.csv"
     PROMPT_NL2Q = "./test_data/nl2q/test_prompt_nl2q"
     EXAMPLES_NL2Q = "./test_data/nl2q/test_examples_nl2q"


### PR DESCRIPTION
This PR introduces a config option to enable/disable the DFIQ feature via the `timesketch.conf`. If disabled, the UI element will not be shown in the frontend.

This allows for a cleaner way of configuring and handling the DFIQ feature in future Timesketch versions.