### PR TITLE
Fix TimelineChip failed mode

### DIFF
--- a/timesketch/frontend-ng/src/components/Explore/TimelineComponent.vue
+++ b/timesketch/frontend-ng/src/components/Explore/TimelineComponent.vue
@@ -400,7 +400,11 @@ export default {
       return this.timelineStatus === 'fail'
     },
     timelineAvailable() {
-      return this.timelineStatus === 'ready' || (this.settings.showProcessingTimelineEvents && this.timelineStatus === 'processing')
+      return (
+        this.timelineStatus === 'ready' ||
+        this.timelineStatus === 'fail' ||
+        (this.settings.showProcessingTimelineEvents && this.timelineStatus === 'processing')
+      )
     },
     timelineChipColor() {
       if (!this.timeline.color.startsWith('#')) {


### PR DESCRIPTION
There was a bug where the a timeline in status "failed" would still show as processing all the time in the frontend even the status was correctly set to "fail".

This PR fixes this by adding the "fail"  status to the conditions for the `timelineAvailable` compute value. By setting this value true, the timeline gets out of the processing slot and into a final state.

Without the fix: 
![image](https://github.com/user-attachments/assets/b96a8e53-eaf1-4389-b88b-6409be896c05)

With the fix:
![image](https://github.com/user-attachments/assets/7d25b736-4d10-4750-96e6-929c4871975f)
