### PR TITLE
fix: make staging tests for plaso 24.04 for now optional

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -126,7 +126,6 @@ jobs:
         if: failure()
         uses: jwalton/gh-docker-logs@v2
   PyPi-plaso-stable-opensearch-v2-ubuntu2404:
-    continue-on-error: true
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
@@ -146,6 +145,7 @@ jobs:
         if: failure()
         uses: jwalton/gh-docker-logs@v2
   PyPi-plaso-staging-opensearch-v2-ubuntu2404:
+    continue-on-error: true
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:


### PR DESCRIPTION
Make the tests for Plaso staging on ubuntu 24.04 staging for now optional.