### PR TITLE
[Fix] Empty Sketch List Overview

### DIFF
--- a/timesketch/api/v1/resources/sketch.py
+++ b/timesketch/api/v1/resources/sketch.py
@@ -188,7 +188,7 @@ class SketchListResource(resources.ResourceMixin, Resource):
                 )
             )
 
-        if not sketches:
+        if not sketches and filtered_sketches:
             pagination = filtered_sketches.paginate(page=page, per_page=per_page)
             sketches = pagination.items
             has_next = pagination.has_next


### PR DESCRIPTION
Fixing the following error that happens with the current latest version when opening Timesketch without any sketches in the list.

```
[2025-09-17 15:40:30 +0000] [146] [ERROR] Error handling request /api/v1/sketches/?scope=recent&page=1&per_page=15
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/gunicorn/workers/sync.py", line 134, in handle
    self.handle_request(listener, req, client, addr)
  File "/usr/local/lib/python3.10/dist-packages/gunicorn/workers/sync.py", line 177, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "/usr/local/lib/python3.10/dist-packages/flask/app.py", line 1498, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/local/lib/python3.10/dist-packages/flask/app.py", line 1476, in wsgi_app
    response = self.handle_exception(e)
  File "/usr/local/lib/python3.10/dist-packages/flask_restful/__init__.py", line 298, in error_router
    return original_handler(e)
  File "/usr/local/lib/python3.10/dist-packages/flask/app.py", line 1473, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.10/dist-packages/flask/app.py", line 882, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.10/dist-packages/flask_restful/__init__.py", line 298, in error_router
    return original_handler(e)
  File "/usr/local/lib/python3.10/dist-packages/flask/app.py", line 880, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.10/dist-packages/flask/app.py", line 865, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
  File "/usr/local/lib/python3.10/dist-packages/flask_restful/__init__.py", line 489, in wrapper
    resp = resource(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/flask/views.py", line 110, in view
    return current_app.ensure_sync(self.dispatch_request)(**kwargs)  # type: ignore[no-any-return]
  File "/usr/local/lib/python3.10/dist-packages/flask_restful/__init__.py", line 604, in dispatch_request
    resp = meth(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/flask_login/utils.py", line 290, in decorated_view
    return current_app.ensure_sync(func)(*args, **kwargs)
  File "/usr/local/src/timesketch/timesketch/api/v1/resources/sketch.py", line 192, in get
    pagination = filtered_sketches.paginate(page=page, per_page=per_page)
AttributeError: 'NoneType' object has no attribute 'paginate'
```