### PR TITLE
Refactor: Enhance JSON decoding error logging in API client

### DIFF
--- a/api_client/python/timesketch_api_client/error.py
+++ b/api_client/python/timesketch_api_client/error.py
@@ -100,8 +100,14 @@ def get_response_json(response, logger):
     try:
         return response.json()
     except json.JSONDecodeError as e:
-        logger.warning("Unable to json decode the Timesketch API response!")
-        raise ValueError("Unable to json decode the Timesketch API response!") from e
+        response_text_snippet = response.text[:500]
+        logger.warning(
+            "Unable to JSON decode the Timesketch API response! "
+            "Response snippet: %s",
+            response_text_snippet,
+            exc_info=True,
+        )
+        raise ValueError("Unable to JSON decode the Timesketch API response.") from e
 
 
 def error_message(response, message=None, error=RuntimeError):


### PR DESCRIPTION
This change improves the debugging information provided when the Timesketch API client fails to decode a JSON response.

Previously, `json.JSONDecodeError` exceptions would log a a
generic ValueError. This made it difficult to diagnose the exact cause of malformed JSON
responses.

This update modifies the `get_response_json` function in
`api_client/python/timesketch_api_client/error.py` to:

* log response snippet first 500 characters, providing context for
   the malformed JSON.
* Include the full traceback of the `json.JSONDecodeError` in the warning log using
   `exc_info=True`.
* Simplify the ValueError message, as the detailed information is now available in the log.

These changes will provide more comprehensive and actionable debugging information, making it
easier to troubleshoot issues related to API response parsing.