### PR TITLE
fix: Gemini styleguide

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -461,7 +461,6 @@ confidence=HIGH,
 # --disable=W".
 disable=assignment-from-none,
         bad-inline-option,
-        broad-except,
         cyclic-import,
         deprecated-pragma,
         duplicate-code,


### PR DESCRIPTION
Codehealth:

* Updating the `.gemini` Styleguide to better mimic the reality of the project and what we set up for `black`.
* Updating the `.gemini` Styleguide to include a check for Pull Requests to see if that helps increase the quality of that as well. If it gets to annoying, we can remove it again