### PR TITLE
Fix stuck timelines by hardening DB connection handling in Celery tasks

### DIFF
--- a/data/timesketch.conf
+++ b/data/timesketch.conf
@@ -14,7 +14,7 @@ ENABLE_PROFILING = False
 # This should be a unique random string. Don't share this with anyone.
 # To generate a key, you can for example use openssl:
 # $ openssl rand -base64 32
-SECRET_KEY = '<KEY_GOES_HERE>'
+SECRET_KEY = "<KEY_GOES_HERE>"
 
 # Setup the database.
 #
@@ -24,11 +24,8 @@ SECRET_KEY = '<KEY_GOES_HERE>'
 #
 # NOTE: SQLite should only be used in development. Use PostgreSQL or MySQL in
 # production.
-SQLALCHEMY_DATABASE_URI = 'postgresql://<USERNAME>:<PASSWORD>@localhost/timesketch'
-SQLALCHEMY_ENGINE_OPTIONS = {
-  'pool_pre_ping': True,
-  'pool_recycle': 3600
-}
+SQLALCHEMY_DATABASE_URI = "postgresql://<USERNAME>:<PASSWORD>@localhost/timesketch"
+SQLALCHEMY_ENGINE_OPTIONS = {"pool_pre_ping": True, "pool_recycle": 3600}
 
 # Configure where your OpenSearch server is located.
 #
@@ -44,7 +41,7 @@ OPENSEARCH_CA_CERTS = None
 OPENSEARCH_TIMEOUT = 10
 OPENSEARCH_FLUSH_INTERVAL = 5000
 OPENSEARCH_INDEX_WAIT_TIMEOUT = 10
-OPENSEARCH_MINIMUM_HEALTH = 'yellow'
+OPENSEARCH_MINIMUM_HEALTH = "yellow"
 # Be careful when increasing the upper limit since this will impact your
 # OpenSearch clusters performance and storage requirements!
 OPENSEARCH_MAPPING_BUFFER = 0.1
@@ -54,16 +51,16 @@ OPENSEARCH_MAPPING_UPPER_LIMIT = 1000
 # timelines will not be deleted. This can be used to add a list of different
 # labels that ensure that a sketch and it's associated timelines cannot be
 # deleted.
-LABELS_TO_PREVENT_DELETION = ['protected', 'preserved']
+LABELS_TO_PREVENT_DELETION = ["protected", "preserved"]
 
 # Number of seconds before a timeout occurs in bulk operations in the
 # OpenSearch client.
 TIMEOUT_FOR_EVENT_IMPORT = 180
 
 # Location for the configuration file of the data finder.
-DATA_FINDER_PATH = '/etc/timesketch/data_finder.yaml'
+DATA_FINDER_PATH = "/etc/timesketch/data_finder.yaml"
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Single Sign On (SSO) configuration.
 
 # Your web server can handle authentication for you by setting a environment
@@ -72,7 +69,7 @@ DATA_FINDER_PATH = '/etc/timesketch/data_finder.yaml'
 # another name you can configure that here.
 
 SSO_ENABLED = False
-SSO_USER_ENV_VARIABLE = 'REMOTE_USER'
+SSO_USER_ENV_VARIABLE = "REMOTE_USER"
 
 # Some SSO systems provides group information as environment variable.
 # Timesketch can automatically create groups and add users as members.
@@ -82,14 +79,14 @@ SSO_GROUP_ENV_VARIABLE = None
 
 # Different systems use different separators in the string returned in the
 # environment variable.
-SSO_GROUP_SEPARATOR = ';'
+SSO_GROUP_SEPARATOR = ";"
 
 # Some SSO systems uses a special prefix for the group name to indicate that
 # the user is not a member of that group. Set this if that is the case, i.e.
 # '-'.
 SSO_GROUP_NOT_MEMBER_SIGN = None
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Google Cloud Identity-Aware Proxy (Cloud IAP) authentication configuration.
 
 # Cloud IAP controls access to your Timesketch server running on Google Cloud
@@ -105,21 +102,20 @@ GOOGLE_IAP_ENABLED = False
 
 # This information is available via the Google Cloud console:
 # https://cloud.google.com/iap/docs/signed-headers-howto
-GOOGLE_IAP_PROJECT_NUMBER = ''
-GOOGLE_IAP_BACKEND_ID = ''
+GOOGLE_IAP_PROJECT_NUMBER = ""
+GOOGLE_IAP_BACKEND_ID = ""
 
 # DON'T EDIT: Google IAP expected audience is based on Cloud project number and
 # backend ID.
-GOOGLE_IAP_AUDIENCE = '/projects/{}/global/backendServices/{}'.format(
-    GOOGLE_IAP_PROJECT_NUMBER,
-    GOOGLE_IAP_BACKEND_ID
+GOOGLE_IAP_AUDIENCE = "/projects/{}/global/backendServices/{}".format(
+    GOOGLE_IAP_PROJECT_NUMBER, GOOGLE_IAP_BACKEND_ID
 )
 
-GOOGLE_IAP_ALGORITHM = 'ES256'
-GOOGLE_IAP_ISSUER = 'https://cloud.google.com/iap'
-GOOGLE_IAP_PUBLIC_KEY_URL = 'https://www.gstatic.com/iap/verify/public_key'
+GOOGLE_IAP_ALGORITHM = "ES256"
+GOOGLE_IAP_ISSUER = "https://cloud.google.com/iap"
+GOOGLE_IAP_PUBLIC_KEY_URL = "https://www.gstatic.com/iap/verify/public_key"
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Google Cloud OpenID Connect (OIDC) authentication configuration.
 
 # Cloud OIDC controls access to your Timesketch server running on Google Cloud
@@ -163,7 +159,7 @@ GOOGLE_OIDC_API_ALLOWED_DOMAINS = []
 # set of users.
 GOOGLE_OIDC_ALLOWED_USERS = []
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Upload and processing of Plaso storage files.
 
 # To enable this feature you need to configure an upload directory and
@@ -172,20 +168,20 @@ UPLOAD_ENABLED = False
 
 # Folder for temporarily storage of Plaso dump files before being processed and
 # inserted into the datastore.
-UPLOAD_FOLDER = '/tmp'
+UPLOAD_FOLDER = "/tmp"
 
 # Celery broker configuration. You need to change ip/port to where your Redis
 # server is running.
-CELERY_BROKER_URL = 'redis://127.0.0.1:6379'
-CELERY_RESULT_BACKEND = 'redis://127.0.0.1:6379'
+CELERY_BROKER_URL = "redis://127.0.0.1:6379"
+CELERY_RESULT_BACKEND = "redis://127.0.0.1:6379"
 
 # File location to store the mappings used when OpenSearch indices are created
 # for plaso files.
-PLASO_MAPPING_FILE = '/etc/timesketch/plaso.mappings'
-GENERIC_MAPPING_FILE = '/etc/timesketch/generic.mappings'
+PLASO_MAPPING_FILE = "/etc/timesketch/plaso.mappings"
+GENERIC_MAPPING_FILE = "/etc/timesketch/generic.mappings"
 
 # Override/extend Plaso default message string formatters.
-PLASO_FORMATTERS = '/etc/timesketch/plaso_formatters.yaml'
+PLASO_FORMATTERS = "/etc/timesketch/plaso_formatters.yaml"
 
 # Upper limits for the process memory that psort.py is allocated when ingesting
 # plaso files. The size is in bytes, with the default value of
@@ -196,9 +192,9 @@ PLASO_UPPER_MEMORY_LIMIT = None
 # If this is set, psort will write execution logs here.
 # If this is NOT set, logs will be discarded to /dev/null.
 # WARNING: These logs can be large. Ensure you have log rotation configured!
-PLASO_LOG_FOLDER = '/var/log/timesketch/psort/'
+PLASO_LOG_FOLDER = "/var/log/timesketch/psort/"
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Analyzers.
 
 # Which analyzers to run automatically.
@@ -235,26 +231,42 @@ DOMAIN_ANALYZER_WATCHED_DOMAINS_SCORE_THRESHOLD = 0.75
 
 # A list of domains that are frequent source of false positives
 # in the "phishy" domain comparison, mostly CDNs and similar.
-DOMAIN_ANALYZER_EXCLUDE_DOMAINS = ['ytimg.com', 'gstatic.com', 'yimg.com', 'akamaized.net', 'akamaihd.net', 's-microsoft.com', 'images-amazon.com', 'ssl-images-amazon.com', 'wikimedia.org', 'redditmedia.com', 'googleusercontent.com', 'googleapis.com', 'wikipedia.org', 'github.io', 'github.com']
+DOMAIN_ANALYZER_EXCLUDE_DOMAINS = [
+    "ytimg.com",
+    "gstatic.com",
+    "yimg.com",
+    "akamaized.net",
+    "akamaihd.net",
+    "s-microsoft.com",
+    "images-amazon.com",
+    "ssl-images-amazon.com",
+    "wikimedia.org",
+    "redditmedia.com",
+    "googleusercontent.com",
+    "googleapis.com",
+    "wikipedia.org",
+    "github.io",
+    "github.com",
+]
 
 # The threshold in minutes which the difference in timestamps has to cross in order to be
 # detected as 'timestomping'.
 NTFS_TIMESTOMP_ANALYZER_THRESHOLD = 10
 
 # Safe Browsing API key for the URL analyzer.
-SAFEBROWSING_API_KEY = ''
+SAFEBROWSING_API_KEY = ""
 
 # For the other possible values of the two settings below, please refer to
 # the Safe Browsing API reference at:
 # https://developers.google.com/safe-browsing/v4/reference/rest
 
 # Platforms to be looked at in Safe Browsing (PlatformType).
-SAFEBROWSING_PLATFORMS = ['ANY_PLATFORM']
+SAFEBROWSING_PLATFORMS = ["ANY_PLATFORM"]
 
 # Types to be looked at in Safe Browsing (ThreatType).
-SAFEBROWSING_THREATTYPES = ['MALWARE']
+SAFEBROWSING_THREATTYPES = ["MALWARE"]
 
-#-- hashR integration --#
+# -- hashR integration --#
 # https://github.com/google/hashr
 # Uncomment and fill this section if you want to use the hashR lookup analyzer.
 # Provide hashR postgres database connection information below:
@@ -277,17 +289,17 @@ SAFEBROWSING_THREATTYPES = ['MALWARE']
 # Threatintel Yeti analyzer-specific configuration
 # https://yeti-platform.io/
 # URI root to Yeti's API, e.g. 'https://localhost:8000'
-YETI_API_ROOT = ''
+YETI_API_ROOT = ""
 
 # API key to authenticate requests
-YETI_API_KEY = ''
+YETI_API_KEY = ""
 
 # Path to a TLS certificate that can be used to authenticate servers
 # using self-signed certificates. Provide the full path to the .crt file.
 YETI_TLS_CERTIFICATE = None
 
 # Labels to narrow down indicator selection
-YETI_INDICATOR_LABELS = ['domain']
+YETI_INDICATOR_LABELS = ["domain"]
 
 # Enable loading DFIQ templates from a Yeti instance.
 # This requires DFIQ_ENABLED to be True and YETI_API_ROOT/YETI_API_KEY to be set.
@@ -296,16 +308,16 @@ YETI_DFIQ_ENABLED = False
 
 # Yeti instance web base URL used for links in the UI.
 # (Falls back to YETI_API_ROOT if not set.)
-YETI_WEB_ROOT = ''
+YETI_WEB_ROOT = ""
 
 # Url to MISP instance
-MISP_URL = ''
+MISP_URL = ""
 
 # API key to authenticate requests
-MISP_API_KEY = ''
+MISP_API_KEY = ""
 
 # Url to Hashlookup instance
-HASHLOOKUP_URL = ''
+HASHLOOKUP_URL = ""
 
 # GeoIP Analyzer Settings
 #
@@ -315,35 +327,35 @@ HASHLOOKUP_URL = ''
 # https://maxmind.com.
 
 # The path to a MaxMind GeoIP database
-MAXMIND_DB_PATH = ''
+MAXMIND_DB_PATH = ""
 
 # The Account ID to access a MaxMind GeoIP web service
-MAXMIND_WEB_ACCOUNT_ID = ''
+MAXMIND_WEB_ACCOUNT_ID = ""
 
 # The license key to access a MaxMind GeoIP web service
-MAXMIND_WEB_LICENSE_KEY = ''
+MAXMIND_WEB_LICENSE_KEY = ""
 
 # The host URL of a MaxMind GeoIP web service
-MAXMIND_WEB_HOST = ''
+MAXMIND_WEB_HOST = ""
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Enable experimental UI features.
 
 ENABLE_EXPERIMENTAL_UI = False
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Email notifications.
 
 ENABLE_EMAIL_NOTIFICATIONS = False
-EMAIL_DOMAIN = 'localhost'
-EMAIL_FROM_USER = 'nobody'
-EMAIL_SMTP_SERVER = 'localhost'
+EMAIL_DOMAIN = "localhost"
+EMAIL_FROM_USER = "nobody"
+EMAIL_SMTP_SERVER = "localhost"
 
 # Only send emails to these users.
 EMAIL_RECIPIENTS = []
 
 # Configuration to construct URLs for resources.
-EXTERNAL_HOST_URL = 'https://localhost'
+EXTERNAL_HOST_URL = "https://localhost"
 
 # SSL/TLS support for emails
 EMAIL_TLS = False
@@ -353,13 +365,13 @@ EMAIL_SSL = False
 EMAIL_AUTH_USERNAME = ""
 EMAIL_AUTH_PASSWORD = ""
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Sigma Settings
 
-SIGMA_CONFIG = '/etc/timesketch/sigma_config.yaml'
+SIGMA_CONFIG = "/etc/timesketch/sigma_config.yaml"
 SIGMA_TAG_DELAY = 5
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Flask Settings
 # Everything mentioned in https://flask-wtf.readthedocs.io/en/latest/config/ can be used.
 # Max age in seconds for CSRF tokens. Default is 3600. If set to None, the CSRF token is valid for the life of the session.
@@ -375,17 +387,17 @@ REVERSE_PROXY_COUNT = 1
 # Default: 200MB chunks
 MAX_FORM_MEMORY_SIZE = 209715200
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # DFIQ - Digital Forensics Investigation Questions
 # How to set-up DFIQ: https://timesketch.org/guides/admin/load-dfiq/
 DFIQ_ENABLED = False
-DFIQ_PATH = '/etc/timesketch/dfiq/'
+DFIQ_PATH = "/etc/timesketch/dfiq/"
 
 # Intelligence tag metadata configuration
-INTELLIGENCE_TAG_METADATA = '/etc/timesketch/intelligence_tag_metadata.yaml'
+INTELLIGENCE_TAG_METADATA = "/etc/timesketch/intelligence_tag_metadata.yaml"
 
 # Context links configuration
-CONTEXT_LINKS_CONFIG_PATH = '/etc/timesketch/context_links.yaml'
+CONTEXT_LINKS_CONFIG_PATH = "/etc/timesketch/context_links.yaml"
 
 # LLM provider configs
 LLM_PROVIDER_CONFIGS = {
@@ -412,36 +424,35 @@ LLM_PROVIDER_CONFIGS = {
     # - aistudio: Google AI Studio (API key).  Get API key from Google AI Studio website.
     #   To use Google's AI Studio simply obtain an API key from https://aistudio.google.com/
     #   $ pip3 install google-generativeai
-    'nl2q': {
-        'vertexai': {
-            'model': 'gemini-2.0-flash',
-            'project_id': '',
+    "nl2q": {
+        "vertexai": {
+            "model": "gemini-2.0-flash",
+            "project_id": "",
         },
     },
-    'llm_summarize': {
-        'aistudio': {
-            'model': 'gemini-2.0-flash',
-            'api_key': '',
+    "llm_summarize": {
+        "aistudio": {
+            "model": "gemini-2.0-flash",
+            "api_key": "",
         },
     },
-    'llm_synthesize': {
-        'aistudio': {
-            'model': 'gemini-2.0-flash',
-            'api_key': '',
+    "llm_synthesize": {
+        "aistudio": {
+            "model": "gemini-2.0-flash",
+            "api_key": "",
         },
     },
-    'log_analyzer':
-    {
+    "log_analyzer": {
         # NOTE: This feature will not work with default LLM providers and requires
         # a dedicated log analyzer agent service!
         # Read more: https://timesketch.org/developers/log-analyzer-agent/
         # Did you install `pip3 install sec-gemini` in your Timesketch containers?
-        'secgemini_log_analyzer_agent': {
-            'logs_processor_api_url': '',
-            'api_key': '',
-            'model': 'logs_analysis_agent-1.1',
-            'base_url': '',
-            'wss_url': '',
+        "secgemini_log_analyzer_agent": {
+            "logs_processor_api_url": "",
+            "api_key": "",
+            "model": "logs_analysis_agent-1.1",
+            "base_url": "",
+            "wss_url": "",
             # Configuration for individual agents. This is a dictionary where the
             # key is the agent name and the value is another dictionary with
             # agent-specific configuration parameters.
@@ -450,26 +461,26 @@ LLM_PROVIDER_CONFIGS = {
             #     'logs_analysis_loop_agent': {
             #         'max_iterations': 10,
             # }
-            'agents_config': {},
+            "agents_config": {},
         }
     },
-    'default': {
-        'ollama': {
-            'server_url': '',
-            'model': '',
+    "default": {
+        "ollama": {
+            "server_url": "",
+            "model": "",
         },
-    }
+    },
 }
 
 
 # LLM nl2q configuration
-DATA_TYPES_PATH = '/etc/timesketch/nl2q/data_types.csv'
-PROMPT_NL2Q = '/etc/timesketch/nl2q/prompt_nl2q'
-EXAMPLES_NL2Q = '/etc/timesketch/nl2q/examples_nl2q'
+DATA_TYPES_PATH = "/etc/timesketch/nl2q/data_types.csv"
+PROMPT_NL2Q = "/etc/timesketch/nl2q/prompt_nl2q"
+EXAMPLES_NL2Q = "/etc/timesketch/nl2q/examples_nl2q"
 
 # LLM event summarization configuration
-PROMPT_LLM_SUMMARIZATION = '/etc/timesketch/llm_summarize/prompt.txt'
-PROMPT_LLM_SYNTHESIZE = '/etc/timesketch/llm_summarize/prompt_llm_synthesize.txt'
+PROMPT_LLM_SUMMARIZATION = "/etc/timesketch/llm_summarize/prompt.txt"
+PROMPT_LLM_SYNTHESIZE = "/etc/timesketch/llm_summarize/prompt_llm_synthesize.txt"
 
 # LLM log_analyzer default prompt
 LLM_LOG_ANALYZER_DEFAULT_PROMPT = (
@@ -478,7 +489,7 @@ LLM_LOG_ANALYZER_DEFAULT_PROMPT = (
     "timeline, from initial compromise to actions on objectives."
 )
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Timesketch UI Option
 
 # Get the search processing timelines setting.

--- a/timesketch/lib/tasks.py
+++ b/timesketch/lib/tasks.py
@@ -199,7 +199,7 @@ def init_worker(**kwargs):
     url = celery.conf.get("SQLALCHEMY_DATABASE_URI")
     engine_options = celery.conf.get("SQLALCHEMY_ENGINE_OPTIONS", {})
     # Ensure pool_pre_ping is enabled by default.
-    if not "pool_pre_ping" in engine_options:
+    if "pool_pre_ping" not in engine_options:
         engine_options["pool_pre_ping"] = True
     engine = create_engine(url, future=True, **engine_options)
     db_session.configure(bind=engine)
@@ -1242,7 +1242,7 @@ def run_csv_jsonl(
         except Exception as db_err:  # pylint: disable=broad-except
             # If the db is so broken we can't even close the session, log it!
             logger.error(
-                "Failed to remove db_session during error handling. " "DB Error: %s",
+                "Failed to remove db_session during error handling. DB Error: %s",
                 db_err,
                 exc_info=True,
             )
@@ -1253,7 +1253,7 @@ def run_csv_jsonl(
         except Exception as db_err:  # pylint: disable=broad-except
             # If we still can't write to DB (e.g. DB server is down), log it!
             logger.critical(
-                "CRITICAL: Could not update timeline status to failed. " "DB Error: %s",
+                "CRITICAL: Could not update timeline status to failed. DB Error: %s",
                 db_err,
             )
         return None

--- a/timesketch/models/__init__.py
+++ b/timesketch/models/__init__.py
@@ -40,7 +40,7 @@ def configure_engine(url, engine_options):
     # pylint: disable=global-statement,global-variable-not-assigned
     # TODO: Can we wrap this in a class?
     # Ensure pool_pre_ping is enabled by default.
-    if not "pool_pre_ping" in engine_options:
+    if "pool_pre_ping" not in engine_options:
         engine_options["pool_pre_ping"] = True
     global engine, session_maker, db_session
     engine = create_engine(url, future=True, **engine_options)


### PR DESCRIPTION
This commit addresses issues where timelines remained stuck in the "processing" state following database connection drops (SSL SYSCALL error: EOF detected) and subsequent transaction corruptions (PendingRollbackError).

Changes:
- Enable `pool_pre_ping` and set `pool_recycle` to 3600 in SQLAlchemy engine options to proactively detect and recycle stale connections.
- Force session removal within task exception handlers to guarantee that failure statuses can be successfully written to the database using a fresh connection.
- Improve logging with postgres connection crashes.