### PR TITLE
Fix DatastoreConnectionError AttributeError

### DIFF
--- a/timesketch/lib/errors.py
+++ b/timesketch/lib/errors.py
@@ -54,5 +54,5 @@ class IndexNotReadyError(Error):
     """Index was created but did not become healthy in time."""
 
 
-class DataStoreConnectionError(Error):
+class DatastoreConnectionError(Error):
     """Cannot connect to the datastore."""


### PR DESCRIPTION
The problem described in #3403 are caused by a case sensitive issue. `DataStoreConnectionError` vs `DatastoreConnectionError` (capital S vs s)

**Closing issues**

closes #3403
