### PR TITLE
fix time filter menu

### DIFF
--- a/timesketch/frontend-v3/src/components/Explore/FilterMenu.vue
+++ b/timesketch/frontend-v3/src/components/Explore/FilterMenu.vue
@@ -82,7 +82,6 @@ limitations under the License.
 
 <script>
 import dayjs from '@/plugins/dayjs'
-import { ref } from 'vue';
 
 import { DatePicker } from 'v-calendar';
 import 'v-calendar/style.css';


### PR DESCRIPTION
The time picker in v3 did not work as expected.

The changes include:

- Fixing a console error that already existed in v2 (ng) and was fixed with https://github.com/google/timesketch/pull/3512/files#diff-4d22dbeebabf2be7d748b5c73d662cec39388127fc14d7b013a99ce36d5826eaR104-R110
- fixing the change listener on the v-text-field: in Vuetify 2 it was triggered on enter and now it does not anymore. So to make it work as in frontend-ng, I had to add a listener for blur and enter key press.
- the DatePicker focusTime does not exist in our version somehow. I could not find out why, but `move` seems to work.

Screencasts:

Before
![image (10)](https://github.com/user-attachments/assets/4dafbeec-1324-4793-9850-ab3be44dba57)

Now

![image (9)](https://github.com/user-attachments/assets/4df338fd-50a0-42df-ba6c-ce4f6b5337cd)
