### PR TITLE
Fix: Ensure consistent datetime handling during CSV import

### DIFF
--- a/timesketch/lib/utils.py
+++ b/timesketch/lib/utils.py
@@ -304,7 +304,7 @@ def read_and_validate_csv(
                 # (not available) as its value and the event row will be
                 # dropped in the next line
                 chunk["datetime"] = pandas.to_datetime(
-                    chunk["datetime"], errors="coerce"
+                    chunk["datetime"], errors="coerce", utc=True
                 )
                 num_chunk_rows = chunk.shape[0]
 


### PR DESCRIPTION
This PR addresses a bug where the CSV importer would fail with a `TypeError` when encountering certain datetime formats with timezone offsets, even if those formats were individually parseable by `dateutil`. The error stemmed from Pandas' inconsistent timezone inference across chunks of the DataFrame.

The fix adds `utc=True` to the `pandas.to_datetime` call within the `read_and_validate_csv` function in `timesketch/lib/utils.py`. This forces all parsed datetimes to be explicitly represented in UTC, preventing timezone-related parsing errors and ensuring consistent datetime handling.

**Key Benefits:**

* Improves data consistency by storing all datetimes as UTC.
* Prevents `TypeError` during CSV import for a broader range of datetime formats.

This change is backward compatible and should not affect existing timelines or functionality.