### PR TITLE
Fix: Correctly handle dynamic tags without modifiers

### DIFF
--- a/timesketch/lib/analyzers/tagger.py
+++ b/timesketch/lib/analyzers/tagger.py
@@ -129,10 +129,13 @@ class TaggerSketchPlugin(interface.BaseAnalyzer):
                 for mod in config.get("modifiers", []):
                     if isinstance(tag_value, str):
                         tag_value = self.MODIFIERS[mod](tag_value)
-                if isinstance(tag_value, Iterable):
-                    dynamic_tag_values.extend(tag_value)
-                else:
+
+                if isinstance(tag_value, str):
                     dynamic_tag_values.append(tag_value)
+                elif isinstance(tag_value, Iterable):
+                    dynamic_tag_values.extend(tag_value)
+                elif tag_value is not None:
+                    dynamic_tag_values.append(str(tag_value))
             event.add_tags(dynamic_tag_values)
 
             event.add_emojis(emojis_to_add)


### PR DESCRIPTION
The tagger analyzer was splitting dynamic tag values into individual characters when no modifiers were specified. This was due to a check for Iterables that returns True for strings and then extends the string into a list.

This PR fixes the issue by:

- Check for Strings and append those first.
- Handle None values
- Explicitly converting the initial config tags to a list to prevent string iteration when adding initial tags.

This change ensures that dynamic tags are correctly handled, even without modifiers, and prevents unexpected splitting behavior. It also improves compatibility with Timesketch by ensuring all tag values are strings, and it addresses a potential TypeError by preventing None values from being added to the tag list.

closes #3206
