### PR TITLE
Provide actionable error message for complex search queries

### DIFF
--- a/timesketch/frontend-ng/src/components/Explore/EventList.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventList.vue
@@ -882,7 +882,14 @@ export default {
           }
         })
         .catch((e) => {
-          this.errorSnackBar('Sorry, there was a problem fetching your search results. Please try again.')
+          let msg = 'Sorry, there was a problem fetching your search results. Error: "'+ e.response.data.message +'"'
+          if (e.response.data.message.includes('too_many_nested_clauses')) {
+            msg = 'Sorry, your query is too complex. Use field-specific search (like "message:(<query terms>)") and try again.'
+            this.errorSnackBar(msg)
+          } else {
+            this.errorSnackBar(msg)
+          }
+          console.error('Error message: ' + msg)
           console.error(e)
         })
     },

--- a/timesketch/lib/datastores/opensearch.py
+++ b/timesketch/lib/datastores/opensearch.py
@@ -28,6 +28,7 @@ from opensearchpy import OpenSearch
 from opensearchpy.exceptions import ConnectionTimeout
 from opensearchpy.exceptions import NotFoundError
 from opensearchpy.exceptions import RequestError
+from opensearchpy.exceptions import TransportError
 
 # pylint: disable=redefined-builtin
 from opensearchpy.exceptions import ConnectionError
@@ -607,7 +608,7 @@ class OpenSearchDataStore(object):
                     _source_includes=return_fields,
                     scroll=scroll_timeout,
                 )
-        except RequestError as e:
+        except (RequestError, TransportError) as e:
             root_cause = e.info.get("error", {}).get("root_cause")
             if root_cause:
                 error_items = []


### PR DESCRIPTION
Catch `TransportError` for "too many nested clauses" and improve error message. 

The change modifies `OpenSearchDataStore.search` to catch `TransportError`, specifically addressing the "too many nested clauses" issue in OpenSearch. It provides a user-friendly error message in both the frontend and logs, guiding users to refine their queries.
