### PR TITLE
feat: timeline tooltip & local defaults

### DIFF
--- a/timesketch/frontend-ng/src/components/Explore/EventActionMenu.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventActionMenu.vue
@@ -58,6 +58,7 @@ limitations under the License.
 <script>
 import ApiClient from '../../utils/RestApiClient'
 import EventBus from '../../event-bus.js'
+import EventMixin from '../../mixins/EventMixin'
 
 export default {
   props: ['event'],
@@ -67,6 +68,7 @@ export default {
       originalContext: false,
     }
   },
+  mixins: [EventMixin],
   computed: {
     sketch() {
       return this.$store.state.sketch
@@ -105,23 +107,13 @@ export default {
         console.error(error)
       }
     },
-    getTimeline() {
-      let isLegacy = this.meta.indices_metadata[this.event._index].is_legacy
-      let timeline
-      if (isLegacy) {
-        timeline = this.sketch.active_timelines.find((timeline) => timeline.searchindex.index_name === this.event._index)
-      } else {
-        timeline = this.sketch.active_timelines.find((timeline) => timeline.id === this.event._source.__ts_timeline_id)
-      }
-      return timeline
-    },
     focusOnTimeline() {
-      const timeline = this.getTimeline()
+      const timeline = this.getTimeline(this.event)
       if (!timeline) return
       this.$store.dispatch('updateEnabledTimelines', [timeline.id])
     },
     filterOutTimeline() {
-      const timeline = this.getTimeline()
+      const timeline = this.getTimeline(this.event)
       if (!timeline) return
       const currentEnabled = this.$store.state.enabledTimelines || []
       const newEnabled = currentEnabled.filter((id) => id !== timeline.id)

--- a/timesketch/frontend-ng/src/components/Explore/EventList.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventList.vue
@@ -353,7 +353,7 @@ limitations under the License.
           </template>
 
           <!-- Event details -->
-          <template slot="expanded-item" slot-scope="{ headers, item }">
+          <template v-slot:[expandedItemSlot]="{ headers, item }">
             <td :colspan="headers.length">
               <!-- Details -->
               <v-container v-if="item.showDetails" fluid class="mt-4">
@@ -381,7 +381,7 @@ limitations under the License.
           </template>
 
           <!-- Actions field -->
-          <template slot="item.actions" slot-scope="{ item }">
+          <template v-slot:[itemActionsSlot]="{ item }">
             <v-btn small icon @click="toggleStar(item)">
               <v-icon title="Toggle star status" v-if="item._source.label.includes('__ts_star')" color="amber"
                 >mdi-star</v-icon
@@ -397,7 +397,7 @@ limitations under the License.
           </template>
 
           <!-- Datetime field with action buttons -->
-          <template slot="item._source.timestamp" slot-scope="{ item }">
+          <template v-slot:[itemTimestampSlot]="{ item }">
             <v-tooltip right open-delay="700">
               <template v-slot:activator="{ on, attrs }">
                 <div v-bind="attrs" v-on="on" v-bind:style="getTimelineColor(item)" class="datetime-table-cell">
@@ -449,7 +449,7 @@ limitations under the License.
           </template>
 
           <!-- Timeline name field -->
-          <template slot="item.timeline_name" slot-scope="{ item }">
+          <template v-slot:[itemTimelineNameSlot]="{ item }">
             <v-chip label style="margin-top: 1px; margin-bottom: 1px; font-size: 0.8em">
               <span class="timeline-name-ellipsis" style="width: 130px; text-align: center">{{
                 getTimeline(item).name
@@ -457,7 +457,7 @@ limitations under the License.
           </template>
 
           <!-- Comment field -->
-          <template slot="item._source.comment" slot-scope="{ item }">
+          <template v-slot:[itemCommentSlot]="{ item }">
             <div class="d-inline-block">
               <v-btn icon small @click="toggleDetailedEvent(item)" v-if="item._source.comment.length">
                 <v-badge :offset-y="10" :offset-x="10" bordered :content="item._source.comment.length">
@@ -488,6 +488,7 @@ limitations under the License.
 <script>
 import ApiClient from '../../utils/RestApiClient.js'
 import EventBus from '../../event-bus.js'
+import EventMixin from '../../mixins/EventMixin'
 
 import TsBarChart from './BarChart.vue'
 import TsEventDetail from './EventDetail.vue'
@@ -530,6 +531,7 @@ export default {
     TsExploreWelcomeCard,
     TsSearchNotFoundCard,
   },
+  mixins: [EventMixin],
   props: {
     queryRequest: {
       type: Object,
@@ -566,6 +568,11 @@ export default {
   },
   data() {
     return {
+      expandedItemSlot: 'expanded-item',
+      itemActionsSlot: 'item.actions',
+      itemTimestampSlot: 'item._source.timestamp',
+      itemTimelineNameSlot: 'item.timeline_name',
+      itemCommentSlot: 'item._source.comment',
       showEventTagMenu: false,
       columnHeaders: [
         {
@@ -796,16 +803,6 @@ export default {
           this.expandedRows.push(prevEvent)
         }
       })
-    },
-    getTimeline: function (event) {
-      let isLegacy = this.meta.indices_metadata[event._index].is_legacy
-      let timeline
-      if (isLegacy) {
-        timeline = this.sketch.active_timelines.find((timeline) => timeline.searchindex.index_name === event._index)
-      } else {
-        timeline = this.sketch.active_timelines.find((timeline) => timeline.id === event._source.__ts_timeline_id)
-      }
-      return timeline
     },
     getTimelineColor(event) {
       let timeline = this.getTimeline(event)

--- a/timesketch/frontend-ng/src/mixins/EventMixin.js
+++ b/timesketch/frontend-ng/src/mixins/EventMixin.js
@@ -1,0 +1,26 @@
+/*
+Copyright 2025 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+export default {
+  methods: {
+    getTimeline(event) {
+      let isLegacy = this.$store.state.meta.indices_metadata[event._index].is_legacy
+      if (isLegacy) {
+        return this.$store.state.sketch.active_timelines.find((timeline) => timeline.searchindex.index_name === event._index)
+      }
+      return this.$store.state.sketch.active_timelines.find((timeline) => timeline.id === event._source.__ts_timeline_id)
+    },
+  },
+}


### PR DESCRIPTION
* This PR adds a tooltip to the datetime field in the event table showing the timeline name when hovering.
* The timeline name column on the right end was hidden by default.
* I've added a local storage for the users decision if they want to hide or keep the timeline name table.
* A timeline can now be filtered or focused from the 3-dot action menu of each event.

### Screenshots
<img width="503" height="396" alt="image" src="https://github.com/user-attachments/assets/97d9f9b6-1ce5-41e7-bdfd-e04d1d1ab24f" />
<img width="929" height="538" alt="image" src="https://github.com/user-attachments/assets/a137376a-2b87-471d-9a32-0c9d1c763ff7" />
