### PR TITLE
Resolve unsoundness caught by pytype --strict-none-binding.

### DIFF
--- a/api_client/python/timesketch_api_client/aggregation.py
+++ b/api_client/python/timesketch_api_client/aggregation.py
@@ -41,6 +41,7 @@ class Aggregation(resource.SketchResource):
         search_id: a search ID if the aggregation is tied to a specific
             saved search.
     """
+
     resource_data: dict[str, Any]
 
     def __init__(self, sketch):

--- a/api_client/python/timesketch_api_client/aggregation.py
+++ b/api_client/python/timesketch_api_client/aggregation.py
@@ -16,6 +16,7 @@ import datetime
 import getpass
 import json
 import logging
+from typing import Any
 
 import altair
 import pandas
@@ -40,6 +41,7 @@ class Aggregation(resource.SketchResource):
         search_id: a search ID if the aggregation is tied to a specific
             saved search.
     """
+    resource_data: dict[str, Any]
 
     def __init__(self, sketch):
         self._created_at = ""
@@ -307,7 +309,7 @@ class Aggregation(resource.SketchResource):
         """Set the description of an aggregation."""
         if "meta" not in self.resource_data:
             return
-        meta = self.resource_data.get("meta")
+        meta = self.resource_data.get("meta", {})
         meta["description"] = description
 
     @property

--- a/api_client/python/timesketch_api_client/client.py
+++ b/api_client/python/timesketch_api_client/client.py
@@ -106,11 +106,11 @@ class TimesketchApi:
         self._flow = None
 
         if not create_session:
-            self.session = None
+            self._session = None
             return
 
         try:
-            self.session = self._create_session(
+            self._session = self._create_session(
                 username,
                 password,
                 verify=verify,
@@ -145,13 +145,20 @@ class TimesketchApi:
 
         return "API Client: {0:s}".format(version.get_version())
 
+    @property
+    def session(self):
+        """Property that returns the session object."""
+        if self._session is None:
+            raise ValueError("Session is not set.")
+        return self._session
+
     def set_credentials(self, credential_object):
         """Sets the credential object."""
         self.credentials = credential_object
 
     def set_session(self, session_object):
         """Sets the session object."""
-        self.session = session_object
+        self._session = session_object
 
     def _authenticate_session(self, session, username, password):
         """Post username/password to authenticate the HTTP session.

--- a/api_client/python/timesketch_api_client/graph.py
+++ b/api_client/python/timesketch_api_client/graph.py
@@ -230,8 +230,10 @@ class Graph(resource.SketchResource):
         time = datetime.datetime.now(datetime.timezone.utc)
         self._created_at = time
         self._updated_at = time
-    
-    def from_manual(self, data, **kwargs):  # pylint: disable=arguments-differ; pytype: disable=signature-mismatch
+
+    def from_manual(
+        self, data, **kwargs
+    ):  # pylint: disable=arguments-differ; pytype: disable=signature-mismatch
         """Generate a new graph using a dictionary.
 
         Args:

--- a/api_client/python/timesketch_api_client/graph.py
+++ b/api_client/python/timesketch_api_client/graph.py
@@ -231,12 +231,12 @@ class Graph(resource.SketchResource):
         self._created_at = time
         self._updated_at = time
 
-    def from_manual(self, data, **kwargs):  # pylint: disable=arguments-differ
+    def from_manual(self, data, **kwargs):  # pytype: disable=signature-mismatch
         """Generate a new graph using a dictionary.
 
         Args:
             data (dict): A dictionary of dictionaries adjacency representation.
-            kwargs (dict[str, object]): Depending on the resource they may
+            **kwargs (dict[str, object]): Depending on the resource they may
                 require different sets of arguments to be able to run a raw
                 API request.
 

--- a/api_client/python/timesketch_api_client/graph.py
+++ b/api_client/python/timesketch_api_client/graph.py
@@ -230,8 +230,8 @@ class Graph(resource.SketchResource):
         time = datetime.datetime.now(datetime.timezone.utc)
         self._created_at = time
         self._updated_at = time
-
-    def from_manual(self, data, **kwargs):  # pytype: disable=signature-mismatch
+    
+    def from_manual(self, data, **kwargs):  # pylint: disable=arguments-differ; pytype: disable=signature-mismatch
         """Generate a new graph using a dictionary.
 
         Args:


### PR DESCRIPTION
Resolve unsoundness caught by pytype --strict-none-binding.

In short, pytype was previously more permissive when variables were initialized to None but may have been re-assigned later. This change improves pytype's ability to catch unsoundness in the affected files.

**Checks**

- [x] All tests succeed.
- [ ] Unit tests added.
- [ ] e2e tests added.
- [ ] Documentation updated.
