### PR TITLE
Development sigma rules update

### DIFF
--- a/docker/dev/build/sigma_rules.txt
+++ b/docker/dev/build/sigma_rules.txt
@@ -1,7 +1,6 @@
 /usr/local/src/sigma/rules/application/rpc_firewall/rpc_firewall_sharphound_recon_sessions.yml
-/usr/local/src/sigma/rules/application/spring/appframework_spring_exceptions.yml
 /usr/local/src/sigma/rules/application/sql/app_sqlinjection_errors.yml
-/usr/local/src/sigma/rules/other/godmode_sigma_rule.yml
+/usr/local/src/sigma/other/godmode_sigma_rule.yml
 /usr/local/src/sigma/rules/windows/powershell/powershell_script/posh_ps_icmp_exfiltration.yml
 /usr/local/src/sigma/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_clip.yml
 /usr/local/src/sigma/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_obfuscated_iex.yml
@@ -20,13 +19,7 @@
 /usr/local/src/sigma/rules/windows/powershell/powershell_script/posh_ps_malicious_keywords.yml
 /usr/local/src/sigma/rules/windows/powershell/powershell_script/posh_ps_susp_keywords.yml
 /usr/local/src/sigma/rules/windows/powershell/powershell_script/posh_ps_susp_ssl_keyword.yml
-/usr/local/src/sigma/rules/windows/windefend/win_defender_disabled.yml
-/usr/local/src/sigma/rules/windows/windefend/win_defender_alert_lsass_access.yml
-/usr/local/src/sigma/rules/windows/windefend/win_defender_exclusions.yml
-/usr/local/src/sigma/rules/windows/windefend/win_defender_psexec_wmi_asr.yml
-/usr/local/src/sigma/rules/windows/windefend/win_defender_amsi_trigger.yml
-/usr/local/src/sigma/rules/windows/windefend/win_defender_exploit_guard_tamper.yml
-/usr/local/src/sigma/rules/windows/windefend/win_defender_tamper_protection_trigger.yml
-/usr/local/src/sigma/rules/windows/windefend/win_defender_disabled.yml
-/usr/local/src/sigma/rules/windows/windefend/win_defender_history_delete.yml
-/usr/local/src/sigma/rules/windows/windefend/win_defender_threat.yml
+/usr/local/src/sigma/deprecated/windows/win_defender_disabled.yml
+/usr/local/src/sigma/rules/windows/builtin/windefend/win_defender_tamper_protection_trigger.yml
+/usr/local/src/sigma/rules/windows/builtin/windefend/win_defender_history_delete.yml
+/usr/local/src/sigma/rules/windows/builtin/windefend/win_defender_threat.yml


### PR DESCRIPTION
Minor development update: Updates the outdated development sigma rules.

Extracted from the [compose-dev](https://github.com/google/timesketch/pull/3226) PR.