### PR TITLE
fix: remove "version" from the toplevel from docker-compose files

### DIFF
--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   timesketch:
     container_name: timesketch-dev
@@ -83,4 +82,3 @@ services:
     ports:
       - 127.0.0.1:9090:9090
     command: --config.file=/etc/prometheus/prometheus.yml
-

--- a/docker/e2e/docker-compose.yml
+++ b/docker/e2e/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   timesketch:
     environment:


### PR DESCRIPTION
Mark `version` string obsolete in the `docker-compose.yml` files.


#vc4a