### PR TITLE
[CLI] Sketch label management

### DIFF
--- a/cli_client/python/timesketch_cli_client/commands/sketch.py
+++ b/cli_client/python/timesketch_cli_client/commands/sketch.py
@@ -158,3 +158,40 @@ def unarchive_sketch(ctx):
     if sketch.is_archived():
         sketch.unarchive()
         click.echo("Sketch unarchived")
+
+
+@sketch_group.command("delete", help="Delete a sketch")
+@click.pass_context
+def delete_sketch(ctx):
+    """Delete a sketch."""
+    sketch = ctx.obj.sketch
+    sketch.delete()
+    click.echo("Sketch deleted")
+
+
+@sketch_group.command("add_label", help="Add a label to a sketch")
+@click.option("--label", required=True, help="Name of label to add.")
+@click.pass_context
+def add_label(ctx, label):
+    """Add a label to a sketch."""
+    sketch = ctx.obj.sketch
+    sketch.add_sketch_label(label)
+    click.echo("Label added")
+
+
+@sketch_group.command("list_label", help="List labels of sketch")
+@click.pass_context
+def list_label(ctx):
+    """List labels of a sketch."""
+    sketch = ctx.obj.sketch
+    click.echo(sketch.labels)
+
+
+@sketch_group.command("remove_label", help="Remove a label from a sketch")
+@click.option("--label", required=True, help="Name of label to remove.")
+@click.pass_context
+def remove_label(ctx, label):
+    """Remove a label from a sketch."""
+    sketch = ctx.obj.sketch
+    sketch.remove_sketch_label(label)
+    click.echo("Label removed.")

--- a/cli_client/python/timesketch_cli_client/commands/sketch.py
+++ b/cli_client/python/timesketch_cli_client/commands/sketch.py
@@ -160,15 +160,6 @@ def unarchive_sketch(ctx):
         click.echo("Sketch unarchived")
 
 
-@sketch_group.command("delete", help="Delete a sketch")
-@click.pass_context
-def delete_sketch(ctx):
-    """Delete a sketch."""
-    sketch = ctx.obj.sketch
-    sketch.delete()
-    click.echo("Sketch deleted")
-
-
 @sketch_group.command("add_label", help="Add a label to a sketch")
 @click.option("--label", required=True, help="Name of label to add.")
 @click.pass_context

--- a/docs/guides/user/cli-client.md
+++ b/docs/guides/user/cli-client.md
@@ -295,6 +295,38 @@ Running `sketch unarchive` will set the archive flag to the sketch.
 
 Running `sketch export` will export the complete Sketch to a file.
 
+### Labels
+
+#### list_labels
+
+Running `sketch list_labels` will give you a list of all labels of a sketch.
+
+Example:
+```bash
+timesketch --sketch 14 --output-format json sketch list_label
+['test', 'foobar']
+```
+
+#### add label
+
+Running `sketch add_label --label foobar` will add the label `foobar` to the sketch.
+
+Example:
+```bash
+timesketch --sketch 14 --output-format json sketch add_label --label=foobar
+Label added
+```
+
+#### Remove label
+
+Running `sketch remove_label --label foobar` will remove the label `foobar` from the sketch.
+
+Example:
+```bash
+timesketch --sketch 14 --output-format json sketch remove_label --label=foobar
+Label removed
+```
+
 ## Intelligence
 
 Intelligence is always sketch specific. The same can be achieved using 


### PR DESCRIPTION
This PR adds three new commands to the Timesketch CLI for managing labels on sketches:

- **add_label**: Adds a label to a sketch.
- **remove_label**: Removes a label from a sketch.
- **list_labels**: Lists all labels associated with a sketch.

These commands provide a convenient way to manage sketch labels directly from the command line, improving workflow efficiency for users who prefer CLI interactions.

Documentation for it is also updated