### PR TITLE
fix: API Client: safely retrieve _retry_count and _backoff_factor using getattr with d…

### DIFF
--- a/api_client/python/timesketch_api_client/client.py
+++ b/api_client/python/timesketch_api_client/client.py
@@ -460,7 +460,7 @@ class TimesketchApi:
                     attempt + 1,
                     retry_count + 1,
                 )
-                time.sleep(backoff_factor**attempt)
+                time.sleep(backoff_factor * (2**attempt))
 
             except ValueError as e:
                 last_exception = e
@@ -471,7 +471,7 @@ class TimesketchApi:
                     attempt + 1,
                     retry_count + 1,
                 )
-                time.sleep(backoff_factor**attempt)
+                time.sleep(backoff_factor * (2**attempt))
                 continue
 
         if last_exception:


### PR DESCRIPTION
This small fix ensures that if the `retry_count` and `backoff_factor` are not set for whatever reason, the default values are used.