### PR TITLE
[DRAFT]Kketch delete poc

### DIFF
--- a/cli_client/python/timesketch_cli_client/commands/sketch.py
+++ b/cli_client/python/timesketch_cli_client/commands/sketch.py
@@ -158,3 +158,12 @@ def unarchive_sketch(ctx):
     if sketch.is_archived():
         sketch.unarchive()
         click.echo("Sketch unarchived")
+
+
+@sketch_group.command("delete", help="Delete a sketch")
+@click.pass_context
+def delete_sketch(ctx):
+    """Delete a sketch."""
+    sketch = ctx.obj.sketch
+    sketch.delete()
+    click.echo("Sketch deleted")

--- a/timesketch/api/v1/resources/sketch.py
+++ b/timesketch/api/v1/resources/sketch.py
@@ -496,6 +496,9 @@ class SketchResource(resources.ResourceMixin, Resource):
                     "Sketch with the label [{0:s}] cannot be deleted.".format(label),
                 )
         sketch.set_status(status="deleted")
+        db_session.delete(sketch)
+        db_session.commit()
+        # TODO: there needs to be a lot of related data to be deleted
         return HTTP_STATUS_CODE_OK
 
     @login_required

--- a/timesketch/models/sketch.py
+++ b/timesketch/models/sketch.py
@@ -58,23 +58,96 @@ class Sketch(AccessControlMixin, LabelMixin, StatusMixin, CommentMixin, BaseMode
     name = Column(Unicode(255))
     description = Column(UnicodeText())
     user_id = Column(Integer, ForeignKey("user.id"))
-    timelines = relationship("Timeline", backref="sketch", lazy="select")
-    views = relationship("View", backref="sketch", lazy="select")
-    events = relationship("Event", backref="sketch", lazy="select")
-    stories = relationship("Story", backref="sketch", lazy="select")
-    aggregations = relationship("Aggregation", backref="sketch", lazy="select")
-    attributes = relationship("Attribute", backref="sketch", lazy="select")
-    graphs = relationship("Graph", backref="sketch", lazy="select")
-    graphcaches = relationship("GraphCache", backref="sketch", lazy="select")
-    aggregationgroups = relationship(
-        "AggregationGroup", backref="sketch", lazy="select"
+    timelines = relationship(
+        "Timeline",
+        backref="sketch",
+        lazy="select",
+        cascade="save-update, merge, delete",
     )
-    analysis = relationship("Analysis", backref="sketch", lazy="select")
-    analysissessions = relationship("AnalysisSession", backref="sketch", lazy="select")
-    searchhistories = relationship("SearchHistory", backref="sketch", lazy="dynamic")
-    scenarios = relationship("Scenario", backref="sketch", lazy="dynamic")
-    facets = relationship("Facet", backref="sketch", lazy="dynamic")
-    questions = relationship("InvestigativeQuestion", backref="sketch", lazy="dynamic")
+    views = relationship(
+        "View",
+        backref="sketch",
+        lazy="select",
+        cascade="save-update, merge, delete",
+    )
+    events = relationship(
+        "Event",
+        backref="sketch",
+        lazy="select",
+        cascade="save-update, merge, delete",
+    )
+    stories = relationship(
+        "Story",
+        backref="sketch",
+        lazy="select",
+        cascade="save-update, merge, delete",
+    )
+    aggregations = relationship(
+        "Aggregation",
+        backref="sketch",
+        lazy="select",
+        cascade="save-update, merge, delete",
+    )
+    attributes = relationship(
+        "Attribute",
+        backref="sketch",
+        lazy="select",
+        cascade="save-update, merge, delete",
+    )
+    graphs = relationship(
+        "Graph",
+        backref="sketch",
+        lazy="select",
+        cascade="save-update, merge, delete",
+    )
+    graphcaches = relationship(
+        "GraphCache",
+        backref="sketch",
+        lazy="select",
+        cascade="save-update, merge, delete",
+    )
+    aggregationgroups = relationship(
+        "AggregationGroup",
+        backref="sketch",
+        lazy="select",
+        cascade="save-update, merge, delete",
+    )
+    analysis = relationship(
+        "Analysis",
+        backref="sketch",
+        lazy="select",
+        cascade="save-update, merge, delete",
+    )
+    analysissessions = relationship(
+        "AnalysisSession",
+        backref="sketch",
+        lazy="select",
+        cascade="save-update, merge, delete",
+    )
+    searchhistories = relationship(
+        "SearchHistory",
+        backref="sketch",
+        lazy="dynamic",
+        cascade="save-update, merge, delete",
+    )
+    scenarios = relationship(
+        "Scenario",
+        backref="sketch",
+        lazy="dynamic",
+        cascade="save-update, merge, delete",
+    )
+    facets = relationship(
+        "Facet",
+        backref="sketch",
+        lazy="dynamic",
+        cascade="save-update, merge, delete",
+    )
+    questions = relationship(
+        "InvestigativeQuestion",
+        backref="sketch",
+        lazy="dynamic",
+        cascade="save-update, merge, delete",
+    )
 
     @property
     def get_named_aggregations(self):

--- a/timesketch/tsctl.py
+++ b/timesketch/tsctl.py
@@ -545,6 +545,21 @@ def print_table(table_data):
         print()
 
 
+@cli.command(name="sketch-delete")
+@click.argument("sketch_id")
+def sketch_delete(sketch_id):
+    """Delete a sketch."""
+    sketch = Sketch.query.filter_by(id=sketch_id).first()
+    if not sketch:
+        print("Sketch does not exist.")
+    else:
+        print(f"Sketch {sketch_id} Name: ({sketch.name})")
+        sketch.delete()
+        db_session.delete(sketch)
+        db_session.commit()
+        print(f"Sketch {sketch_id} deleted.")
+
+
 @cli.command(name="sketch-info")
 @click.argument("sketch_id")
 def sketch_info(sketch_id):


### PR DESCRIPTION
This PR introduces a new feature to Timesketch and tsctl that allows users to delete sketches. The following changes have been made:

Sketch API: Added a new endpoint to the Sketch API for deleting sketches.
tsctl: Added a new command to tsctl for deleting sketches.
Documentation: Updated the documentation to reflect the new functionality.
This feature will provide users with a more streamlined way to manage their sketches and remove unwanted data.

**Checks**

- [ ] All tests succeed.
- [ ] Unit tests added.
- [ ] e2e tests added.
- [ ] Documentation updated.
