### PR TITLE
[tsctl] introduce read only access to a sketch via tsctl

### DIFF
--- a/docs/guides/admin/admin-cli.md
+++ b/docs/guides/admin/admin-cli.md
@@ -183,6 +183,36 @@ This command would revoke the administrator privileges of the user with the spec
 
 Once a user's administrator privileges are revoked, they will no longer be able to perform tasks that require administrator privileges in the Timesketch instance. You can use the `list-users` subcommand to verify that the user's administrator privileges have been revoked successfully.
 
+#### Grant user access to a sketch
+
+tsctl provides a subcommand for granting a user access to a specific sketch. This subcommand is called `grant-user`, and it allows you to specify the username of the user and the ID of the sketch.
+
+By default, this command grants both 'read' and 'write' permissions to the user for the specified sketch.
+
+You can use the `--read-only` flag to grant only 'read' access.
+
+Command:
+
+```shell
+tsctl grant-user [OPTIONS] USERNAME
+```
+
+Parameters:
+
+```shell
+--sketch_id INTEGER  [required]
+--read-only          (optional) Grant only read access.
+```
+
+Example:
+
+```shell
+# Grant read and write access to user 'john' for sketch ID 123
+tsctl grant-user john --sketch_id 123
+# Grant read-only access to user 'jane' for sketch ID 456
+tsctl grant-user jane --sketch_id 456 --read-only
+```
+
 ### Group management
 
 #### Adding groups
@@ -204,6 +234,34 @@ tsctl create-group [OPTIONS] GROUP_NAME
 #### Removing groups
 
 Not yet implemented.
+
+#### Grant group access to a sketch
+
+tsctl provides a subcommand for granting a group access to a specific sketch. This subcommand is called `grant-group`, and it allows you to specify the groupname of the group and the ID of the sketch.
+
+By default, this command grants both 'read' and 'write' permissions to the group for the specified sketch.
+
+You can use the `--read-only` flag to grant only 'read' access.
+
+Command:
+
+```shell
+tsctl grant-group [OPTIONS] USERNAME
+```
+
+Parameters:
+
+```shell
+--sketch_id INTEGER  [required]
+--read-only          (optional) Grant only read access.
+```
+
+Example:
+
+```shell
+tsctl grant-group groupname --sketch_id 123
+tsctl grant-group groupname --sketch_id 456 --read-only
+```
 
 #### Managing group membership
 

--- a/docs/guides/admin/admin-cli.md
+++ b/docs/guides/admin/admin-cli.md
@@ -246,7 +246,7 @@ You can use the `--read-only` flag to grant only 'read' access.
 Command:
 
 ```shell
-tsctl grant-group [OPTIONS] USERNAME
+tsctl grant-group [OPTIONS] GROUPNAME
 ```
 
 Parameters:

--- a/timesketch/tsctl.py
+++ b/timesketch/tsctl.py
@@ -727,18 +727,38 @@ def sketch_info(sketch_id: int):
     print_table(table_data)
 
     print(f"Created by: {sketch.user.username}")
+    all_permissions = sketch.get_all_permissions()
+
     print("Shared with:")
-    print("\tUsers: (user_id, username)")
+    print("\tUsers: (user_id, username, access_level)")
     if sketch.collaborators:
-        print("\tUsers: (user_id, username)")
         for user in sketch.collaborators:
-            print(f"\t\t{user.id}: {user.username}")
+            user_perm_key = f"user/{user.username}"
+            perms = all_permissions.get(user_perm_key, [])
+            access_level = "unknown"
+            if "write" in perms:  # 'write' permission implies 'read'
+                access_level = "read/write"
+            elif "read" in perms:
+                access_level = "read-only"
+            else:
+                access_level = "none"  # Should not happen if user is a collaborator
+            print(f"\t\t{user.id}: {user.username} ({access_level})")
     else:
         print("\tNo users shared with.")
-    print(f"\tGroups ({len(sketch.groups)}):")
+
+    print(f"\tGroups ({len(sketch.groups)}): (group_name, access_level)")
     if sketch.groups:
         for group in sketch.groups:
-            print(f"\t\t{group.display_name}")
+            group_perm_key = f"group/{group.name}"
+            perms = all_permissions.get(group_perm_key, [])
+            access_level = "unknown"
+            if "write" in perms:  # 'write' permission implies 'read'
+                access_level = "read/write"
+            elif "read" in perms:
+                access_level = "read-only"
+            else:
+                access_level = "none"  # Should not happen if group is listed
+            print(f"\t\t{group.display_name} ({access_level})")
     else:
         print("\tNo groups shared with.")
     sketch_labels = [label.label for label in sketch.labels]

--- a/timesketch/tsctl.py
+++ b/timesketch/tsctl.py
@@ -224,7 +224,7 @@ def grant_user(username, sketch_id, read_only):
     if not sketch:
         print("Sketch does not exist.")
         return
-    elif not user:
+    if not user:
         print(f"User {username} does not exist.")
         return
 
@@ -260,7 +260,7 @@ def grant_group(group_name, sketch_id, read_only):
     if not sketch:
         print("Sketch does not exist.")
         return
-    elif not group:
+    if not group:
         print(f"Group {group_name} does not exist.")
         return
     sketch.grant_permission(permission="read", group=group)

--- a/timesketch/tsctl.py
+++ b/timesketch/tsctl.py
@@ -201,18 +201,37 @@ def revoke_admin(username):
 @cli.command(name="grant-user")
 @click.argument("username")
 @click.option("--sketch_id", type=int, required=True)
-def grant_user(username, sketch_id):
-    """Grant access to a sketch."""
+@click.option("--read-only", is_flag=True, help="Grant only read access to the sketch.")
+def grant_user(username, sketch_id, read_only):
+    """Grant a user access to a specific sketch.
+
+    This command allows an administrator to grant permissions to a user
+    for a given sketch. By default, both 'read' and 'write' permissions
+    are granted. If the '--read-only' flag is provided, only 'read'
+    permission will be granted.
+
+    Args:
+        username (str): The username of the user to grant access to.
+        sketch_id (int): The ID of the sketch to grant access to.
+        read_only (bool): If True, grants only 'read' permission.
+                          Otherwise, grants 'read' and 'write' permissions.
+
+    Prints a confirmation message upon success or an error message
+    if the user or sketch does not exist.
+    """
     sketch = Sketch.get_by_id(sketch_id)
-    user = User.query.filter_by(username=username).first()
+    user = User.get_by_username(username)
     if not sketch:
         print("Sketch does not exist.")
+        return
     elif not user:
         print(f"User {username} does not exist.")
-    else:
-        sketch.grant_permission(permission="read", user=user)
+        return
+
+    sketch.grant_permission(permission="read", user=user)
+    if not read_only:
         sketch.grant_permission(permission="write", user=user)
-        print(f"User {username} added to the sketch {sketch.id} ({sketch.name})")
+    print(f"User {username} added to the sketch {sketch.id} ({sketch.name})")
 
 
 @cli.command(name="version")

--- a/timesketch/tsctl.py
+++ b/timesketch/tsctl.py
@@ -234,6 +234,41 @@ def grant_user(username, sketch_id, read_only):
     print(f"User {username} added to the sketch {sketch.id} ({sketch.name})")
 
 
+@cli.command(name="grant-group")
+@click.argument("group_name")
+@click.option("--sketch_id", type=int, required=True)
+@click.option("--read-only", is_flag=True, help="Grant only read access to the sketch.")
+def grant_group(group_name, sketch_id, read_only):
+    """Grant a group access to a specific sketch.
+
+    This command allows an administrator to grant permissions to a group
+    for a given sketch. By default, both 'read' and 'write' permissions
+    are granted. If the '--read-only' flag is provided, only 'read'
+    permission will be granted.
+
+    Args:
+        group_name (str): The name of the group to grant access to.
+        sketch_id (int): The ID of the sketch to grant access to.
+        read_only (bool): If True, grants only 'read' permission.
+                          Otherwise, grants 'read' and 'write' permissions.
+
+    Prints a confirmation message upon success or an error message
+    if the group or sketch does not exist.
+    """
+    sketch = Sketch.get_by_id(sketch_id)
+    group = Group.query.filter_by(name=group_name).first()
+    if not sketch:
+        print("Sketch does not exist.")
+        return
+    elif not group:
+        print(f"Group {group_name} does not exist.")
+        return
+    sketch.grant_permission(permission="read", group=group)
+    if not read_only:
+        sketch.grant_permission(permission="write", group=group)
+    print(f"Group {group_name} added to the sketch {sketch.id} ({sketch.name})")
+
+
 @cli.command(name="version")
 def get_version():
     """Return the version information of Timesketch."""

--- a/timesketch/tsctl.py
+++ b/timesketch/tsctl.py
@@ -220,7 +220,7 @@ def grant_user(username, sketch_id, read_only):
     if the user or sketch does not exist.
     """
     sketch = Sketch.get_by_id(sketch_id)
-    user = User.get_by_username(username)
+    user = User.query.filter_by(username=username).first()
     if not sketch:
         print("Sketch does not exist.")
         return
@@ -277,7 +277,12 @@ def get_version():
 
 @cli.command(name="drop-db")
 def drop_db():
-    """Drop all database tables."""
+    """Permanently remove all database tables.
+
+    This action is irreversible and will result in the loss of all data
+    stored in the Timesketch database, including users, sketches, timelines,
+    and all associated metadata. Use with extreme caution.
+    """
     if click.confirm("Do you really want to drop all the database tables?"):
         if click.confirm(
             "Are you REALLLY sure you want to DROP ALL the database tables?"


### PR DESCRIPTION
This PR introduces the capability to grant read-only access to Timesketch sketches via the `tsctl` command-line tool. Previously, the `grant-user` command only granted both read and write permissions. This change adds a `--read-only` flag to the `grant-user` command and also introduces a new `grant-group` command with the same `--read-only` option, allowing administrators to grant granular access permissions from the command line. The relevant documentation has also been updated to reflect these new commands and options.

### Highlights
* **Read-Only Access**: Adds a `--read-only` flag to the `tsctl grant-user` command to allow granting only read permission to a sketch.
* **Grant Group Access**: Introduces a new `tsctl grant-group` command to grant sketch access to a group, also supporting the `--read-only` flag.
* **Documentation Updates**: Updates the administrator CLI documentation (`admin-cli.md`) to include the new `grant-user` and `grant-group` commands and their `--read-only` option.
