### PR TITLE
[tsctl] display the latest timeskertch commit used on the system in tsctl

### DIFF
--- a/docs/guides/admin/admin-cli.md
+++ b/docs/guides/admin/admin-cli.md
@@ -43,12 +43,13 @@ Example
 
 ```shell
 tsctl info
-Timesketch version: 20210602
-plaso - psort version 20220930
-Node version: v14.20.1
-npm version: 6.14.17
-yarn version: 1.22.19
-Python version: Python 3.10.6
+Timesketch version: 20250708
+Timesketch commit: 2cb3356b (dirty)
+plaso - psort version 20240308
+Node version: v20.19.1
+npm version: 10.8.2
+yarn version: 1.22.22
+Python version: Python 3.10.12
 pip version: pip 22.0.2 from /usr/lib/python3/dist-packages/pip (python 3.10)
 ```
 

--- a/timesketch/tsctl.py
+++ b/timesketch/tsctl.py
@@ -22,6 +22,7 @@ import subprocess
 import time
 import io
 import zipfile
+import subprocess
 import csv
 import datetime
 import traceback
@@ -288,7 +289,38 @@ def grant_group(group_name, sketch_id, read_only):
 @cli.command(name="version")
 def get_version():
     """Return the version information of Timesketch."""
-    print(f"Timesketch version: {version.get_version()}")
+    timesketch_path = os.path.dirname(os.path.abspath(__file__))
+    project_root = os.path.abspath(os.path.join(timesketch_path, ".."))
+    git_dir = os.path.join(project_root, ".git")
+    version_string = version.__version__
+
+    if os.path.isdir(git_dir):
+        try:
+            # Get the short commit hash
+            p_hash = subprocess.run(
+                ["git", "rev-parse", "--short", "HEAD"],
+                capture_output=True,
+                text=True,
+                cwd=project_root,
+                check=False,
+            )
+            if p_hash.returncode == 0 and p_hash.stdout:
+                version_string = p_hash.stdout.strip()
+
+                # Check if the repository is dirty (has uncommitted changes)
+                p_dirty = subprocess.run(
+                    ["git", "status", "--porcelain"],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    cwd=project_root,
+                )
+                if p_dirty.returncode == 0 and p_dirty.stdout:
+                    version_string += "-dirty"
+        except OSError:
+            # Not a git repo or git is not installed.
+            pass
+
+    print(f"Timesketch version: {version_string}")
 
 
 @cli.command(name="drop-db")
@@ -617,10 +649,59 @@ def export_sigma_rules(path):
 
 @cli.command(name="info")
 def info():
-    """Get various information about the environment that runs Timesketch."""
+    """Display detailed information about the Timesketch environment.
 
-    # Get Timesketch version
-    print(f"Timesketch version: {version.get_version()}")
+    This command provides a comprehensive overview of the Timesketch installation
+    and its environment, including version information, commit details (if
+    applicable), and the versions of key dependencies.
+
+    The output includes:
+        - Timesketch version and, if available, the Git commit hash (with a
+          "-dirty" suffix if there are uncommitted changes).
+        - Versions of essential tools like psort (from Plaso), Node.js, npm, yarn,
+          Python, and pip.
+    """
+    print(f"Timesketch version: {version.get_version()}")  # Displays Timesketch version
+
+    timesketch_path = os.path.dirname(os.path.abspath(__file__))
+    project_root = os.path.abspath(
+        os.path.join(timesketch_path, "..")
+    )  # Project root directory
+    git_dir = os.path.join(project_root, ".git")  # Path to the .git directory
+    if os.path.isdir(git_dir):
+        try:
+            # Get the short commit hash
+            p_hash = subprocess.run(
+                ["git", "rev-parse", "--short", "HEAD"],
+                capture_output=True,
+                text=True,
+                cwd=project_root,
+                check=False,
+            )
+            if (
+                p_hash.returncode == 0 and p_hash.stdout
+            ):  # Check for successful git execution and output
+                commit_hash = p_hash.stdout.strip()
+
+                # Check if the repository is dirty (has uncommitted changes)
+                p_dirty = subprocess.run(
+                    ["git", "status", "--porcelain"],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    cwd=project_root,
+                )
+                if p_dirty.returncode == 0 and p_dirty.stdout:
+                    commit_hash += "-dirty"
+                timesketch_commit = commit_hash
+        except OSError:
+            # Not a git repo or git is not installed.
+            pass
+
+        if timesketch_commit.endswith("-dirty"):
+            timesketch_commit = timesketch_commit.replace("-dirty", "")
+            print(f"Timesketch commit: {timesketch_commit} (dirty)")
+        else:
+            print(f"Timesketch commit: {timesketch_commit}")
 
     # Get plaso version
     try:


### PR DESCRIPTION
The core change is the relocation of the logic that fetches the Git commit hash and checks for a "dirty" repository state. This functionality has been moved from timesketch/version.py directly into the version command within timesketch/tsctl.py.

* timesketch/tsctl.py:
The version command now directly executes git commands to determine the commit hash and repository status, appending this information to the base version string.
The info command was also updated to provide a clearer and more comprehensive output of the environment, including the git commit if available.

Example:

```
tsctl info
Timesketch version: 20250708
Timesketch commit: d2646b2d (dirty)
plaso - psort version 20240308
Node version: v20.19.1
npm version: 10.8.2
yarn version: 1.22.22
Python version: Python 3.10.12
pip version: pip 22.0.2 from /usr/lib/python3/dist-packages/pip (python 3.10)
```