### PR TITLE
Enable support for vue3 UI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ recursive-include config *
 recursive-include data *
 recursive-include timesketch/frontend/dist *
 recursive-include timesketch/frontend-ng/dist *
+recursive-include timesketch/frontend-v3/dist *
 recursive-include timesketch/lib/experimental *.cql
 recursive-include timesketch/static *
 recursive-include timesketch/templates *


### PR DESCRIPTION
This change will start adding the vue3 UI into the release builds. The default is still `frontend-ng` but this change will allow to switch to `frontend-v3` if configured.