### PR TITLE
Prevent E2E / unit Tests on Documentation and Non-Code Changes

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -2,6 +2,13 @@ name: e2e-tests
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - 'docs/**'
+      - '.gitignore'
+      - 'README.md'
+      - '*.md'
+      - '*.txt'
+
 jobs:
   # OpenSearch version 1.x.x
   PyPi-plaso-stable-opensearch-v1:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,6 +8,8 @@ on:
       - 'README.md'
       - '*.md'
       - '*.txt'
+    paths:
+      - '**/requirements.txt'
 
 jobs:
   # OpenSearch version 1.x.x

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -7,9 +7,6 @@ on:
       - '.gitignore'
       - 'README.md'
       - '*.md'
-      - '*.txt'
-    paths:
-      - '**/requirements.txt'
 
 jobs:
   # OpenSearch version 1.x.x

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,6 +8,8 @@ on:
       - '.gitignore'
       - 'README.md'
       - '*.md'
+    paths:
+      - '**/requirements.txt'
 
 jobs:
   # Backend tests (Python/Flask)

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,9 +7,6 @@ on:
       - 'docs/**'
       - '.gitignore'
       - 'README.md'
-      - '*.md'
-    paths:
-      - '**/requirements.txt'
 
 jobs:
   # Backend tests (Python/Flask)

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -3,6 +3,11 @@ name: unit-tests
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - 'docs/**'
+      - '.gitignore'
+      - 'README.md'
+      - '*.md'
 
 jobs:
   # Backend tests (Python/Flask)


### PR DESCRIPTION
## Prevent E2E / unit Tests on Documentation and Non-Code Changes

This pull request introduces optimizations to our GitHub Actions workflow to prevent unnecessary E2E / unit test runs. Specifically, it implements the following changes:

* **`paths-ignore` in `push` Trigger:**
    * The `paths-ignore` directive has been added to the `push` trigger in our E2E test workflow. This configuration excludes changes to the following paths from triggering E2E tests:
        * `/docs/**`: Documentation changes.
        * `README.md`: Documentation.
        * `*.md`, `*.txt`, : Various configuration and documentation files.
    * This prevents E2E tests from running when only documentation, configuration, or other non-code changes are made, significantly reducing CI/CD pipeline run times.

**Rationale:**

* Running E2E / unit tests on every push, even for documentation or configuration changes, is inefficient and time-consuming.
* These changes optimize our CI/CD pipeline by only running E2E tests when code changes that could affect the application's behavior are detected.
* This also decreases the time it takes for the CI to run.

**Impact:**

* Reduced CI/CD pipeline run times.
* More efficient use of CI/CD resources.
* Faster feedback loops for developers.

This change contributes to a more efficient and streamlined development process.