### PR TITLE
add better error mesage to count message in opensearch.py

### DIFF
--- a/timesketch/lib/datastores/opensearch.py
+++ b/timesketch/lib/datastores/opensearch.py
@@ -1146,8 +1146,7 @@ class OpenSearchDataStore:
 
         except NotFoundError as e:
             os_logger.error(
-                "Unable to count indices (index not found).",
-                " Attempted indices: %s. Error: %s",
+                "Unable to count indices (index not found). Attempted indices: %s. Error: %s",  # pylint: disable=line-too-long
                 ", ".join(indices),
                 e,
                 exc_info=True,


### PR DESCRIPTION
While going over e2e tests, I ran into:
https://github.com/google/timesketch/actions/runs/17617569208/job/50056270992?pr=3431

```
[2025-09-10 15:07:58,794] timesketch.tasks/INFO Index timeline (ID: 6) to index [6379] - 5 events imported.
  [2025-09-10 15:07:58,826] celery.app.trace/INFO Task timesketch.lib.tasks.run_csv_jsonl[c7c9bf67000b4cb0a1bc75cfec96b857] succeeded in 0.07461173299998336s: '6379'
  [2025-09-10 15:08:12,688] timesketch.opensearch/ERROR Unable to count indices (request error)
  Traceback (most recent call last):
    File "/usr/local/lib/python3.10/dist-packages/timesketch/lib/datastores/opensearch.py", line 1138, in count
      es_stats = self.client.indices.stats(index=indices, metric="docs, store")
    File "/usr/local/lib/python3.10/dist-packages/opensearchpy/client/utils.py", line 180, in _wrapped
      return func(*args, params=params, headers=headers, **kwargs)
    File "/usr/local/lib/python3.10/dist-packages/opensearchpy/client/indices.py", line 1551, in stats
      return self.transport.perform_request(
    File "/usr/local/lib/python3.10/dist-packages/opensearchpy/transport.py", line 455, in perform_request
      raise e
    File "/usr/local/lib/python3.10/dist-packages/opensearchpy/transport.py", line 416, in perform_request
      status, headers_response, data = connection.perform_request(
    File "/usr/local/lib/python3.10/dist-packages/opensearchpy/connection/http_urllib3.py", line 308, in perform_request
      self._raise_error(
    File "/usr/local/lib/python3.10/dist-packages/opensearchpy/connection/base.py", line 315, in _raise_error
      raise HTTP_EXCEPTIONS.get(status_code, TransportError)(
```

Which is very hard to investigate with the current logging in an error case in the `count` method.

This PR fixes that and adds the indeces to the error message.

It might be worth to consider to note down the exact index that caused the problem but that would mean to rewrite that method and itterate over the indeces.