### PR TITLE
[CI] Remove python 3.9 checks

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10"]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        python-version: ['3.9', '3.10']
+        python-version: ['3.10']
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
The standard supported deployment of Timesketch runs in a container using Python 3.10. The CI workflows testing for compatibility with Python 3.9 were a legacy from the times where Timesketch was installed as a package.

Since docker deployment is our standard and easier deployment for a long time now, it is time to remove the python 3.9 compatibility.
