### PR TITLE
Fix link between ng & v3 UI

### DIFF
--- a/docs/developers/log-analyzer-agent.md
+++ b/docs/developers/log-analyzer-agent.md
@@ -22,6 +22,7 @@ we've implemented a hybrid architecture that combines Timesketch's existing
 **Analyzer Framework** with the new **LLM Feature and Provider** system.
 
 This approach gives us the best of both worlds:
+
 *   **Asynchronous Execution:** The analysis is triggered as a Celery background
     task, preventing API timeouts and allowing the user to continue working while
     the analysis runs.
@@ -133,10 +134,13 @@ that works with the `log_analyzer` feature.
 **API Contract:**
 
 #### **Endpoint**
+
 Your service must expose an endpoint to receive the log data. The default is `/analyze_logs`.
 
 #### **Request Format**
+
 The provider will send a streaming `POST` request with the following characteristics:
+
 *   **Method:** `POST`
 *   **Headers:**
     *   `Content-Type: application/x-ndjson`
@@ -144,13 +148,16 @@ The provider will send a streaming `POST` request with the following characteris
 *   **Body:** A stream of newline-delimited JSON objects. Each object is a complete Timesketch event.
 
 **Example Request Body (NDJSON stream):**
+
 ```json
 {"_index": "a1b2c3d4...", "_id": "event_id_1", "_source": {"message": "User 'admin' logged in from 192.168.1.100", "timestamp": 1672531200000000, ...}}
 {"_index": "a1b2c3d4...", "_id": "event_id_2", "_source": {"message": "Process 'evil.exe' created by pid 1234", "timestamp": 1672531201000000, ...}}
 ```
 
 #### **Response Format**
+
 Your agent must stream back a response with the following characteristics:
+
 *   **Headers:** `Content-Type: application/x-ndjson`
 *   **Body:** A stream of newline-delimited JSON objects. Each line should be a
     complete, self-contained JSON object representing a question and "finding"
@@ -180,6 +187,7 @@ Each object inside the `annotations` list must have the following structure:
 | `attack_stage` | String | No | A suggested attack stage (e.g., MITRE ATT&CK Tactic). This is stored as a question attribute. |
 
 **Example of a Single Finding Object (one line in the NDJSON stream):**
+
 ```json
 {
   "annotations": [

--- a/docs/guides/admin/investigation-view-setup.md
+++ b/docs/guides/admin/investigation-view-setup.md
@@ -77,6 +77,7 @@ settings in your `timesketch.conf` file. We also recommend to ensure the DFIQ
 
         ```
         DFIQ_ENABLED = True
+
         ENABLE_V3_INVESTIGATION_VIEW = True
         ```
 
@@ -94,6 +95,7 @@ settings in your `timesketch.conf` file. We also recommend to ensure the DFIQ
 
     ```
     sudo docker compose -f /opt/timesketch/docker-compose.yml --env-file /opt/timesketch/config.env down
+
     sudo docker compose -f /opt/timesketch/docker-compose.yml --env-file /opt/timesketch/config.env --profile v3-ui up -d
     ```
 
@@ -154,7 +156,7 @@ the data and sends back structured findings and questions.
 
     ```
     LLM_PROVIDER_CONFIGS = {
-        # ... other feature configs ...
+        ... other feature configs ...
 
         'log_analyzer':
         {
@@ -177,6 +179,7 @@ the data and sends back structured findings and questions.
 
     ```
     sudo docker compose -f /opt/timesketch/docker-compose.yml --env-file /opt/timesketch/config.env down
+
     sudo docker compose -f /opt/timesketch/docker-compose.yml --env-file /opt/timesketch/config.env --profile v3-ui up -d
     ```
 

--- a/timesketch/frontend-ng/src/components/LeftPanel/Investigation.vue
+++ b/timesketch/frontend-ng/src/components/LeftPanel/Investigation.vue
@@ -16,7 +16,7 @@ limitations under the License.
 <template>
   <div v-if="iconOnly" class="pa-4" style="cursor: pointer">
     <a :href="destinationUrl" style="color: inherit; text-decoration: none;">
-      <v-icon left title="AI Investigation">mdi-creation</v-icon>
+      <v-icon left>{{ menuTitle.icon }}</v-icon>
       <div style="height: 1px"></div>
     </a>
   </div>
@@ -56,7 +56,7 @@ export default {
       if (!this.sketch.id) {
         return '#'
       }
-      return `/v3/sketch/${this.sketch.id}/ai-investigation`
+      return `/v3/sketch/${this.sketch.id}/investigation`
     },
   },
 }


### PR DESCRIPTION
This PR updates a missed link from the frontend-ng version pointing to a fronend-v3 version if the v3-ui profile is used.