### PR TITLE
docs: adjusting performance monitoring docs

### DIFF
--- a/docs/guides/admin/performance_monitoring.md
+++ b/docs/guides/admin/performance_monitoring.md
@@ -111,6 +111,6 @@ This command forwards your local port `8080` to the remote server's port `8080`.
 
 Now, open a web browser on your local machine and navigate to:
 
-[http://localhost:8080](http://localhost:8080)
+[http://localhost:8080/snakeviz](http://localhost:8080/snakeviz)
 
 You can now interact with the `snakeviz` UI to analyze the performance data for your Timesketch application.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
       - LLM Features: guides/admin/llm-features.md
       - Investigation View: guides/admin/investigation-view-setup.md
       - DFIQ Templates: guides/admin/load-dfiq.md
+      - Performance Monitoring: guides/admin/performance-monitoring.md
   - Developers:
       - Getting started: developers/getting-started.md
       - Frontend development: developers/frontend-development.md


### PR DESCRIPTION
Small update to the performance monitoring docs to appear on the page and path for the snakeviz url.