### PR TITLE
Prevent opensearch from aggregating across all indices.

### DIFF
--- a/timesketch/api/v1/resources/sketch.py
+++ b/timesketch/api/v1/resources/sketch.py
@@ -469,7 +469,11 @@ class SketchResource(resources.ResourceMixin, Resource):
             stats_per_timeline=stats_per_timeline,
             last_activity=utils.get_sketch_last_activity(sketch),
             sketch_labels=[label.label for label in sketch.labels],
-            filter_labels=self.datastore.get_filter_labels(sketch.id, sketch_indices),
+            filter_labels=(
+                self.datastore.get_filter_labels(sketch.id, sketch_indices)
+                if sketch_indices
+                else []
+            ),
         )
         return self.to_json(sketch, meta=meta)
 

--- a/timesketch/lib/datastores/opensearch.py
+++ b/timesketch/lib/datastores/opensearch.py
@@ -714,6 +714,14 @@ class OpenSearchDataStore(object):
         Returns:
             List with label names.
         """
+        # If no indices are provided, return an empty list. This indicates
+        # there are no labels to aggregate within the specified sketch.
+        # Returning early prevents querying OpenSearch with an empty
+        # index list, which would default to querying all indices ("_all")
+        # and could potentially cause performance issues or errors.
+        if not indices:
+            return []
+
         # This is a workaround to return all labels by setting the max buckets
         # to something big. If a sketch has more than this amount of labels
         # the list will be incomplete but it should be uncommon to have >10k


### PR DESCRIPTION
This PR addresses an issue where Timesketch attempts to execute an OpenSearch query with an empty index list when fetching labels for sketches without active timelines. This defaults to querying `_all` indices, which can lead to performance issues and the "got more than 100 headers" error due to excessive task management headers and/or large responses in the aggregation.

The following changes were made:

- In the `SketchResource.get` function (`timesketch/api/v1/resources/sketch.py`), a conditional check was added to ensure `get_filter_labels` is called only if `sketch_indices` is not empty.  If the list is empty (no indices to query), an empty list is directly assigned to `filter_labels` in the metadata.
- In the `get_filter_labels` function (`timesketch/lib/datastores/opensearch.py`) a check was added at the beginning of the function to immediately return an empty list if the provided `indices` parameter is empty.  This prevents the aggregation query from being constructed and executed unnecessarily.  Explanatory comments were added to clarify the purpose of these changes.

These modifications prevent querying `_all` indices with empty `sketch_indices`, improving performance and preventing header limit errors when fetching sketch details for empty sketches or sketches without active timelines.

**Closing issues**

closes #3191 
