### PR TITLE
Fix Story bug when no DFIQ is used

### DIFF
--- a/timesketch/frontend-ng/src/utils/RestApiClient.js
+++ b/timesketch/frontend-ng/src/utils/RestApiClient.js
@@ -159,7 +159,7 @@ export default {
       annotation: annotation,
       annotation_type: annotationType,
       events: events,
-      current_search_node_id: currentSearchNode?.id,
+      current_search_node_id: currentSearchNode ? currentSearchNode.id : undefined,
       remove: remove,
       conclusion_id: conclusionId
     }

--- a/timesketch/frontend-ng/src/views/Story.vue
+++ b/timesketch/frontend-ng/src/views/Story.vue
@@ -427,7 +427,8 @@ export default {
        const addedQuestionIds = this.blocks
          .filter(block => block.componentName === 'TsInvestigativeQuestion')
          .map(block => block.componentProps.questionId);
-       return this.sketchQuestions.filter(question => !addedQuestionIds.includes(question.id));
+       const questions = Array.isArray(this.sketchQuestions) ? this.sketchQuestions : [];
+       return questions.filter(question => !addedQuestionIds.includes(question.id));
     },
   },
   methods: {
@@ -688,4 +689,3 @@ export default {
   background-color: transparent !important;
 }
 </style>
-


### PR DESCRIPTION
This is a fix for #3433 by ensuring the question list defaults to empty if there are no DFIQ features used or questions assigned.
Also fixes a small bug introduced in #3357 with the API client.

**Closing issues**

closes #3433 