### PR TITLE
Change icon for opening TI view.

### DIFF
--- a/timesketch/frontend-ng/src/components/LeftPanel/ThreatIntel.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/ThreatIntel.vue
@@ -58,7 +58,7 @@ limitations under the License.
         :to="{ name: 'Intelligence', params: { sketchId: sketch.id } }"
         @click.stop=""
       >
-        <v-icon small title="Manage indicators">mdi-pencil</v-icon>
+        <v-icon small title="Manage indicators">mdi-open-in-new</v-icon>
       </v-btn>
 
       <span v-if="!expanded" class="float-right" style="margin-right: 10px">


### PR DESCRIPTION
The Threat Intel section in the left bar used a pencil icon for opening the TI view. This PR changes that to the "open in new" icon as requested by @tomchop 