### PR TITLE
Fix: Correctly parse microsecond epoch timestamps in CSV files

### DIFF
--- a/tests/test_events/csv_timestamp_as_datetime.csv
+++ b/tests/test_events/csv_timestamp_as_datetime.csv
@@ -1,0 +1,5 @@
+datetime,uid,tool,message,query,event_type,organization_name,timestamp_desc,unique_id
+1723474994349345,mustermann,exampletool,PageView,,foobar,example.my.org.com,<URL placeholder>,"DETAILED DATA"
+1751313029117113,jondoe,exampletool,PageView,,foobar,example.my.org.com,<URL placeholder>,"DETAILED DATA"
+1723213989468712,mustermann,exampletool,PageView,,foobar,example.my.org.com,<URL placeholder>,"DETAILED DATA"
+1751349507214025,jondoe,exampletool,PageView,,foobar,example.my.org.com,<URL placeholder>,"DETAILED DATA"

--- a/timesketch/lib/utils_test.py
+++ b/timesketch/lib/utils_test.py
@@ -358,9 +358,6 @@ class TestUtils(BaseTest):
         self.assertDictEqual(results[0], expected_output_1)
         self.assertDictEqual(results[1], expected_output_2)
 
-    def test_csv_time_validation(self):
-        """Test for a specific parsing error"""
-
     def test_invalid_JSONL_file(self):
         """Test for JSONL with missing keys in the dictionary wrt headers mapping"""
         linedict = {"DT": "2011-11-11", "MSG": "this is a test"}

--- a/timesketch/lib/utils_test.py
+++ b/timesketch/lib/utils_test.py
@@ -323,6 +323,44 @@ class TestUtils(BaseTest):
         self.assertIn("2024-07-24T10:57:02.877297+00:00", str(results_list))
         self.assertIn("timestamptest2", str(results_list))
 
+    def test_csv_with_timestamp_in_datetime_field(self):
+        """Test parsing a CSV where the datetime column contains a timestamp."""
+        data_generator = read_and_validate_csv(
+            "tests/test_events/csv_timestamp_as_datetime.csv"
+        )
+        results = list(data_generator)
+
+        expected_output_1 = {
+            "datetime": "2024-08-12T15:03:14.349345+00:00",
+            "uid": "mustermann",
+            "tool": "exampletool",
+            "message": "PageView",
+            "event_type": "foobar",
+            "organization_name": "example.my.org.com",
+            "timestamp_desc": "<URL placeholder>",
+            "unique_id": "DETAILED DATA",
+            "timestamp": 1723474994349345,
+        }
+
+        expected_output_2 = {
+            "datetime": "2025-06-30T19:50:29.117113+00:00",
+            "uid": "jondoe",
+            "tool": "exampletool",
+            "message": "PageView",
+            "event_type": "foobar",
+            "organization_name": "example.my.org.com",
+            "timestamp_desc": "<URL placeholder>",
+            "unique_id": "DETAILED DATA",
+            "timestamp": 1751313029117113,
+        }
+
+        self.assertEqual(len(results), 4)
+        self.assertDictEqual(results[0], expected_output_1)
+        self.assertDictEqual(results[1], expected_output_2)
+
+    def test_csv_time_validation(self):
+        """Test for a specific parsing error"""
+
     def test_invalid_JSONL_file(self):
         """Test for JSONL with missing keys in the dictionary wrt headers mapping"""
         linedict = {"DT": "2011-11-11", "MSG": "this is a test"}


### PR DESCRIPTION
### Fix: Correctly parse microsecond epoch timestamps in CSV files

This pull request resolves an issue where the CSV parser would misinterpret epoch timestamps provided in microsecond precision, leading to incorrect date ingestion.

**The Problem**

When a CSV file is uploaded with a `datetime` column containing a large integer (e.g., `1723474994349345`), the Pandas parser defaults to interpreting it as nanoseconds. This causes timestamps that are actually in microseconds to be parsed as dates in the early 1970s, corrupting the event data upon import.

**The Solution**

The `read_and_validate_csv` function in `timesketch/lib/utils.py` has been updated to intelligently handle this scenario. The new logic performs a check on numeric `datetime` columns:

1.  It uses a heuristic to determine if the timestamp is likely in microseconds (i.e., if the number is greater than 1e15).
2.  If it is, `pandas.to_datetime` is called with `unit='us'` to ensure correct conversion.
3.  If not, it falls back to the existing general-purpose date string parser.

This ensures that both standard date strings and high-precision epoch timestamps are handled correctly.

**Testing**

To verify this fix and prevent regressions, a new unit test, `test_csv_with_timestamp_in_datetime_field`, has been added to `timesketch/lib/utils_test.py`. This test uses a new data file, `tests/test_events/csv_timestamp_as_datetime.csv`, which contains the problematic microsecond timestamps, and asserts that they are parsed into the correct ISO 8601 datetime strings.
