### PR TITLE
Add Support for Searching Processing Timelines

### DIFF
--- a/data/timesketch.conf
+++ b/data/timesketch.conf
@@ -401,3 +401,10 @@ EXAMPLES_NL2Q = '/etc/timesketch/nl2q/examples_nl2q'
 
 # LLM event summarization configuration
 PROMPT_LLM_SUMMARIZATION = '/etc/timesketch/llm_summarize/prompt.txt'
+
+#-------------------------------------------------------------------------------
+# Timesketch UI Option
+
+# Get the search processing timelines setting.
+# If set to True, the search processing timelines options will be displayed in the UI.
+SEARCH_PROCESSING_TIMELINES = False

--- a/timesketch/api/v1/resources/aggregation.py
+++ b/timesketch/api/v1/resources/aggregation.py
@@ -466,7 +466,7 @@ class AggregationExploreResource(resources.ResourceMixin, Resource):
         sketch_indices = {
             t.searchindex.index_name
             for t in sketch.timelines
-            if t.get_status.status.lower() == "ready"
+            if t.get_status.status.lower() in ["ready", "processing"]
         }
 
         aggregation_dsl = form.aggregation_dsl.data

--- a/timesketch/api/v1/resources/aggregation.py
+++ b/timesketch/api/v1/resources/aggregation.py
@@ -18,6 +18,7 @@ import time
 
 from opensearchpy.exceptions import NotFoundError
 
+from flask import current_app
 from flask import jsonify
 from flask import request
 from flask import abort
@@ -465,7 +466,9 @@ class AggregationExploreResource(resources.ResourceMixin, Resource):
 
         include_processing_timelines = form.include_processing_timelines.data
         allowed_statuses = ["ready"]
-        if include_processing_timelines:
+        if include_processing_timelines and current_app.config.get(
+            "SEARCH_PROCESSING_TIMELINES", False
+        ):
             allowed_statuses.append("processing")
 
         sketch_indices = {

--- a/timesketch/api/v1/resources/aggregation.py
+++ b/timesketch/api/v1/resources/aggregation.py
@@ -463,10 +463,15 @@ class AggregationExploreResource(resources.ResourceMixin, Resource):
                 "Not able to run aggregation on an archived sketch.",
             )
 
+        include_processing_timelines = form.include_processing_timelines.data
+        allowed_statuses = ["ready"]
+        if include_processing_timelines:
+            allowed_statuses.append("processing")
+
         sketch_indices = {
             t.searchindex.index_name
             for t in sketch.timelines
-            if t.get_status.status.lower() in ["ready", "processing"]
+            if t.get_status.status.lower() in allowed_statuses
         }
 
         aggregation_dsl = form.aggregation_dsl.data
@@ -490,7 +495,9 @@ class AggregationExploreResource(resources.ResourceMixin, Resource):
                 aggregator_parameters = {}
 
             indices = aggregator_parameters.pop("index", sketch_indices)
-            indices, timeline_ids = lib_utils.get_validated_indices(indices, sketch)
+            indices, timeline_ids = lib_utils.get_validated_indices(
+                indices, sketch, form.include_processing_timelines.data
+            )
 
             if not (indices or timeline_ids):
                 abort(HTTP_STATUS_CODE_BAD_REQUEST, "No indices to aggregate on")

--- a/timesketch/api/v1/resources/event.py
+++ b/timesketch/api/v1/resources/event.py
@@ -27,6 +27,7 @@ from opensearchpy.exceptions import RequestError
 import numpy as np
 import pandas as pd
 
+from flask import current_app
 from flask import jsonify
 from flask import request
 from flask import abort
@@ -296,8 +297,9 @@ class EventResource(resources.ResourceMixin, Resource):
             args.get("include_processing_timelines", False)
         )
         allowed_statuses = ["ready"]
-
-        if include_processing_timelines:
+        if include_processing_timelines and current_app.config.get(
+            "SEARCH_PROCESSING_TIMELINES", False
+        ):
             allowed_statuses.append("processing")
         indices = [
             t.searchindex.index_name
@@ -840,7 +842,9 @@ class EventAnnotationResource(resources.ResourceMixin, Resource):
         if _search_node_id:
             current_search_node = self._get_current_search_node(_search_node_id, sketch)
 
-        allowed_statuses = ["ready", "processing"]
+        allowed_statuses = ["ready"]
+        if current_app.config.get("SEARCH_PROCESSING_TIMELINES", False):
+            allowed_statuses.append("processing")
 
         indices = [
             t.searchindex.index_name

--- a/timesketch/api/v1/resources/event.py
+++ b/timesketch/api/v1/resources/event.py
@@ -30,7 +30,7 @@ import pandas as pd
 from flask import jsonify
 from flask import request
 from flask import abort
-from flask_restful import Resource
+from flask_restful import Resource, inputs
 from flask_restful import reqparse
 from flask_login import login_required
 from flask_login import current_user
@@ -249,6 +249,12 @@ class EventResource(resources.ResourceMixin, Resource):
             "searchindex_id", type=str, required=True, location="args"
         )
         self.parser.add_argument("event_id", type=str, required=True, location="args")
+        self.parser.add_argument(
+            "include_processing_timelines",
+            type=inputs.boolean,
+            required=False,
+            location="args",
+        )
 
     @login_required
     def get(self, sketch_id: int):
@@ -286,10 +292,17 @@ class EventResource(resources.ResourceMixin, Resource):
             )
 
         event_id = args.get("event_id")
+        include_processing_timelines = bool(
+            args.get("include_processing_timelines", False)
+        )
+        allowed_statuses = ["ready"]
+
+        if include_processing_timelines:
+            allowed_statuses.append("processing")
         indices = [
             t.searchindex.index_name
             for t in sketch.timelines
-            if t.get_status.status.lower() == "ready"
+            if t.get_status.status.lower() in allowed_statuses
         ]
 
         # Check if the requested searchindex is part of the sketch
@@ -827,10 +840,12 @@ class EventAnnotationResource(resources.ResourceMixin, Resource):
         if _search_node_id:
             current_search_node = self._get_current_search_node(_search_node_id, sketch)
 
+        allowed_statuses = ["ready", "processing"]
+
         indices = [
             t.searchindex.index_name
             for t in sketch.timelines
-            if t.get_status.status.lower() == "ready"
+            if t.get_status.status.lower() in allowed_statuses
         ]
         annotation_type = form.annotation_type.data
         events = form.events.raw_data

--- a/timesketch/api/v1/resources/explore.py
+++ b/timesketch/api/v1/resources/explore.py
@@ -142,7 +142,9 @@ class ExploreResource(resources.ResourceMixin, Resource):
         query_filter = request.json.get("filter", {})
         parent = request.json.get("parent", None)
         incognito = request.json.get("incognito", False)
-
+        include_processing_timelines = request.json.get(
+            "include_processing_timelines", False
+        )
         return_field_string = form.fields.data
         if return_field_string:
             return_fields = [x.strip() for x in return_field_string.split(",")]
@@ -163,7 +165,9 @@ class ExploreResource(resources.ResourceMixin, Resource):
 
         # Make sure that the indices in the filter are part of the sketch.
         # This will also remove any deleted timeline from the search result.
-        indices, timeline_ids = get_validated_indices(indices, sketch)
+        indices, timeline_ids = get_validated_indices(
+            indices, sketch, include_processing_timelines
+        )
 
         # Remove indices that don't exist from search.
         indices = utils.validate_indices(indices, self.datastore)

--- a/timesketch/api/v1/resources/explore.py
+++ b/timesketch/api/v1/resources/explore.py
@@ -22,6 +22,7 @@ import prometheus_client
 
 from flask import abort
 from flask import jsonify
+from flask import current_app
 from flask import request
 from flask import send_file
 from flask_restful import Resource
@@ -142,9 +143,13 @@ class ExploreResource(resources.ResourceMixin, Resource):
         query_filter = request.json.get("filter", {})
         parent = request.json.get("parent", None)
         incognito = request.json.get("incognito", False)
-        include_processing_timelines = request.json.get(
-            "include_processing_timelines", False
-        )
+
+        include_processing_timelines = False
+        if current_app.config.get("SEARCH_PROCESSING_TIMELINES", False):
+            include_processing_timelines = request.json.get(
+                "include_processing_timelines", False
+            )
+
         return_field_string = form.fields.data
         if return_field_string:
             return_fields = [x.strip() for x in return_field_string.split(",")]

--- a/timesketch/api/v1/resources/settings.py
+++ b/timesketch/api/v1/resources/settings.py
@@ -62,4 +62,11 @@ class SystemSettingsResource(Resource):
             result["llm_config_warning"] = warning_message
             logger.warning(warning_message)
 
+        # Get the search processing timelines setting, default is False if not set.
+        # if set to True, the search processing timelines will be displayed in the UI.
+        search_processing_timelines = current_app.config.get(
+            "SEARCH_PROCESSING_TIMELINES", False
+        )
+        result["SEARCH_PROCESSING_TIMELINES"] = search_processing_timelines
+
         return jsonify(result)

--- a/timesketch/api/v1/resources/user.py
+++ b/timesketch/api/v1/resources/user.py
@@ -16,6 +16,7 @@ import json
 import logging
 
 from flask import abort
+from flask import current_app
 from flask import jsonify
 from flask import request
 from flask_restful import Resource
@@ -170,6 +171,14 @@ class UserSettingsResource(resources.ResourceMixin, Resource):
         """
         profile = UserProfile.get_or_create(user=current_user)
         settings = json.loads(profile.settings)
+
+        # If the value of SEARCH_PROCESSING_TIMELINES changes to false while the user
+        # had the option enabled, it remains enabled without functioning.
+        # Therefore, if SEARCH_PROCESSING_TIMELINES changes to false, we disable the
+        # showProcessingTimelineEvents option in the user's settings for display
+        # consistency.
+        if not current_app.config.get("SEARCH_PROCESSING_TIMELINES", False):
+            settings["showProcessingTimelineEvents"] = False
         schema = {"objects": [settings], "meta": {}}
         return jsonify(schema)
 

--- a/timesketch/api/v1/resources_test.py
+++ b/timesketch/api/v1/resources_test.py
@@ -1371,7 +1371,11 @@ class SystemSettingsResourceTest(BaseTest):
 
         self.login()
         response = self.client.get(self.resource_url)
-        expected_response = {"DFIQ_ENABLED": False, "LLM_PROVIDER": "test"}
+        expected_response = {
+            "DFIQ_ENABLED": False,
+            "LLM_PROVIDER": "test",
+            "SEARCH_PROCESSING_TIMELINES": False,
+        }
         self.assertEqual(response.json, expected_response)
 
 

--- a/timesketch/frontend-ng/src/components/Analyzer/TimelineChip.vue
+++ b/timesketch/frontend-ng/src/components/Analyzer/TimelineChip.vue
@@ -38,6 +38,9 @@ limitations under the License.
             </template>
             <span>{{ timeline.name }}</span>
           </v-tooltip>
+          <span v-if="timeline.status[0].status === 'processing'" class="ml-3 mr-3">
+            <v-progress-circular small indeterminate color="grey" :size="17" :width="2"></v-progress-circular>
+          </span>
         </div>
       </v-chip>
     </template>

--- a/timesketch/frontend-ng/src/components/Analyzer/TimelineSearch.vue
+++ b/timesketch/frontend-ng/src/components/Analyzer/TimelineSearch.vue
@@ -63,7 +63,7 @@ export default {
   components:{
     TsAnalyzerTimelineChip,
   },
-  props: ['analyzerTimelineId', 'componentName'],
+  props: ['analyzerTimelineId', 'componentName', 'includeProcessingTimelines'],
   data() {
     return {
       selectedTimelines: [],
@@ -75,8 +75,9 @@ export default {
     },
     allReadyTimelines() {
       // Sort alphabetically based on timeline name.
-      const timelines = this.sketch.timelines.filter(
-        tl => tl.status[0].status === 'ready'
+      const timelines = this.sketch.timelines.filter(tl =>
+        tl.status[0].status === 'ready' ||
+        (this.includeProcessingTimelines && tl.status[0].status === 'processing')
       );
       timelines.sort((a, b) => a.name.localeCompare(b.name))
       return timelines;

--- a/timesketch/frontend-ng/src/components/Explore/AggregateDialog.vue
+++ b/timesketch/frontend-ng/src/components/Explore/AggregateDialog.vue
@@ -313,6 +313,9 @@ export default {
     }
   },
   computed: {
+    settings() {
+      return this.$store.state.settings
+    },
     sketch() {
       return this.$store.state.sketch
     },
@@ -556,7 +559,8 @@ export default {
         aggregator_parameters: {
           field: this.eventKey,
           field_query_string: this.eventValue
-        }
+        },
+        include_processing_timelines: !!this.settings.showProcessingTimelineEvents,
       }).then((response) => {
         this.stats = response.data.objects[0].field_summary.buckets[0]
         this.statsReady = true
@@ -570,7 +574,8 @@ export default {
         aggregator_parameters: {
           field: this.eventKey,
           date_interval: this.selectedDistributionInterval
-        }
+        },
+        include_processing_timelines: !!this.settings.showProcessingTimelineEvents,
       }).then((response) => {
         this.eventDistributionData = response.data.objects[0].datefield_summary.buckets[0]
         this.eventDistributionReady = true
@@ -624,7 +629,8 @@ export default {
           supported_intervals: supportedIntervals,
           start_time: startTime.toISOString().slice(0, -1),
           end_time: endTime.toISOString().slice(0, -1),
-        }
+        },
+        include_processing_timelines: !!this.settings.showProcessingTimelineEvents,
       }).then((response) => {
         this.data = response.data.objects[0].date_histogram.buckets[0]
         this.recentHistogramSeries = [{

--- a/timesketch/frontend-ng/src/components/Explore/EventActionMenu.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventActionMenu.vue
@@ -59,13 +59,16 @@ export default {
     sketch() {
       return this.$store.state.sketch
     },
+    settings() {
+      return this.$store.state.settings
+    },
   },
   methods: {
     showContextWindow() {
       EventBus.$emit('showContextWindow', this.event)
     },
     copyEventAsJSON() {
-      ApiClient.getEvent(this.sketch.id, this.event._index, this.event._id)
+      ApiClient.getEvent(this.sketch.id, this.event._index, this.event._id, !!this.settings.showProcessingTimelineEvents)
         .then((response) => {
           let fullEvent = response.data.objects
           let eventJSON = JSON.stringify(fullEvent, null, 3)

--- a/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
@@ -246,12 +246,16 @@ export default {
     contextLinkConf() {
       return this.$store.state.contextLinkConf
     },
+    settings() {
+      return this.$store.state.settings
+    },
   },
   methods: {
     getEvent: function () {
       let searchindexId = this.event._index
       let eventId = this.event._id
-      ApiClient.getEvent(this.sketch.id, searchindexId, eventId)
+      let includeProcessingTimelines = !!this.settings.showProcessingTimelineEvents
+      ApiClient.getEvent(this.sketch.id, searchindexId, eventId, includeProcessingTimelines)
         .then((response) => {
           this.fullEvent = response.data.objects
           this.comments = response.data.meta.comments

--- a/timesketch/frontend-ng/src/components/Explore/EventList.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventList.vue
@@ -15,6 +15,15 @@ limitations under the License.
 -->
 <template>
   <div>
+    <v-alert
+      v-model="showBanner"
+      dense
+      dismissible
+      type="info"
+    >
+      Data may be incomplete. Some timelines are still loading.
+    </v-alert>
+
     <v-dialog v-model="exportDialog" width="700">
       <v-card flat class="pa-5">
         <v-progress-circular indeterminate size="20" width="1"></v-progress-circular>
@@ -618,6 +627,7 @@ export default {
       branchParent: null,
       sortOrderAsc: true,
       summaryCollapsed: false,
+      showBanner: false,
     }
   },
   computed: {
@@ -852,7 +862,7 @@ export default {
     },
     search: function (resetPagination = true, incognito = false, parent = false) {
       this.isSummaryLoading = true
-      
+
       // Exit early if there are no indices selected.
       if (this.currentQueryFilter.indices && !this.currentQueryFilter.indices.length) {
         this.eventList = emptyEventList()
@@ -925,6 +935,7 @@ export default {
         .then((response) => {
           this.eventList.objects = response.data.objects
           this.eventList.meta = response.data.meta
+          this.updateShowBanner()
           this.searchInProgress = false
           EventBus.$emit('updateCountPerTimeline', response.data.meta.count_per_timeline)
           this.$emit('countPerTimeline', response.data.meta.count_per_timeline)
@@ -1112,6 +1123,15 @@ export default {
         })
         .catch((e) => {})
     },
+    updateShowBanner: function() {
+      // Show banner only when processing timelines are enabled and at
+      // least one enabled timeline is the "processing" state.
+      this.showBanner =
+        !!this.settings.showProcessingTimelineEvents &&
+        this.sketch.active_timelines
+          .filter(tl => this.$store.state.enabledTimelines.includes(tl.id))
+          .some(tl => tl.status && tl.status[0].status === 'processing')
+    },
   },
   watch: {
     tableOptions: {
@@ -1150,6 +1170,11 @@ export default {
         this.search(resetPagination, incognito, parent)
       },
       deep: true,
+    },
+    'settings.showProcessingTimelineEvents': {
+      handler() {
+        this.updateShowBanner()
+      },
     },
   },
   created() {
@@ -1253,24 +1278,24 @@ th:first-child {
 }
 
 .ts-ai-summary-card {
-  border: 1px solid transparent !important; 
+  border: 1px solid transparent !important;
   border-radius: 8px;
-  background-color: #fafafa; 
+  background-color: #fafafa;
   background-image:
-      linear-gradient(white, white), 
+      linear-gradient(white, white),
       linear-gradient(90deg,
-          #8ab4f8 0%,   
-          #81c995 20%, 
-          #f8c665 40%, 
-          #ec7764 60%,  
-          #b39ddb 80%,  
-          #8ab4f8 100%  
+          #8ab4f8 0%,
+          #81c995 20%,
+          #f8c665 40%,
+          #ec7764 60%,
+          #b39ddb 80%,
+          #8ab4f8 100%
       );
   background-origin: border-box;
   background-clip: content-box, border-box;
   background-size: 300% 100%;
-  animation: borderBeamIridescent-subtle 6s linear infinite; 
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.08); 
+  animation: borderBeamIridescent-subtle 6s linear infinite;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.08);
   display: block;
   margin-bottom: 20px;
 }
@@ -1279,7 +1304,7 @@ th:first-child {
   display: block; /* Ensure block display for data table */
 }
 
-@keyframes borderBeamIridescent-subtle { 
+@keyframes borderBeamIridescent-subtle {
     0% {
         background-position: 0% 50%;
     }
@@ -1289,17 +1314,17 @@ th:first-child {
 }
 
 .theme--dark.ts-ai-summary-card {
-  background-color: #1e1e1e; 
-  border-color: hsla(0,0%,100%,.12) !important; 
+  background-color: #1e1e1e;
+  border-color: hsla(0,0%,100%,.12) !important;
   background-image:
-      linear-gradient(#1e1e1e, #1e1e1e), 
+      linear-gradient(#1e1e1e, #1e1e1e),
       linear-gradient(90deg,
-          #8ab4f8 0%,  
-          #81c995 20%,  
-          #f8c665 40%, 
-          #ec7764 60%, 
+          #8ab4f8 0%,
+          #81c995 20%,
+          #f8c665 40%,
+          #ec7764 60%,
           #b39ddb 80%,
-          #8ab4f8 100%  
+          #8ab4f8 100%
       );
       box-shadow: 0 2px 5px rgba(255, 255, 255, 0.08);
   display: block;
@@ -1357,8 +1382,8 @@ th:first-child {
 .ts-event-list-container {
   display: flex;
   flex-direction: column;
-  width: 100%; 
-  gap: 20px;  
+  width: 100%;
+  gap: 20px;
 }
 
 ::v-deep .no-transition {

--- a/timesketch/frontend-ng/src/components/Explore/EventList.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventList.vue
@@ -726,6 +726,9 @@ export default {
     activeContext() {
       return this.$store.state.activeContext
     },
+    settings() {
+      return this.$store.state.settings
+    },
     filterChips: function () {
       return this.currentQueryFilter.chips.filter((chip) => chip.type === 'label' || chip.type === 'term')
     },
@@ -915,6 +918,8 @@ export default {
       formData['scenario'] = this.activeContext.scenarioId
       formData['facet'] = this.activeContext.facetId
       formData['question'] = this.activeContext.questionId
+
+      formData['include_processing_timelines'] = this.settings.showProcessingTimelineEvents
 
       ApiClient.search(this.sketch.id, formData)
         .then((response) => {

--- a/timesketch/frontend-ng/src/components/Explore/TimelineChip.vue
+++ b/timesketch/frontend-ng/src/components/Explore/TimelineChip.vue
@@ -50,7 +50,7 @@ limitations under the License.
             <template v-slot:activator="{ on: onTooltip, attrs }">
               <span
                 class="timeline-name-ellipsis"
-                :class="{ disabled: !isSelected && slotProps.timelineStatus === 'ready' }"
+                :class="{ disabled: !isSelected && (slotProps.timelineStatus === 'processing' || slotProps.timelineStatus === 'ready') }"
                 v-bind="attrs"
                 v-on="onTooltip"
                 >{{ timeline.name }}</span
@@ -88,7 +88,7 @@ export default {
   },
   methods: {
     timelineStyle(timelineStatus) {
-      const greyOut = timelineStatus === 'ready' && !this.isSelected
+      const greyOut = (timelineStatus === 'processing' || timelineStatus === 'ready') && !this.isSelected
       return {
         opacity: greyOut ? '50%' : '100%',
         backgroundColor: this.$vuetify.theme.dark ? '#303030' : '#f5f5f5',

--- a/timesketch/frontend-ng/src/components/LeftPanel/TimelinesTable.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/TimelinesTable.vue
@@ -307,9 +307,10 @@ export default {
 .chip-content {
   flex: 1;
   margin: 0;
-  padding: 0 10px;
+  padding-left: 10px;
   display: flex;
   align-items: center;
+  width:340px;
 }
 
 .timeline-name.disabled {
@@ -319,5 +320,11 @@ export default {
   align-items: center;
   display: flex;
   margin-left: auto;
+  max-width: 50%;
 }
+
+.timeline-name-ellipsis {
+  width: 50%;
+}
+
 </style>

--- a/timesketch/frontend-ng/src/components/LeftPanel/TimelinesTable.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/TimelinesTable.vue
@@ -136,6 +136,9 @@ limitations under the License.
                   </v-tooltip>
 
                   <span class="right">
+                    <span v-if="slotProps.timelineStatus === 'processing'" class="ml-3 mr-3">
+                        <v-progress-circular small indeterminate color="grey" :size="17" :width="2"></v-progress-circular>
+                    </span>
                     <span v-if="!slotProps.timelineFailed" class="events-count mr-1" x-small>
                       {{ getCount(item) | compactNumber }}
                     </span>
@@ -170,6 +173,7 @@ import ApiClient from '../../utils/RestApiClient.js'
 
 import TsUploadTimelineForm from '../UploadForm.vue'
 import TsTimelineComponent from '../Explore/TimelineComponent.vue'
+
 export default {
   props: {
     iconOnly: Boolean,
@@ -197,6 +201,14 @@ export default {
         return a.name.localeCompare(b.name)
       })
     },
+    settings() {
+      return this.$store.state.settings
+    },
+  },
+  watch: {
+    'settings.showProcessingTimelineEvents': function (newValue, oldValue) {
+      this.updateEnabledTimelines(oldValue === undefined)
+    },
   },
   methods: {
     isEnabled(timeline) {
@@ -208,8 +220,35 @@ export default {
     disableAllOtherTimelines(timeline) {
       this.$store.dispatch('updateEnabledTimelines', [timeline.id])
     },
+    updateEnabledTimelines(isNewSelection) {
+      let timelines = this.activeTimelines
+
+      if (isNewSelection) {
+        if (!this.settings.showProcessingTimelineEvents) {
+          timelines = timelines.filter((tl) => tl.status[0].status !== 'processing')
+        }
+      } else {
+        timelines = timelines.filter((tl) => this.$store.state.enabledTimelines.includes(tl.id))
+        if (this.settings.showProcessingTimelineEvents) {
+          this.activeTimelines.forEach((tl) => {
+            if (!timelines.includes(tl) && tl.status[0].status === 'processing') {
+              timelines.push(tl)
+            }
+          })
+          timelines.sort((a, b) => a.id - b.id)
+        }
+      }
+
+      let timelineIds = timelines.map((tl) => tl.id)
+
+      this.$store.dispatch('updateEnabledTimelines', timelineIds)
+    },
     timelineStyle(timelineStatus, isSelected) {
-      const greyOut = timelineStatus === 'ready' && !isSelected
+      let statusList = ['ready']
+      if (this.settings.showProcessingTimelineEvents) {
+        statusList.push('processing')
+      }
+      const greyOut = statusList.includes(timelineStatus) && !isSelected
       return {
         opacity: greyOut ? '50%' : '100%',
       }
@@ -252,10 +291,7 @@ export default {
     }
   },
   created() {
-    this.$store.dispatch(
-      'updateEnabledTimelines',
-      this.activeTimelines.map((tl) => tl.id)
-    )
+    this.updateEnabledTimelines(true)
   },
   mounted() {
     EventBus.$on('updateCountPerTimeline', this.updateCountPerTimeline)

--- a/timesketch/frontend-ng/src/components/SettingsDialog.vue
+++ b/timesketch/frontend-ng/src/components/SettingsDialog.vue
@@ -43,7 +43,7 @@ limitations under the License.
 
       <!-- Child Setting: Event Summarization -->
       <v-list-item v-if="systemSettings.LLM_PROVIDER">
-        <v-list-item-action class="ml-8"> 
+        <v-list-item-action class="ml-8">
           <v-switch
             v-model="settings.eventSummarization"
             color="primary"
@@ -51,7 +51,7 @@ limitations under the License.
             :disabled="!settings.aiPoweredFeaturesMain"
           ></v-switch>
         </v-list-item-action>
-        <v-list-item-content class="ml-8"> 
+        <v-list-item-content class="ml-8">
           <v-list-item-title>Event summarization</v-list-item-title>
           <v-list-item-subtitle
             >Enable AI powered summarization of events</v-list-item-subtitle
@@ -76,6 +76,17 @@ limitations under the License.
           >
         </v-list-item-content>
       </v-list-item>
+      <v-list-item>
+        <v-list-item-action>
+          <v-switch v-model="settings.showProcessingTimelineEvents" color="primary" @change="saveSettings()"></v-switch>
+        </v-list-item-action>
+        <v-list-item-content>
+          <v-list-item-title>Include Processing Events</v-list-item-title>
+          <v-list-item-subtitle
+          >Allows queries to include events from timelines still being <strong>processed</strong>.</v-list-item-subtitle
+          >
+        </v-list-item-content>
+      </v-list-item>
     </v-list>
   </v-card>
 </template>
@@ -88,6 +99,7 @@ const DEFAULT_SETTINGS = {
   aiPoweredFeaturesMain: false,
   eventSummarization: false,
   generateQuery: false,
+  showProcessingTimelineEvents: false,
 }
 
 export default {
@@ -98,6 +110,7 @@ export default {
         aiPoweredFeaturesMain: false,
         eventSummarization: false,
         generateQuery: false,
+        showProcessingTimelineEvents: false,
       },
     }
   },
@@ -140,6 +153,7 @@ export default {
       this.settings.aiPoweredFeaturesMain = this.settings.aiPoweredFeaturesMain !== undefined ? this.settings.aiPoweredFeaturesMain : DEFAULT_SETTINGS.aiPoweredFeaturesMain;
       this.settings.eventSummarization = this.settings.eventSummarization !== undefined ? this.settings.eventSummarization : DEFAULT_SETTINGS.eventSummarization;
       this.settings.generateQuery = this.settings.generateQuery !== undefined ? this.settings.generateQuery : DEFAULT_SETTINGS.generateQuery;
+      this.settings.showProcessingTimelineEvents = this.settings.showProcessingTimelineEvents !== undefined ? this.settings.showProcessingTimelineEvents : DEFAULT_SETTINGS.showProcessingTimelineEvents;
     }
   },
 }

--- a/timesketch/frontend-ng/src/components/SettingsDialog.vue
+++ b/timesketch/frontend-ng/src/components/SettingsDialog.vue
@@ -76,7 +76,7 @@ limitations under the License.
           >
         </v-list-item-content>
       </v-list-item>
-      <v-list-item>
+      <v-list-item v-if="systemSettings.SEARCH_PROCESSING_TIMELINES">
         <v-list-item-action>
           <v-switch v-model="settings.showProcessingTimelineEvents" color="primary" @change="saveSettings()"></v-switch>
         </v-list-item-action>

--- a/timesketch/frontend-ng/src/components/Visualization/AggregationEventSelect.vue
+++ b/timesketch/frontend-ng/src/components/Visualization/AggregationEventSelect.vue
@@ -20,6 +20,7 @@ limitations under the License.
         <!-- <v-container class="ma-0"> -->
           <ts-timeline-search
             componentName="visualization"
+            :includeProcessingTimelines="this.settings.showProcessingTimelineEvents"
             :analyzer-timeline-id="timelineIDs"
             @selectedTimelines="selectedTimelineIDs = $event"
           >
@@ -104,6 +105,9 @@ export default {
     }
   },
   computed: {
+    settings(){
+      return this.$store.state.settings
+    },
     sketch() {
       return this.$store.state.sketch
     },

--- a/timesketch/frontend-ng/src/components/Visualization/VisualizationEditor.vue
+++ b/timesketch/frontend-ng/src/components/Visualization/VisualizationEditor.vue
@@ -314,6 +314,9 @@ export default {
       }
       return undefined
     },
+    settings() {
+      return this.$store.state.settings
+    },
   },
   methods: {
     rename() {
@@ -438,7 +441,8 @@ export default {
             xTitle: this.selectedXTitle,
             yTitle: this.selectedYTitle,
           },
-        }
+        },
+        include_processing_timelines: !!this.settings.showProcessingTimelineEvents,
       }
     },
     loadAggregationData() {

--- a/timesketch/frontend-ng/src/store.js
+++ b/timesketch/frontend-ng/src/store.js
@@ -265,6 +265,7 @@ export default new Vuex.Store({
           field: 'tag',
           limit: '1000',
         },
+        include_processing_timelines: !!context.state.settings.showProcessingTimelineEvents,
       }
       return ApiClient.runAggregator(payload.sketchId, formData)
         .then((response) => {
@@ -292,6 +293,7 @@ export default new Vuex.Store({
           field: 'data_type',
           limit: '1000',
         },
+        include_processing_timelines: !!context.state.settings.showProcessingTimelineEvents,
       }
       return ApiClient.runAggregator(sketchId, formData)
         .then((response) => {

--- a/timesketch/frontend-ng/src/utils/RestApiClient.js
+++ b/timesketch/frontend-ng/src/utils/RestApiClient.js
@@ -141,11 +141,12 @@ export default {
     }
     return RestApiClient.post('/sketches/' + sketchId + '/event/create/', formData, config)
   },
-  getEvent(sketchId, searchindexId, eventId) {
+  getEvent(sketchId, searchindexId, eventId, includeProcessingTimelines) {
     let params = {
       params: {
         searchindex_id: searchindexId,
         event_id: eventId,
+        include_processing_timelines: includeProcessingTimelines
       },
     }
     return RestApiClient.get('/sketches/' + sketchId + '/event/', params)

--- a/timesketch/frontend-ng/src/views/Analyze.vue
+++ b/timesketch/frontend-ng/src/views/Analyze.vue
@@ -17,7 +17,7 @@ limitations under the License.
   <v-container fluid>
     <v-card flat class="pa-3 pt-0 mt-n3" color="transparent">
       <div class="mt-2">
-        <ts-timeline-search componentName="analysis" :analyzer-timeline-id="analyzerTimelineId" @selectedTimelines="timelineSelection = $event"></ts-timeline-search>
+        <ts-timeline-search componentName="analysis" :includeProcessingTimelines="false" :analyzer-timeline-id="analyzerTimelineId" @selectedTimelines="timelineSelection = $event"></ts-timeline-search>
       </div>
       <v-divider></v-divider>
       <div>

--- a/timesketch/frontend-ng/src/views/Sketch.vue
+++ b/timesketch/frontend-ng/src/views/Sketch.vue
@@ -417,15 +417,15 @@ export default {
   mounted() {
     this.loadingSketch = true
     this.showLeftPanel = false
-    this.$store.dispatch('updateSketch', this.sketchId).then(() => {
+    this.$store.dispatch('updateUserSettings').then(() =>
+      this.$store.dispatch('updateSketch', this.sketchId)).then(() => {
       this.$store.dispatch('updateSearchHistory', this.sketchId)
       this.$store.dispatch('updateScenarioTemplates', this.sketchId)
       this.$store.dispatch('updateSavedGraphs', this.sketchId)
       this.$store.dispatch('updateGraphPlugins')
       this.$store.dispatch('updateContextLinks')
       this.$store.dispatch('updateAnalyzerList', this.sketchId)
-      this.$store.dispatch('updateSystemSettings')
-      this.$store.dispatch('updateUserSettings').then(() => {
+      this.$store.dispatch('updateSystemSettings').then(() => {
         if (this.userSettings.showLeftPanel) {
           this.toggleDrawer()
         }

--- a/timesketch/lib/forms.py
+++ b/timesketch/lib/forms.py
@@ -222,6 +222,9 @@ class AggregationExploreForm(BaseForm):
     aggregator_parameters = StringField(
         "Aggregator Parameters", validators=[Optional()]
     )
+    include_processing_timelines = BooleanField(
+        "Include processing timelines", validators=[Optional()], default=False
+    )
 
 
 class AggregationLegacyForm(ExploreForm):

--- a/timesketch/lib/utils.py
+++ b/timesketch/lib/utils.py
@@ -531,21 +531,29 @@ def read_and_validate_jsonl(
             )
 
 
-def get_validated_indices(indices: List, sketch: object):
+def get_validated_indices(
+    indices: List, sketch: object, include_processing_timelines: bool = False
+):
     """Exclude any deleted search index references.
 
     Args:
         indices: List of indices from the user
         sketch: A sketch object (instance of models.sketch.Sketch).
+        include_processing_timelines: True to include Timelines
+          in status "processing". False by default.
 
     Returns:
         Tuple of two items:
           List of indices with those removed that is not in the sketch
           List of timeline IDs that should be part of the output.
     """
+    allowed_statuses = ["ready"]
+    if include_processing_timelines:
+        allowed_statuses.append("processing")
+
     sketch_structure = {}
     for timeline in sketch.timelines:
-        if timeline.get_status.status.lower() != "ready":
+        if timeline.get_status.status.lower() not in allowed_statuses:
             continue
         index_ = timeline.searchindex.index_name
         sketch_structure.setdefault(index_, [])

--- a/timesketch/lib/utils.py
+++ b/timesketch/lib/utils.py
@@ -548,7 +548,9 @@ def get_validated_indices(
           List of timeline IDs that should be part of the output.
     """
     allowed_statuses = ["ready"]
-    if include_processing_timelines:
+    if include_processing_timelines and current_app.config.get(
+        "SEARCH_PROCESSING_TIMELINES", False
+    ):
         allowed_statuses.append("processing")
 
     sketch_structure = {}

--- a/timesketch/models/sketch.py
+++ b/timesketch/models/sketch.py
@@ -141,10 +141,14 @@ class Sketch(AccessControlMixin, LabelMixin, StatusMixin, CommentMixin, BaseMode
             List of instances of timesketch.models.sketch.Timeline
         """
         _timelines = []
+        statuts_exclus = ["processing", "fail", "archived"]
+        if current_app.config.get("SEARCH_PROCESSING_TIMELINES", False):
+            statuts_exclus.remove("processing")
+
         for timeline in self.timelines:
             timeline_status = timeline.get_status.status
             index_status = timeline.searchindex.get_status.status
-            if (timeline_status or index_status) in ("fail", "archived"):
+            if (timeline_status or index_status) in statuts_exclus:
                 continue
             _timelines.append(timeline)
         return _timelines

--- a/timesketch/models/sketch.py
+++ b/timesketch/models/sketch.py
@@ -135,7 +135,7 @@ class Sketch(AccessControlMixin, LabelMixin, StatusMixin, CommentMixin, BaseMode
 
     @property
     def active_timelines(self):
-        """List timelines that are ready for analysis.
+        """List timelines that are being processed or ready for analysis.
 
         Returns:
             List of instances of timesketch.models.sketch.Timeline
@@ -144,7 +144,7 @@ class Sketch(AccessControlMixin, LabelMixin, StatusMixin, CommentMixin, BaseMode
         for timeline in self.timelines:
             timeline_status = timeline.get_status.status
             index_status = timeline.searchindex.get_status.status
-            if (timeline_status or index_status) in ("processing", "fail", "archived"):
+            if (timeline_status or index_status) in ("fail", "archived"):
                 continue
             _timelines.append(timeline)
         return _timelines


### PR DESCRIPTION
**IMPORTANT: All Pull Requests should be connected to an issue, if you don't
have an issue, please start by creating an issue and link it to the PR.**

Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or adding a minor bug fix -->

+ What existing problem does this PR solve?
  - Impossible to get timeline events when the one is being updated (new Plaso ingestion for the timeline).
+ What new feature is being introduced with this PR?
  - Allows to get timeline events when the timeline is being updated (new Plaso ingestion) i.e. allows to get partial events, already indexed,
  - Adds a setting to enable or disable this feature,
  - The UI clearly communicates to the user that search results against processing timelines may be incomplete and subject to change.
+ Overview of changes to existing functions if required.
  - Backend: In the `Sketch` model, the `active_timelines` property includes timelines with a status set to `processing`,
  - Backend: In the `utils.py`, the `get_validated_indices` function includes timelines with a status set to `processing`,
  - Backend: The `POST /sketches/{{sketch_id}}/aggregation/explore/` endpoint includes indices which timeline has a status set to `processing`.

**Checks**

- [x] All tests succeed.
- [ ] Unit tests added.
- [ ] e2e tests added.
- [ ] Documentation updated.

**Closing issues**

Closes #3219.
