### PR TITLE
Add --skip-create-user option to enable non-interactive deployments

### DIFF
--- a/contrib/deploy_timesketch.sh
+++ b/contrib/deploy_timesketch.sh
@@ -157,7 +157,7 @@ else
 fi
 
 if [ -z "$SKIP_CREATE_USER" ]; then
-  read -p "Would you like to create a new timesketch user? [Y/n] (default:no)" CREATE_USER
+  read -p "Would you like to create a new timesketch user? [y/N]" CREATE_USER
 fi
 
 if [ "$CREATE_USER" != "${CREATE_USER#[Yy]}" ] ;then

--- a/contrib/deploy_timesketch.sh
+++ b/contrib/deploy_timesketch.sh
@@ -16,10 +16,16 @@
 set -e
 
 START_CONTAINER=
+SKIP_CREATE_USER=
 
-if [ "$1" == "--start-container" ]; then
-    START_CONTAINER=yes
-fi
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --start-container) START_CONTAINER=yes ;;
+        --skip-create-user) SKIP_CREATE_USER=yes ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
 
 # Exit early if run as non-root user.
 if [ "$EUID" -ne 0 ]; then
@@ -150,7 +156,9 @@ else
   exit
 fi
 
-read -p "Would you like to create a new timesketch user? [Y/n] (default:no)" CREATE_USER
+if [ -z "$SKIP_CREATE_USER" ]; then
+  read -p "Would you like to create a new timesketch user? [Y/n] (default:no)" CREATE_USER
+fi
 
 if [ "$CREATE_USER" != "${CREATE_USER#[Yy]}" ] ;then
   read -p "Please provide a new username: " NEWUSERNAME


### PR DESCRIPTION
**What existing problem does this PR solve?**
This PR solves the issue of the deploy_timesketch.sh script requiring user interaction during deployments. Specifically, the script prompts for user input to confirm whether to create a user or not, which blocks automated deployment processes. This PR addresses this issue by allowing the script to run non-interactively.

**What new feature is being introduced with this PR?**
This PR introduces a new `--skip-create-user` option to the deploy_timesketch.sh script. By passing this option, the script will skip the user creation prompt, enabling non-interactive and automated deployments. This provides greater flexibility for both manual and automated environments.

**Checks**

- [ ] All tests succeed.
- [ ] Unit tests added.
- [ ] e2e tests added.
- [ ] Documentation updated.

**Closing issues**

closes #3193