### PR TITLE
Update scenarios.py

### DIFF
--- a/timesketch/api/v1/resources/scenarios.py
+++ b/timesketch/api/v1/resources/scenarios.py
@@ -52,7 +52,7 @@ def load_dfiq_from_config():
     """
     dfiq_path = current_app.config.get("DFIQ_PATH")
     if not current_app.config.get("DFIQ_ENABLED"):
-        logger.info("DFIQ is disabled. Enable in the timesketch.conf!")
+        logger.debug("DFIQ is disabled. Enable in the timesketch.conf!")
         return None
     if not dfiq_path:
         logger.error("No DFIQ_PATH configured")


### PR DESCRIPTION
Change the output log level for a "DFIQ is disabled" message from `INFO` to `DEBUG` rationale being: this log statement is printed out almost everytime someone accesses Sketch info in the Frontend. So the value added is little unless someone is really debugging it.

--> Less noise

**Closing issues**

closes #3419