### PR TITLE
Fix permission checks with the scenarios API

### DIFF
--- a/timesketch/api/v1/resources/scenarios.py
+++ b/timesketch/api/v1/resources/scenarios.py
@@ -779,7 +779,6 @@ class QuestionConclusionResource(resources.ResourceMixin, Resource):
                 "User does not have write access controls on sketch",
             )
 
-
         question = InvestigativeQuestion.get_by_id(question_id)
         if not question:
             abort(HTTP_STATUS_CODE_NOT_FOUND, "No question found with this ID")


### PR DESCRIPTION
This pull request addresses an issue where the scenarios API had incorrect permission checks. It refines access control by ensuring read-only operations (GET) require read permissions, and modifying operations (POST, PUT, DELETE) correctly enforce write permissions on the associated sketch.

### Changes

* **API Permission Correction (GET methods)**: GET methods within the `scenarios.py` API resource now correctly enforce `read` permissions on the associated sketch, or have had overly strict `write` permission checks removed, aligning with read-only access.
* **API Permission Correction (Write methods)**: POST, PUT, and DELETE methods within the `scenarios.py` API resource now explicitly enforce `write` permissions on the associated sketch, ensuring proper access control for modifying data.