### PR TITLE
Chore: Add 30-minute timeouts to GitHub Actions workflow jobs

### DIFF
--- a/.github/workflows/build_frontend-ng.yml
+++ b/.github/workflows/build_frontend-ng.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   build-frontend-ng:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build_frontend-v3.yml
+++ b/.github/workflows/build_frontend-v3.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   build-frontend-v3:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,6 +12,7 @@ jobs:
   # OpenSearch version 1.x.x
   PyPi-plaso-stable-opensearch-v1:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [ubuntu-22.04]
@@ -29,6 +30,7 @@ jobs:
         uses: jwalton/gh-docker-logs@v2
   PyPi-plaso-staging-opensearch-v1:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [ubuntu-22.04]
@@ -48,6 +50,7 @@ jobs:
   # OpenSearch version 2.x.x
   PyPi-plaso-stable-opensearch-v2:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [ubuntu-22.04]
@@ -65,6 +68,7 @@ jobs:
         uses: jwalton/gh-docker-logs@v2
   PyPi-plaso-staging-opensearch-v2:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [ubuntu-22.04]
@@ -80,4 +84,3 @@ jobs:
       - name: Dump docker logs on failure
         if: failure()
         uses: jwalton/gh-docker-logs@v2
-

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   # Backend tests (Python/Flask)
   Python:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -35,6 +36,7 @@ jobs:
 
   # Frontend tests (VueJS)
   VueJS:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## Summary

This pull request introduces a consistent 30-minute timeout (`timeout-minutes: 30`) to various jobs across our GitHub Actions workflows. Previously, these jobs would use the GitHub Actions default timeout of 360 minutes (6 hours).

## Changes Made

The `timeout-minutes: 30` setting has been applied to the following workflow jobs:

*   **End-to-End Tests (`e2e-tests.yml`):**
    *   `PyPi-plaso-stable-opensearch-v1`
    *   `PyPi-plaso-staging-opensearch-v1`
    *   `PyPi-plaso-stable-opensearch-v2`
    *   `PyPi-plaso-staging-opensearch-v2`
*   **Unit Tests (`unit-tests.yml`):**
    *   `Python` (backend tests)
    *   `VueJS` (frontend tests)
*   **Frontend Builds:**
    *   `build-frontend-ng` (in `build_frontend-ng.yml`)
    *   `build-frontend-v3` (in `build_frontend-v3.yml`)

## Benefits

*   **Improved Resource Management:** Prevents runaway jobs from consuming excessive runner time by enforcing a 30-minute limit, a significant reduction from the 6-hour default.
*   **Faster Feedback on Stuck Jobs:** If a job hangs or takes unexpectedly long, it will now fail faster, allowing for quicker identification and resolution of underlying issues.
*   **Consistency:** Standardizes job execution time limits across different testing and build workflows.

This change enhances the reliability and efficiency of our CI pipeline.


closes #3352
