### PR TITLE
[tsclt] searchindex set get status

### DIFF
--- a/docs/guides/admin/admin-cli.md
+++ b/docs/guides/admin/admin-cli.md
@@ -559,6 +559,46 @@ Examples:
     # This will fail and display an error message.
 ```
 
+### Searchindex-status
+
+The `tsctl searchindex-status` command allows to get or set a searchindex status.
+
+Usage:
+```
+tsctl searchindex-status --help
+Usage: tsctl searchindex-status [OPTIONS] SEARCHINDEX_ID
+
+  Get or set a searchindex status
+
+  If "action" is "set", the given value of status will be written in the
+  status.
+
+  Args:     action: get or set searchindex status.     status: searchindex
+  status. Only valid choices are ready, processing, fail.
+
+Options:
+  --action [get|set]              get or set timeline status.
+  --status [ready|processing|fail]
+                                  get or set timeline status.
+  --searchindex_id TEXT           Searchindex ID to search for e.g.
+                                  4c5afdf60c6e49499801368b7f238353.
+                                  [required]
+  --help                          Show this message and exit.
+```
+
+
+Examples:
+```bash
+tsctl searchindex-status --action set 1 --status fail
+Searchindex 1 status set to fail
+To verify run: tsctl searchindex-status 1 --action get
+tsctl searchindex-status --action set --status fail 1
+Searchindex 1 status set to fail
+To verify run: tsctl searchindex-status 1 --action get
+tsctl searchindex-status 1 --action get
+searchindex_id index_name                       created_at                 user_id description status
+1              f609b138aa1e4c448ece6c012dcb2bab 2025-03-07 09:23:37.172143 1       #           fail
+```
 
 ### Sigma
 

--- a/timesketch/tsctl.py
+++ b/timesketch/tsctl.py
@@ -809,6 +809,77 @@ def searchindex_info(searchindex_id):
     print(f"Corresponding Sketch id: {sketch.id} Sketch name: {sketch.name}")
 
 
+@cli.command(name="searchindex-status")
+@click.argument("searchindex_id")
+@click.option(
+    "--action",
+    default="get",
+    type=click.Choice(["get", "set"]),
+    required=False,
+    help="get or set timeline status.",
+)
+@click.option(
+    "--status",
+    required=False,
+    type=click.Choice(["ready", "processing", "fail"]),
+    help="get or set timeline status.",
+)
+@click.option(
+    "--searchindex_id",
+    required=True,
+    help="Searchindex ID to search for e.g. 4c5afdf60c6e49499801368b7f238353.",
+)
+def searchindex_status(searchindex_id, action, status):
+    """Get or set a searchindex status
+
+    If "action" is "set", the given value of status will be written in the status.
+
+    Args:
+        action: get or set searchindex status.
+        status: searchindex status. Only valid choices are ready, processing, fail.
+    """
+    if action == "get":
+        searchindex = SearchIndex.query.filter_by(id=searchindex_id).first()
+        if not searchindex:
+            print("Searchindex does not exist.")
+            return
+        table_data = [
+            [
+                "searchindex_id",
+                "index_name",
+                "created_at",
+                "user_id",
+                "description",
+                "status",
+            ],
+        ]
+        table_data.append(
+            [
+                searchindex.id,
+                searchindex.index_name,
+                searchindex.created_at,
+                searchindex.user_id,
+                searchindex.description,
+                searchindex.status[0].status,
+            ]
+        )
+        print_table(table_data)
+    elif action == "set":
+        searchindex = SearchIndex.query.filter_by(id=searchindex_id).first()
+        if not searchindex:
+            print("Searchindex does not exist.")
+            return
+        # exit if status is not set
+        if not status:
+            print("Status is not set.")
+            return
+        searchindex.set_status(status)
+        db_session.commit()
+        print(f"Searchindex {searchindex_id} status set to {status}")
+        # to verify run:
+        print(f"To verify run: tsctl searchindex-status {searchindex_id} --action get")
+
+
 # Analyzer stats cli command
 @cli.command(name="analyzer-stats")
 @click.argument(


### PR DESCRIPTION
Add `searchindex-status` command to `tsctl`

**Description:**

This PR introduces a new subcommand, `searchindex-status`, to the `tsctl` command-line tool. This command enables users to retrieve or modify the status of a Timesketch search index directly from the command line.

**Changes:**

* **Added `searchindex-status` subcommand:**
    * Allows users to `get` or `set` the status of a specific search index.
    * Uses `click` for command-line argument parsing and validation.
    * Implements functionality to query the database for search index information and update its status.
    * Provides clear output, including a formatted table for `get` actions and confirmation messages for `set` actions.
    * Includes a command to verify the status after a set action.
* **Added documentation:**