### PR TITLE
Fix index explosion during rapid automated uploads

### DIFF
--- a/timesketch/api/v1/resources/upload.py
+++ b/timesketch/api/v1/resources/upload.py
@@ -97,11 +97,11 @@ class UploadFileResource(resources.ResourceMixin, Resource):
         if data_label in ("csv", "json", "jsonl"):
             data_label = "csv_jsonl"
 
-        indices = [
+        indices = (
             t.searchindex
             for t in sketch.timelines
             if t.get_status.status not in ("deleted", "archived")
-        ]
+        )
         for index in indices:
             if index.has_label(data_label) and sketch.has_permission(
                 permission="write", user=current_user


### PR DESCRIPTION
#### **Problem**
During load testing and high-frequency automated imports (e.g., using the Importer Client or `dftimewolf`), Timesketch was frequently creating a new OpenSearch index for every file uploaded, even if they shared the same data label (e.g., Plaso).

**Technical Root Cause:**
The `UploadFileResource._get_index` logic previously relied on the `sketch.active_timelines` property to identify existing indices available for re-use. However, the `active_timelines` property explicitly filters out timelines with a status of `processing`. 

In automated scenarios where files are uploaded in second intervals:
1. Request # 1 creates an index and sets its status to `processing`.
2. Request # 2 arrives while Request # 1 is still being handled by a Celery worker.
3. Request # 2 checks `active_timelines`, fails to see the index from Request # 1 (because it isn't `ready` yet), and assumes it must create a new index.
4. This results in an "Index Explosion," where $N$ uploads result in $N$ OpenSearch indices, putting unnecessary metadata strain on the OpenSearch cluster.

#### **Solution**
Modified the index lookup logic in `timesketch/api/v1/resources/upload.py` to check for reusable indices across **all** timelines associated with a sketch, provided they are not `deleted` or `archived`. 

By including timelines in the `processing` state, subsequent rapid-fire requests can successfully identify the "in-flight" index and append their data to it as intended.

#### **Changes**
*   Updated `_get_index` in `upload.py` to iterate through `sketch.timelines` with a status check instead of using the restrictive `sketch.active_timelines` property.

#### **Impact & Expected Side Effects**
*   **OpenSearch Stability:** Significantly reduces the number of indices and shards created during large-scale ingestions.
*   **Concurrency:** Multiple Celery workers will now more frequently perform bulk imports into the same index simultaneously.

#### **Testing Performed**
*   Verified that rapid uploads of multiple CSV/Plaso files via the Importer Client now correctly merge into a single search index.
*   Confirmed that deleted/archived timelines are still excluded from the re-use logic.

### Validation Results

The following measurements were taken using `tsctl sketch-info` to observe how the API handles multiple rapid uploads of the same data type (Plaso).

#### **1. Before Change (Sketch 2)**
In the original state, two Plaso uploads initiated within seconds of each other resulted in **two separate Search Indices**. 

*   **Timeline 5** was created and entered `processing` status.
*   **Timeline 6** was created while Timeline 5 was still processing. 
*   **Result:** The API failed to reuse Index ID 2 and created **Index ID 3**.

```text
Timelines (Sketch 2):
ID  Name                             Search Index ID   Index Name                         Status
5   vm-1_plaso_fsstat                2                 dac719ef334744c898e20f4f95ebc167   processing
6   firefox_internal_testdata_202309 3                 a2b0750129c74ce1b1fec381c8564d7e   ready
```

#### **2. After Change (Sketch 3) - FIXED**
With the fix applied, three rapid Plaso uploads were initiated. Even though the first timeline was still in `processing` status when the subsequent requests arrived, the API correctly identified and reused the existing index.

*   **Timeline 7** created **Index ID 4**.
*   **Timeline 8** identified Index ID 4 (despite it being in `processing`) and reused it.
*   **Timeline 9** identified Index ID 4 and reused it.
*   **Result:** All three timelines were merged into **one single Search Index (ID 4)**.

```text
Timelines (Sketch 3):
ID  Name                             Search Index ID   Index Name                         Status
7   vm-1_plaso_fsstat                4                 3c8a5d4f80244a918225b814c5193548   ready
8   firefox_internal_testdata_202309 4                 3c8a5d4f80244a918225b814c5193548   ready
9   vm-1_plaso_parsed_logs           4                 3c8a5d4f80244a918225b814c5193548   ready
```
