### PR TITLE
Fix unit-tests for Ubuntu 24.04 containers

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
         python-version: ['3.10']
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
@@ -52,7 +52,7 @@ jobs:
         working-directory: timesketch/frontend-ng
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
         node-version: ["20"]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2


### PR DESCRIPTION
In #3568 we have failing unit-tests and I think this is due to #3567. So this PR is checking if moving the unit-tests to ubuntu 24.04 as well fixes the issues.