### PR TITLE
TagList bug fix

### DIFF
--- a/timesketch/frontend-ng/src/components/LeftPanel/TagsList.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/TagsList.vue
@@ -93,6 +93,7 @@ export default {
     allTagsAndLabels() {
       const labelOrder = ['__ts_star', '__ts_comment', 'bad', 'suspicious', 'good']
       return [...this.labels, ...this.assignedQuickTags, ...this.customTags]
+        .filter(item => item.tag || item.label) // Filter out items without tag or label
         .sort((a, b) => {
           const aLabel = a.tag || a.label
           const bLabel = b.tag || b.label


### PR DESCRIPTION
This PR fixes a small bug introduced in #3267 where in rare situations a tag or label element can be `undefined` leading to the [localCompare in the allTagsAndLabels() function](https://github.com/google/timesketch/blob/master/timesketch/frontend-ng/src/components/LeftPanel/TagsList.vue#L115) to fail, rendering the TagList on the left panel broken.

This is fixed by filtering the data prior to sending it to the compare function.