### PR TITLE
Remove sketch.upload() from the api client since it was unused and depracated for a long time

### DIFF
--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -956,29 +956,6 @@ class Sketch(resource.BaseResource):
         return timelines
 
     # pylint: disable=unused-argument
-    def upload(self, timeline_name, file_path, es_index=None):
-        """Deprecated function to upload data, does nothing.
-
-        Args:
-            timeline_name: Name of the resulting timeline.
-            file_path: Path to the file to be uploaded.
-            es_index: Index name for the ES database
-
-        Raises:
-            RuntimeError: If this function is used, since it has been
-                deprecated in favor of the importer client.
-        """
-        message = (
-            "This function has been deprecated, use the CLI tool: "
-            "timesketch_importer: https://github.com/google/timesketch/blob/"
-            "master/docs/UploadData.md#using-the-importer-clie-tool or the "
-            "importer library: https://github.com/google/timesketch/blob/"
-            "master/docs/UploadDataViaAPI.md"
-        )
-        logger.error(message)
-        raise RuntimeError(message)
-
-    # pylint: disable=unused-argument
     def add_timeline(self, searchindex):
         """Deprecated function to add timeline to sketch.
 


### PR DESCRIPTION
That function was long deprecated so we should remove it.