### PR TITLE
Error handling for DFIQ data import

### DIFF
--- a/test_data/dfiq/facets/F1001.yaml
+++ b/test_data/dfiq/facets/F1001.yaml
@@ -7,3 +7,4 @@ tags:
   - test
 parent_ids:
  - S1001
+dfiq_version: 1.1.0

--- a/test_data/dfiq/questions/Q1001.yaml
+++ b/test_data/dfiq/questions/Q1001.yaml
@@ -24,3 +24,4 @@ approaches:
 tags:
 parent_ids:
   - F1001
+dfiq_version: 1.1.0

--- a/test_data/dfiq/scenarios/S1001.yaml
+++ b/test_data/dfiq/scenarios/S1001.yaml
@@ -5,3 +5,4 @@ id: S1001
 uuid: 6e5d9e63-b477-4392-8742-c85ac9b653e2
 tags:
   - test
+dfiq_version: 1.1.0

--- a/timesketch/api/v1/resources/scenarios.py
+++ b/timesketch/api/v1/resources/scenarios.py
@@ -49,7 +49,10 @@ def load_dfiq_from_config():
         DFIQ object or None if no DFIQ_PATH is configured.
     """
     dfiq_path = current_app.config.get("DFIQ_PATH")
-    if not dfiq_path:
+    if not current_app.config.get("DFIQ_ENABLED"):
+        logger.info("DFIQ is disabled. Enable in the timesketch.conf!")
+        return None
+    if not dfiq_path or not current_app.config.get("DFIQ_ENABLED"):
         logger.error("No DFIQ_PATH configured")
         return None
     return DFIQ(dfiq_path)

--- a/timesketch/api/v1/resources/scenarios.py
+++ b/timesketch/api/v1/resources/scenarios.py
@@ -52,7 +52,7 @@ def load_dfiq_from_config():
     if not current_app.config.get("DFIQ_ENABLED"):
         logger.info("DFIQ is disabled. Enable in the timesketch.conf!")
         return None
-    if not dfiq_path or not current_app.config.get("DFIQ_ENABLED"):
+    if not dfiq_path:
         logger.error("No DFIQ_PATH configured")
         return None
     return DFIQ(dfiq_path)


### PR DESCRIPTION
This PR fixes a bug with the handling of older DFIQ versions.
* Add checks for min supported DFIQ version before importing the data.
* Catching errors if the imported data does not have the supported fields.
