### PR TITLE
Fix: Remove unsupported 'features' argument in tsctl

### DIFF
--- a/timesketch/tsctl.py
+++ b/timesketch/tsctl.py
@@ -435,11 +435,9 @@ def list_sketches(
             if indices_to_check_in_os:
                 try:
                     # Check the actual status of these indices in OpenSearch
-                    # pylint: disable=unexpected-keyword-arg
                     indices_status = datastore.client.indices.get(
-                        index=list(indices_to_check_in_os), features="settings"
+                        index=list(indices_to_check_in_os)
                     )
-                    # pylint: enable=unexpected-keyword-arg
                     for index_name, status_info in indices_status.items():
                         is_closed = (
                             status_info.get("settings", {})


### PR DESCRIPTION
This pull request resolves a `TypeError` that occurs when running the `tsctl list-sketches --archived-with-open-indexes `command.

Context:

The `tsctl list-sketches --archived-with-open-indexes` command fails with the following error:

```
ERROR checking OpenSearch for indices: IndicesClient.get() got an unexpected keyword argument 'features'
```

This is caused by the features parameter being passed to the `datastore.client.indices.get()` method. While this is a valid argument in the `elasticsearch-py` client library to optimize the response by requesting only specific parts of the index metadata (like settings), it is not supported by the `opensearch-py`.