### PR TITLE
fix: [API client] remove a warning in explore()

### DIFF
--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -1025,11 +1025,6 @@ class Sketch(resource.BaseResource):
             RuntimeError: if the query is missing needed values, or if the
                 sketch is archived.
         """
-        logger.warning(
-            "Using this function is discouraged, please consider using "
-            "the search.Search object instead, which is more flexible."
-        )
-
         if not (query_string or query_filter or query_dsl or view):
             raise RuntimeError("You need to supply a query or view")
 


### PR DESCRIPTION
We have a warning in .explore() to discourage usage of the method, but we keep using the method in various places and never went anywhere with deprecating the method, which only clutters peoples output.

So this PR will remove the warning.