### PR TITLE
Enhance tsctl with User Status and Group Membership Information

### DIFF
--- a/docs/guides/admin/admin-cli.md
+++ b/docs/guides/admin/admin-cli.md
@@ -150,6 +150,17 @@ bar
 dev (admin)
 ```
 
+Adding `--status` will add the status of the user to the output.
+
+Example
+```shell
+tsctl list-users --status
+dev (active: True)
+admin (active: True)
+foobar2 (active: True)
+foobar (active: False)
+```
+
 #### Make admin
 
 tsctl provides a subcommand for granting administrator privileges to a user in a Timesketch instance. This subcommand is called `make-admin`, and it allows you to specify the username of the user you want to grant administrator privileges to.

--- a/docs/guides/admin/admin-cli.md
+++ b/docs/guides/admin/admin-cli.md
@@ -220,10 +220,8 @@ Example:
 
 ```bash
 tsctl list-groups --showmembership
-foobar
-foobar-group
-	foobar2
-	foobar
+foobar:
+foobar-group: foobar2, foobar
 ```
 
 ##### Add a suer to a group

--- a/docs/guides/admin/admin-cli.md
+++ b/docs/guides/admin/admin-cli.md
@@ -221,7 +221,7 @@ Example:
 ```bash
 tsctl list-groups --showmembership
 foobar:
-foobar-group: foobar2, foobar
+foobar-group:foobar2,foobar
 ```
 
 ##### Add a suer to a group

--- a/docs/guides/admin/admin-cli.md
+++ b/docs/guides/admin/admin-cli.md
@@ -212,6 +212,20 @@ Not yet implemented.
 
 #### Managing group membership
 
+##### List groups
+
+To list groups, use `tsctl list-groups`. This can be extended  to show the members of a group using `tsctl list-groups --showmembershipt`
+
+Example:
+
+```bash
+tsctl list-groups --showmembership
+foobar
+foobar-group
+	foobar2
+	foobar
+```
+
 ##### Add a suer to a group
 
 tsctl provides a subcommand for adding users to a group in a Timesketch instance. This subcommand is called `add-group-member`, and it allows you to specify the username of the user you want to add to the group, as well as the name of the group you want to add the user to.

--- a/timesketch/tsctl.py
+++ b/timesketch/tsctl.py
@@ -49,14 +49,18 @@ def cli():
 
 
 @cli.command(name="list-users")
-def list_users():
+@click.option("--status", "-s", is_flag=True, help="Show status of the users.")
+def list_users(status):
     """List all users."""
     for user in User.query.all():
         if user.admin:
             extra = " (admin)"
         else:
             extra = ""
-        print(f"{user.username}{extra}")
+        if status:
+            print(f"{user.username}{extra} (active: {user.active})")
+        else:
+            print(f"{user.username}{extra}")
 
 
 @cli.command(name="create-user")

--- a/timesketch/tsctl.py
+++ b/timesketch/tsctl.py
@@ -196,10 +196,14 @@ def list_sketches():
 
 
 @cli.command(name="list-groups")
-def list_groups():
+@click.option("--showmembership", is_flag=True, help="Show members of that group.")
+def list_groups(showmembership):
     """List all groups."""
     for group in Group.query.all():
         print(group.name)
+        if showmembership:
+            for user in group.users:
+                print(f"\t{user.username}")
 
 
 @cli.command(name="create-group")

--- a/timesketch/tsctl.py
+++ b/timesketch/tsctl.py
@@ -200,10 +200,13 @@ def list_sketches():
 def list_groups(showmembership):
     """List all groups."""
     for group in Group.query.all():
-        print(group.name)
         if showmembership:
+            users = []
             for user in group.users:
-                print(f"\t{user.username}")
+                users.append(user.username)
+            print(f"{group.name}: {', '.join(users)}")
+        else:
+            print(group.name)
 
 
 @cli.command(name="create-group")

--- a/timesketch/tsctl.py
+++ b/timesketch/tsctl.py
@@ -204,7 +204,7 @@ def list_groups(showmembership):
             users = []
             for user in group.users:
                 users.append(user.username)
-            print(f"{group.name}: {', '.join(users)}")
+            print(f"{group.name}:{','.join(users)}")
         else:
             print(group.name)
 


### PR DESCRIPTION
This pull request improves the tsctl command-line tool by adding two new features:

- **User Status in list-users**: The tsctl list-users command now displays the status of each user (e.g., active, inactive, locked). This allows administrators to quickly check the status of users in the system.

- **Group Membership** in list-groups: The tsctl list-groups command now lists the members of each group. This makes it easier to understand the composition of groups and manage user access controls.

These enhancements provide administrators with better visibility into user and group information, making it easier to manage Timesketch users and permissions.

Examples:

```
tsctl list-users --status
dev (active: True)
admin (active: True)
foobar2 (active: True)
foobar (active: False)
```

```
tsctl list-groups --showmembership
foobar:
foobar-group: foobar2, foobar
```