### PR TITLE
Improvements to the threat intel view

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        python-version: ['3.9', '3.10']
+        python-version: ["3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        node-version: ["18"]
+        node-version: ["20"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Node ${{ matrix.node-version }}
@@ -66,7 +66,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        node-version: ["18"]
+        node-version: ["20"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Node ${{ matrix.node-version }}

--- a/data/intelligence_tag_metadata.yaml
+++ b/data/intelligence_tag_metadata.yaml
@@ -10,21 +10,36 @@
 
 malware:
   weight: 100
-  class: 'danger'
+  type: 'danger'
+
+bad:
+  weight: 90
+  type: 'danger'
 
 suspicious:
   weight: 50
-  class: 'warning'
+  type: 'warning'
+
+good:
+  weight: 10
+  type: 'legit'
 
 legit:
   weight: 10
-  class: 'success'
+  type: 'legit'
 
 default:
   weight: 0
-  class: 'info'
+  type: 'default'
+
+export:
+  weight: 100
+  type: 'info'
 
 regexes:
   '^GROUPNAME':
-    weight: 100
-    class: 'danger'
+      weight: 100
+      type: 'danger'
+  '^inv_':
+      weight: 80
+      type: 'warning'

--- a/timesketch/frontend-ng/src/utils/ThreatIntelMetadata.js
+++ b/timesketch/frontend-ng/src/utils/ThreatIntelMetadata.js
@@ -1,15 +1,15 @@
 const IOCTypes = [
-    { regex: /^(\/[\S]+)+$/i, type: 'fs_path' },
-    { regex: /^([-\w]+\.)+[a-z]{2,}$/i, type: 'hostname' },
+    { regex: /^(\/[\S]+)+$/i, type: 'fs_path', humanReadable: 'Filesystem path' },
+    { regex: /^([-\w]+\.)+[a-z]{2,}$/i, type: 'hostname', humanReadable: 'Hostname' },
     {
       regex: /^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/g,
       type: 'ipv4',
     },
-    { regex: /^[0-9a-f]{64}$/i, type: 'hash_sha256' },
-    { regex: /^[0-9a-f]{40}$/i, type: 'hash_sha1' },
-    { regex: /^[0-9a-f]{32}$/i, type: 'hash_md5' },
+    { regex: /^[0-9a-f]{64}$/i, type: 'hash_sha256', humanReadable: 'SHA256' },
+    { regex: /^[0-9a-f]{40}$/i, type: 'hash_sha1', humanReadable: 'SHA1' },
+    { regex: /^[0-9a-f]{32}$/i, type: 'hash_md5', humanReadable: 'MD5' },
     // Match any "other" selection
-    { regex: /./g, type: 'other' },
+    { regex: /./g, type: 'other', humanReadable: 'Other' },
 ]
 
 export {IOCTypes}

--- a/timesketch/frontend-ng/src/views/ThreatIntel.vue
+++ b/timesketch/frontend-ng/src/views/ThreatIntel.vue
@@ -15,21 +15,14 @@ limitations under the License.
 -->
 <template>
   <div>
-    <ts-indicator-dialog
-      :dialog.sync="indicatorDialog"
-      :index="currentIndex"
-      :tag-info="tagInfo"
-      :ioc="indicator"
-      @open-dialog="indicatorDialog = true"
-      @close-dialog="
+    <ts-indicator-dialog :dialog.sync="indicatorDialog" :index="currentIndex" :tag-info="tagInfo" :ioc="indicator"
+      @open-dialog="indicatorDialog = true" @close-dialog="
         indicatorDialog = false
-        currentIndex = -1
-      "
-      @save="
-        saveIntelligence($event)
+      currentIndex = -1
+        " @save="
+          saveIntelligence($event)
         indicatorDialog = false
-      "
-    >
+          ">
     </ts-indicator-dialog>
 
     <v-container fluid>
@@ -39,13 +32,9 @@ limitations under the License.
       </v-btn>
 
       <v-card outlined class="mt-3 mx-3">
-        <v-data-table
-          :headers="headers"
-          :items="intelligenceData"
+        <v-data-table :headers="headers" :items="intelligenceData"
           :footer-props="{ 'items-per-page-options': [10, 40, 80, 100, 200, 500], 'show-current-page': true }"
-          :items-per-page="40"
-          selectable
-        >
+          :items-per-page="40" selectable>
           <template v-slot:item.search="{ item }">
             <v-btn icon small @click="generateSearchQuery(item.ioc)">
               <v-icon title="Search this indicator" small>mdi-magnify</v-icon>
@@ -54,23 +43,20 @@ limitations under the License.
 
           <template v-slot:item.externalURI="{ item }">
             <v-icon title="Open link" v-if="item.externalURI" x-small>mdi-open-in-new</v-icon>
-            <a
-              style="text-decoration: none"
-              v-if="getValidUrl(item.externalURI)"
-              :href="getValidUrl(item.externalURI)"
-              target="_blank"
-            >
-              {{ getValidUrl(item.externalURI).host }}</a
-            >
+            <a style="text-decoration: none" v-if="getValidUrl(item.externalURI)" :href="getValidUrl(item.externalURI)"
+              target="_blank">
+              {{ getValidUrl(item.externalURI).host }}</a>
           </template>
 
           <template v-slot:item.type="{ item }">
-            {{getIocTypeMetadata(item).humanReadable}}
+            {{ getIocTypeMetadata(item).humanReadable }}
           </template>
 
           <template v-slot:item.tags="{ item }">
             <v-chip-group>
-              <v-chip small v-for="tag in augmentedTags(item.tags).sort((a, b) => b.weight - a.weight)" :color="tag.color" :text-color="tag.textColor" :outlined="tag.style == 'outlined'" :key="tag.name" @click="searchForIOC(tag)">
+              <v-chip small v-for="tag in augmentedTags(item.tags).sort((a, b) => b.weight - a.weight)"
+                :color="tag.color" :text-color="tag.textColor" :outlined="tag.style == 'outlined'" :key="tag.name"
+                @click="searchForIOC(tag)">
                 {{ tag.name }}
               </v-chip>
             </v-chip-group>
@@ -126,13 +112,13 @@ export default {
       indicatorDialog: false,
       currentIndex: -1,
       indicator: '',
-      tagMetadata: {default: {weight: 0, type: 'default'}},
+      tagMetadata: { default: { weight: 0, type: 'default' } },
       tagColorDefinitions: {
-        danger: { color: 'red', textColor: 'white'},
-        warning: { color: 'orange', textColor: 'white'},
-        legit: { color: 'green', textColor: 'white'},
-        default: { color: 'default', textColor: null},
-        info: { color: 'blue', textColor: null, style: 'outlined'}
+        danger: { color: 'red', textColor: 'white' },
+        warning: { color: 'orange', textColor: 'white' },
+        legit: { color: 'green', textColor: 'white' },
+        default: { color: 'default', textColor: null },
+        info: { color: 'blue', textColor: null, style: 'outlined' }
       }
     }
   },
@@ -168,12 +154,12 @@ export default {
         metadata = this.tagMetadata[tag]
       } else {
         for (var regex in this.tagMetadata['regexes']) {
-            if (tag.match(regex)) {
-              metadata = this.tagMetadata['regexes'][regex]
-            }
+          if (tag.match(regex)) {
+            metadata = this.tagMetadata['regexes'][regex]
           }
         }
-      return {...this.tagColorDefinitions[metadata.type], name: tag, weight: metadata.weight}
+      }
+      return { ...this.tagColorDefinitions[metadata.type], name: tag, weight: metadata.weight }
     },
     augmentedTags(tags) {
       return tags.map(tag => this.metadataForTag(tag))
@@ -274,8 +260,8 @@ export default {
         })
     },
     showIndicatorDialog(payload) {
-        this.indicator = payload
-        this.indicatorDialog = true
+      this.indicator = payload
+      this.indicatorDialog = true
     },
   },
   mounted() {

--- a/timesketch/frontend-ng/src/views/ThreatIntel.vue
+++ b/timesketch/frontend-ng/src/views/ThreatIntel.vue
@@ -62,6 +62,11 @@ limitations under the License.
               {{ getValidUrl(item.externalURI).host }}</a
             >
           </template>
+
+          <template v-slot:item.type="{ item }">
+            {{getIocTypeMetadata(item).humanReadable}}
+          </template>
+
           <template v-slot:item.tags="{ item }">
             <v-chip-group>
               <v-chip small v-for="tag in augmentedTags(item.tags).sort((a, b) => b.weight - a.weight)" :color="tag.color" :text-color="tag.textColor" :outlined="tag.style == 'outlined'" :key="tag.name" @click="searchForIOC(tag)">
@@ -88,6 +93,7 @@ limitations under the License.
 import ApiClient from '../utils/RestApiClient.js'
 import EventBus from '../event-bus.js'
 import TsIndicatorDialog from '../components/ThreatIntel/IndicatorDialog.vue'
+import { IOCTypes } from '@/utils/ThreatIntelMetadata'
 
 const defaultQueryFilter = () => {
   return {
@@ -171,6 +177,14 @@ export default {
     },
     augmentedTags(tags) {
       return tags.map(tag => this.metadataForTag(tag))
+    },
+    getIocTypeMetadata(ioc) {
+      let iocTypeMetatada = IOCTypes.find(def => def.type == ioc.type)
+      if (iocTypeMetatada !== undefined) {
+        return iocTypeMetatada
+      } else {
+        return IOCTypes.find(def => def.type === 'other')
+      }
     },
     deleteIndicator(index) {
       if (confirm('Delete indicator?')) {

--- a/timesketch/frontend-ng/src/views/ThreatIntel.vue
+++ b/timesketch/frontend-ng/src/views/ThreatIntel.vue
@@ -55,7 +55,7 @@ limitations under the License.
           <template v-slot:item.tags="{ item }">
             <v-chip-group>
               <v-chip small v-for="tag in augmentedTags(item.tags).sort((a, b) => b.weight - a.weight)"
-                :color="tag.color" :text-color="tag.textColor" :outlined="tag.style == 'outlined'" :key="tag.name"
+                :color="tag.color" :text-color="tag.textColor" :outlined="tag.style === 'outlined'" :key="tag.name"
                 @click="searchForIOC(tag)">
                 {{ tag.name }}
               </v-chip>
@@ -165,7 +165,7 @@ export default {
       return tags.map(tag => this.metadataForTag(tag))
     },
     getIocTypeMetadata(ioc) {
-      let iocTypeMetatada = IOCTypes.find(def => def.type == ioc.type)
+      let iocTypeMetatada = IOCTypes.find(def => def.type === ioc.type)
       if (iocTypeMetatada !== undefined) {
         return iocTypeMetatada
       } else {

--- a/timesketch/frontend-ng/src/views/ThreatIntel.vue
+++ b/timesketch/frontend-ng/src/views/ThreatIntel.vue
@@ -44,6 +44,7 @@ limitations under the License.
           :items="intelligenceData"
           :footer-props="{ 'items-per-page-options': [10, 40, 80, 100, 200, 500], 'show-current-page': true }"
           :items-per-page="40"
+          selectable
         >
           <template v-slot:item.search="{ item }">
             <v-btn icon small @click="generateSearchQuery(item.ioc)">
@@ -158,7 +159,6 @@ export default {
     },
     loadTagMetadata() {
       ApiClient.getTagMetadata().then((response) => {
-        console.log("CALLED")
         this.tagMetadata = response.data
       })
     },


### PR DESCRIPTION
This PR brings back some changes that were lost in the move to the "new UI".

* Tags can be colored and "weighed", by specifying their type in a YAML file that is loaded by the API server
  * e.g. `malware` tags will appear in red, and earlier in the list of tags.
* Human readable indicator types

<img width="1254" alt="image" src="https://github.com/user-attachments/assets/2d68490c-bfa8-4314-b084-91aba57dc596" />
