### PR TITLE
fix: Improve Visibility of Data Source Import Errors

### DIFF
--- a/timesketch/frontend-ng/src/components/Explore/TimelineComponent.vue
+++ b/timesketch/frontend-ng/src/components/Explore/TimelineComponent.vue
@@ -68,9 +68,9 @@ limitations under the License.
               <li>
                 <strong>Total File Events:</strong>{{ totalEventsDatasource(datasource.file_on_disk) | compactNumber }}
               </li>
-              <li v-if="dataSourceStatus(datasource) === 'fail'">
+              <li v-if="datasource.error_message">
                 <strong>Error message:</strong>
-                <code v-if="datasource.error_message"> {{ datasource.error_message }}</code>
+                <code> {{ datasource.error_message }}</code>
               </li>
             </ul>
             <br />
@@ -218,9 +218,9 @@ limitations under the License.
                       <strong>Total File Events: </strong
                       >{{ totalEventsDatasource(datasource.file_on_disk) | compactNumber }}
                     </li>
-                    <li v-if="dataSourceStatus(datasource) === 'fail'">
+                    <li v-if="datasource.error_message">
                       <strong>Error message:</strong>
-                      <code v-if="datasource.error_message"> {{ datasource.error_message }}</code>
+                      <code> {{ datasource.error_message }}</code>
                     </li>
                   </ul>
                 </v-alert>

--- a/timesketch/tsctl.py
+++ b/timesketch/tsctl.py
@@ -950,6 +950,34 @@ def timeline_status(timeline_id: int, action: str, status: str):
         print("Status:")
         print_table(status_table)
 
+        print("\nData Sources:")
+        if timeline.datasources:
+            ds_table_data = [
+                [
+                    "ID",
+                    "File Path",
+                    "Status",
+                    "Error Message",
+                ],
+            ]
+            for ds in timeline.datasources:
+                error_message = ds.error_message or "N/A"
+                # Truncate long error messages for display
+                if len(error_message) > 100:
+                    error_message = error_message[:97] + "..."
+
+                ds_table_data.append(
+                    [
+                        ds.id,
+                        ds.file_on_disk,
+                        ds.get_status.status,
+                        error_message,
+                    ]
+                )
+            print_table(ds_table_data)
+        else:
+            print("No data sources found for this timeline.")
+
     elif action == "set":
         timeline = Timeline.query.filter_by(id=timeline_id).first()
         if not timeline:


### PR DESCRIPTION
**Summary**
This pull request introduces two enhancements to improve the visibility and debugging of data source import errors, both in the command-line interface and the web UI.

- Enhanced **tsctl timeline-status** Command: The **tsctl timeline-status <TIMELINE_ID>** command has been updated to display a detailed list of all data sources associated with the timeline. This new section includes the **status and any error messages** for each data source, making it easier for administrators to diagnose import issues directly from the command line.

- **Always Display Error Messages in UI**: The data source information dialog in the web UI now displays the **error_message** field whenever it contains data, regardless of the overall import status. Previously, error messages were only shown for datasources with a "fail" status. This change ensures that partial import errors (e.g., from a CSV file where some rows fail) are now visible to the user, providing better feedback.

