### PR TITLE
fix: API client - ensure functions in scenario return strings

### DIFF
--- a/api_client/python/timesketch_api_client/scenario.py
+++ b/api_client/python/timesketch_api_client/scenario.py
@@ -111,7 +111,7 @@ class Scenario(resource.BaseResource):
             Scenario name as string.
         """
         self.lazyload_data()
-        return self._name
+        return str(self._name)
 
     @property
     def display_name(self) -> str:
@@ -121,7 +121,7 @@ class Scenario(resource.BaseResource):
             Scenario display name as string.
         """
         self.lazyload_data()
-        return self._display_name
+        return str(self._display_name)
 
     def set_display_name(self, display_name: str) -> None:
         """Sets the display name of the scenario.
@@ -174,7 +174,7 @@ class Scenario(resource.BaseResource):
             dfiq identifier as string.
         """
         self.lazyload_data()
-        return self._dfiq_identifier
+        return str(self._dfiq_identifier)
 
     @property
     def description(self) -> str:
@@ -184,7 +184,7 @@ class Scenario(resource.BaseResource):
             Description as string.
         """
         self.lazyload_data()
-        return self._description
+        return str(self._description)
 
     def to_dict(self) -> Dict[str, Any]:
         """Returns a dict representation of the scenario."""
@@ -325,7 +325,7 @@ class Question(resource.BaseResource):
             Question name as string.
         """
         self.lazyload_data()
-        return self._name
+        return str(self._name)
 
     def set_name(self, name: str) -> None:
         """Sets the name of the question.
@@ -342,7 +342,7 @@ class Question(resource.BaseResource):
     def display_name(self) -> str:
         """Property that returns the question display name."""
         self.lazyload_data()
-        return self._display_name
+        return str(self._display_name)
 
     def set_display_name(self, display_name: str) -> None:
         """Sets the display name of the question.
@@ -427,7 +427,7 @@ class Question(resource.BaseResource):
             Question DFIQ identifier as string.
         """
         self.lazyload_data()
-        return self._dfiq_identifier
+        return str(self._dfiq_identifier)
 
     @property
     def description(self) -> str:
@@ -437,7 +437,7 @@ class Question(resource.BaseResource):
             Question description as string.
         """
         self.lazyload_data()
-        return self._description
+        return str(self._description)
 
     def set_description(self, description: str) -> None:
         """Sets the description of the question.


### PR DESCRIPTION
This PR fixes some issues with functions that promise to return Strings but don't enforce it.