### PR TITLE
Fix pytype error in TS API client

### DIFF
--- a/api_client/python/timesketch_api_client/graph.py
+++ b/api_client/python/timesketch_api_client/graph.py
@@ -232,7 +232,7 @@ class Graph(resource.SketchResource):
         self._updated_at = time
 
     def from_manual(
-        self, data, **kwargs
+        self, data=None, **kwargs
     ):  # pylint: disable=arguments-differ; pytype: disable=signature-mismatch
         """Generate a new graph using a dictionary.
 


### PR DESCRIPTION
This PR fixes a pytype error in the TS API client graph.py file.