### PR TITLE
Feat(cli): Add field count to Timesketch index information

### DIFF
--- a/cli_client/python/timesketch_cli_client/commands/timelines.py
+++ b/cli_client/python/timesketch_cli_client/commands/timelines.py
@@ -63,6 +63,7 @@ def describe_timeline(ctx, timeline_id):
     lines_indexed = timeline.resource_data.get("meta").get("lines_indexed", 0)
     click.echo(f"Event count: {lines_indexed or 0}")
     click.echo(f"Color: {timeline.color}")
+    click.echo(f"Number of fields: {len(timeline.index.fields)}")
 
     for timeline_object in timeline.resource_data.get("objects", None):
         name = timeline_object.get("name", "no name")


### PR DESCRIPTION
This pull request enhances the Timesketch CLI client by adding the ability to display the number of fields present in each index associated with a sketch.  This provides users with valuable information about the structure of their data directly from the command line, improving their workflow when working with Timesketch.

Key changes:
*   Calculated the number of fields based on the retrieved mapping data.
*   Modified the CLI output for sketch/index information to include the `fields`.  

```
timesketch --sketch 16 timelines describe 18
Name: 2
Index: dd9b6f91f8a04018a44afcb82d762c8d
Status: ready
Event count: 200
Color: F379E1
Number of fields: 407
Name: 2
Created: 2025-01-31T11:01:28.693660
Datasources:
	Original filename:
	File on disk:
	Error:
	Original filename:
	File on disk:
	Error:
```
