### PR TITLE
Add events to conclusions

### DIFF
--- a/timesketch/models/sketch.py
+++ b/timesketch/models/sketch.py
@@ -705,6 +705,13 @@ questionconclusion_aggregation_association_table = Table(
     Column("aggregation_id", Integer, ForeignKey("aggregation.id")),
 )
 
+questionconclusion_event_association_table = Table(
+    "investigativequestionconclusion_event",
+    BaseModel.metadata,
+    Column("investigativequestionconclusion_id", Integer, ForeignKey("investigativequestionconclusion.id")),
+    Column("event_id", Integer, ForeignKey("event.id")),
+)
+
 
 class InvestigativeQuestionConclusion(LabelMixin, StatusMixin, CommentMixin, BaseModel):
     """Implements the InvestigativeQuestionConclusion model.
@@ -734,6 +741,11 @@ class InvestigativeQuestionConclusion(LabelMixin, StatusMixin, CommentMixin, Bas
     )
     analysis = relationship(
         "Analysis", backref="investigativequestionconclusion", lazy="select"
+    )
+    events = relationship(
+        "Event",
+        secondary=questionconclusion_event_association_table,
+        backref="conclusions", lazy="select"
     )
 
 


### PR DESCRIPTION
Added new relationship between DFIQ conclusion and event.

The relationship is maintained in `questionconclusion_event_association_table` and connects Events to InvestigationQuestionsConclusions.
