### PR TITLE
Add a warning snackbar

### DIFF
--- a/timesketch/frontend-ng/src/components/Explore/EventList.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventList.vue
@@ -885,7 +885,7 @@ export default {
           let msg = 'Sorry, there was a problem fetching your search results. Error: "'+ e.response.data.message +'"'
           if (e.response.data.message.includes('too_many_nested_clauses')) {
             msg = 'Sorry, your query is too complex. Use field-specific search (like "message:(<query terms>)") and try again.'
-            this.errorSnackBar(msg)
+            this.warningSnackBar(msg)
           } else {
             this.errorSnackBar(msg)
           }

--- a/timesketch/frontend-ng/src/mixins/snackBar.js
+++ b/timesketch/frontend-ng/src/mixins/snackBar.js
@@ -38,6 +38,12 @@ Vue.mixin({
             snackbar.color = "error"
             this.$store.dispatch('setSnackBar', snackbar)
         },
+        warningSnackBar(message) {
+          let snackbar = defaultSnackBar
+          snackbar.message = message
+          snackbar.color = "warning"
+          this.$store.dispatch('setSnackBar', snackbar)
+        },
         infoSnackBar(message) {
           let snackbar = defaultSnackBar
           snackbar.message = message


### PR DESCRIPTION
Follow-up for #3233 : Based on internal discussion the color for the actionable error snackbar is changed to warning (orange). To distinguish the actionable non-blocking messages from real errors.

![image](https://github.com/user-attachments/assets/aa7106bf-a9f6-452f-a7cb-45bb531e4083)
