### PR TITLE
Update image version in release config.env

### DIFF
--- a/docker/release/config.env
+++ b/docker/release/config.env
@@ -1,7 +1,7 @@
 # Timesketch version to run. Latest is build from the master branch and a release
 # number is build from a release tag. Using latest means that you are running
 # the bleeding edge version and we cannot guarantee that it will not be broken.
-TIMESKETCH_VERSION=latest
+TIMESKETCH_VERSION=20240828
 
 # Timesketch PATH local etc/timesketch
 TIMESKETCH_CONFIG_PATH=./etc/timesketch


### PR DESCRIPTION
Setting the image version to the latest release in the config.env for release deployments. 
* This will pull the latest release version when following the installation steps on https://timesketch.org