### PR TITLE
Feat/Celery: Configurable and safe psort logging

### DIFF
--- a/data/timesketch.conf
+++ b/data/timesketch.conf
@@ -193,7 +193,7 @@ PLASO_UPPER_MEMORY_LIMIT = None
 # If this is set, psort will write execution logs here.
 # If this is NOT set, logs will be discarded to /dev/null.
 # WARNING: These logs can be large. Ensure you have log rotation configured!
-PLASO_LOG_FOLDER = '/var/logs/timesketch/psort/'
+PLASO_LOG_FOLDER = '/var/log/timesketch/psort/'
 
 #-------------------------------------------------------------------------------
 # Analyzers.

--- a/docs/guides/admin/troubleshooting.md
+++ b/docs/guides/admin/troubleshooting.md
@@ -80,6 +80,7 @@ See [docs/learn/server-admin](docs/learn/server-admin#troubleshooting-database-s
 - Which Plaso version was used to create the Plaso file?
 - Is the issue for both web upload and `import_client`?
 - If you open a Github Issue, please indicate the Plaso version used to generate the file.
+- **Note:** By default, `psort` execution logs are logged. If you need to debug a specific crash, see the [Plaso / Psort](#plaso-psort) section below.
 
 Try to run the following in the Docker container after the file was uploaded (but not successfully imported):
 
@@ -142,6 +143,25 @@ docker exec -it $CONTAINER_ID celery -A timesketch.lib.tasks inspect query_task 
 ```
 
 Where $TASKID is the id that was shown in the previous step.
+
+### Plaso / Psort
+
+By default, the `psort` process (used to process Plaso files) writes execution
+logs to `/var/log/timesketch/psort/` which should be mapped to the host.
+
+If this is not set it will be logged to `/dev/null` to prevent cluttering the disk.
+
+You can configure the path in the `timesketch.conf`:
+
+```
+# Directory to store Plaso (psort) log files.
+# If this is set, psort will write execution logs here.
+# If this is NOT set, logs will be discarded to /dev/null.
+PLASO_LOG_FOLDER = '/var/log/timesketch/psort/'
+```
+
+**Note:** Psort logs can be large. If you enable this, ensure you have log
+          rotation configured on the target directory.
 
 ### OpenSearch
 

--- a/timesketch/lib/tasks.py
+++ b/timesketch/lib/tasks.py
@@ -919,6 +919,7 @@ def run_plaso(
         index_name,
     ]
 
+    log_file_path = "/dev/null"
     log_dir = current_app.config.get("PLASO_LOG_FOLDER")
 
     if log_dir:
@@ -931,7 +932,7 @@ def run_plaso(
             log_filename = f"psort_{index_name}_{timestamp}_{unique_suffix}.log.gz"
             log_full_path = os.path.join(log_dir, log_filename)
 
-            cmd.extend(["--logfile", log_full_path])
+            log_file_path = log_full_path
             logger.info(
                 "[%s] Psort log enabled: Writing to [%s]", index_name, log_full_path
             )
@@ -945,10 +946,8 @@ def run_plaso(
                 log_dir,
                 e,
             )
-            cmd.extend(["--logfile", "/dev/null"])
-    else:
-        # If no logging path for plaso is defined use /dev/null
-        cmd.extend(["--logfile", "/dev/null"])
+
+    cmd.extend(["--logfile", log_file_path])
 
     if mappings_file_path:
         cmd.extend(["--opensearch_mappings", mappings_file_path])


### PR DESCRIPTION
This PR updates the `run_plaso` Celery task to address potential disk exhaustion issues while maintaining the ability to capture psort logs when required.

Previously, `psort` generated a log file in the worker's root directory (`/`) for every execution. In high-volume environments, this can deplete disk space and inodes, leading to worker instability.

**Changes**
*   **Configurable Logging:** Introduced support for a `PLASO_LOG_FOLDER` configuration variable.
*   **Opt-In Logic:**
    *   **If `PLASO_LOG_FOLDER` is set:** Psort logs are written to this directory. Filenames now include a timestamp and a short UUID suffix to prevent collisions during concurrent processing of the same index.
    *   **If `PLASO_LOG_FOLDER` is unset:** Psort logs are directed to `/dev/null`. This ensures the system is "safe by default" and prevents disk fill-up on standard installations.
*   **Resilience:** Added error handling around directory creation. If the configured log path is unwritable, the task logs an error to the worker log but falls back to `/dev/null` for `psort`, allowing the ingestion to proceed without crashing.