### PR TITLE
Security: Upgrade Redis to version 7.2.11 to address critical vulnerability

### DIFF
--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -60,7 +60,7 @@ services:
 
   redis:
     container_name: redis
-    image: redis:6.0.10-alpine
+    image: redis:7.2.11-alpine
     restart: always
 
   notebook:

--- a/docker/e2e/docker-compose.yml
+++ b/docker/e2e/docker-compose.yml
@@ -55,5 +55,5 @@ services:
     restart: always
 
   redis:
-    image: redis
+    image: redis:latest
     restart: always

--- a/docker/release/config.env
+++ b/docker/release/config.env
@@ -39,7 +39,7 @@ POSTGRES_DATA_PATH=./data/postgresql
 POSTGRES_PASSWORD=
 
 # Redis version to run.
-REDIS_VERSION=6.0.8-alpine
+REDIS_VERSION=7.2.11-alpine
 
 # Nginx webserver version to run.
 NGINX_VERSION=1.25.5-alpine-slim


### PR DESCRIPTION
This pull request upgrades the Redis versions used in the dev and e2e Docker environments to
7.2.11. This is a direct response to the critical remote code execution vulnerability
identified in CVE-2025-49844 (CVSS Score: 10.0).

Vulnerability Details

 * CVE: CVE-2025-49844
 * Impact: A Use-After-Free vulnerability in the Lua scripting engine could allow for remote
   code execution.
 * Affected Versions: All unpatched Redis releases.
 * Patched Versions: Includes 7.2.11 and above.

Changes Made

 1. Development Environment (`docker/dev/docker-compose.yml`):
 * The Redis image has been updated from 6.0.10-alpine to 7.2.11-alpine.

 2. End-to-End Test Environment (`docker/e2e/docker-compose.yml`):
  * The Redis image has been pinned to latest

 3. Release Environment (`docker/release/docker-compose.yml`):
     * No code change was made, as this configuration uses an environment variable
       (${REDIS_VERSION}).
     * ACTION REQUIRED FOR DEPLOYMENTS: Operators must update their deployment configuration
       to set REDIS_VERSION to 7.2.11 or a newer patched version.

Risk Assessment

 * An review indicates that Timesketch does **not** expose redis to the network by default