### PR TITLE
[tests] add sketch related tests to the API unit tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 """This is the setup file for the project. The standard setup rules apply:
 
-   python setup.py build
-   sudo python setup.py install
+python setup.py build
+sudo python setup.py install
 """
 
 from __future__ import print_function

--- a/timesketch/api/v1/resources_test.py
+++ b/timesketch/api/v1/resources_test.py
@@ -114,7 +114,7 @@ class SketchResourceTest(BaseTest):
         response = self.client.get("/api/v1/sketches/2/")
         self.assert403(response)
 
-        def test_create_a_sketch(self):
+    def test_create_a_sketch(self):
         """Authenticated request to create a sketch."""
         self.login()
         data = dict(

--- a/timesketch/api/v1/resources_test.py
+++ b/timesketch/api/v1/resources_test.py
@@ -114,6 +114,101 @@ class SketchResourceTest(BaseTest):
         response = self.client.get("/api/v1/sketches/2/")
         self.assert403(response)
 
+        def test_create_a_sketch(self):
+        """Authenticated request to create a sketch."""
+        self.login()
+        data = dict(
+            name="test_create_a_sketch",
+            description="test_create_a_sketch",
+        )
+        response = self.client.post(
+            "/api/v1/sketches/",
+            data=json.dumps(data, ensure_ascii=False),
+            content_type="application/json",
+        )
+        self.assertEqual(HTTP_STATUS_CODE_CREATED, response.status_code)
+
+        # check the created sketch
+
+        response = self.client.get("/api/v1/sketches/")
+        self.assertEqual(len(response.json["objects"]), 3)
+        self.assertIn(b"test_create_a_sketch", response.data)
+        self.assertEqual("test_create_a_sketch", response.json["objects"][2]["name"])
+        self.assert200(response)
+
+    def test_append_label_to_sketch(self):
+        """Authenticated request to append a label to a sketch."""
+        self.login()
+
+        data = dict(
+            labels=["test_append_label_to_sketch"],
+            label_action="add",
+        )
+
+        response = self.client.post(
+            "/api/v1/sketches/3/",
+            data=json.dumps(data, ensure_ascii=False),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, HTTP_STATUS_CODE_CREATED)
+
+        # check the result in content
+        response = self.client.get("/api/v1/sketches/3/")
+        self.assertEqual(len(response.json["objects"]), 1)
+        self.assertEqual(len(response.json["objects"]), 1)
+        self.assertEqual(response.json["objects"][0]["name"], "Test 3")
+        self.assertIn(
+            "test_append_label_to_sketch", response.json["objects"][0]["label_string"]
+        )
+        self.assert200(response)
+
+    def test_sketch_delete_not_existant_sketch(self):
+        """Authenticated request to delete a sketch."""
+        self.login()
+        response = self.client.delete("/api/v1/sketches/99/")
+        self.assert404(response)
+
+    def test_sketch_delete_no_acl(self):
+        """Authenticated request to delete a sketch that the User has no read
+        permission on.
+        """
+        self.login()
+        response = self.client.delete("/api/v1/sketches/2/")
+        self.assert403(response)
+
+    def test_attempt_to_delete_protected_sketch(self):
+        """Authenticated request to delete a protected sketch."""
+        self.login()
+        data = dict(
+            name="test_attempt_to_delete_protected_sketch",
+            description="test_attempt_to_delete_protected_sketch",
+        )
+        response = self.client.post(
+            "/api/v1/sketches/",
+            data=json.dumps(data, ensure_ascii=False),
+            content_type="application/json",
+        )
+        self.assertEqual(HTTP_STATUS_CODE_CREATED, response.status_code)
+        data = dict(
+            labels=["protected"],
+            label_action="add",
+        )
+        response = self.client.post(
+            "/api/v1/sketches/4/",
+            data=json.dumps(data, ensure_ascii=False),
+            content_type="application/json",
+        )
+
+        self.assertEqual(
+            response.json["objects"][0]["name"],
+            "test_attempt_to_delete_protected_sketch",
+        )
+        self.assertIn("protected", response.json["objects"][0]["label_string"])
+
+        response = self.client.delete("/api/v1/sketches/4/")
+        self.assert403(response)
+
 
 class ViewListResourceTest(BaseTest):
     """Test ViewListResource."""

--- a/timesketch/api/v1/resources_test.py
+++ b/timesketch/api/v1/resources_test.py
@@ -164,7 +164,7 @@ class SketchResourceTest(BaseTest):
         self.assert200(response)
 
     def test_sketch_delete_not_existant_sketch(self):
-        """Authenticated request to delete a sketch."""
+        """Authenticated request to delete a sketch that does not exist."""
         self.login()
         response = self.client.delete("/api/v1/sketches/99/")
         self.assert404(response)

--- a/timesketch/api/v1/resources_test.py
+++ b/timesketch/api/v1/resources_test.py
@@ -133,7 +133,6 @@ class SketchResourceTest(BaseTest):
         response = self.client.get("/api/v1/sketches/")
         self.assertEqual(len(response.json["objects"]), 3)
         self.assertIn(b"test_create_a_sketch", response.data)
-        self.assertEqual("test_create_a_sketch", response.json["objects"][2]["name"])
         self.assert200(response)
 
     def test_append_label_to_sketch(self):
@@ -155,7 +154,6 @@ class SketchResourceTest(BaseTest):
 
         # check the result in content
         response = self.client.get("/api/v1/sketches/3/")
-        self.assertEqual(len(response.json["objects"]), 1)
         self.assertEqual(len(response.json["objects"]), 1)
         self.assertEqual(response.json["objects"][0]["name"], "Test 3")
         self.assertIn(


### PR DESCRIPTION
Adding new unit tests to API resources_test to:

* create a sketch
* add a label to a Sketch
* attempt to delete an acled Sketch
* attempt to delete a non existent sketch
* attempt to delete a protected sketch

**Checks**

- [ ] All tests succeed.
- [ ] Unit tests added.
- [x] e2e tests added.
- [x] Documentation updated.
