### PR TITLE
Remove legacy logging message

### DIFF
--- a/timesketch/views/auth.py
+++ b/timesketch/views/auth.py
@@ -316,15 +316,6 @@ def validate_api_token():
             )
 
     allowed_users = current_app.config.get("GOOGLE_OIDC_ALLOWED_USERS")
-    # TODO: Remove that after a 6 months, this following check is to ensure
-    # compatibility of config file
-    if not allowed_users:
-        current_app.logger.warning(
-            "Warning, GOOGLE_OIDC_USER_WHITELIST has "
-            "been deprecated. Please update "
-            "timesketch.conf."
-        )
-        allowed_users = current_app.config.get("GOOGLE_OIDC_USER_WHITELIST", [])
 
     # Check if the authenticating user is on the allow list.
     if allowed_users:


### PR DESCRIPTION
Remove logging for `GOOGLE_OIDC_USER_WHITELIST` which is a legacy setting for a long time and not used fora long time anymore. By now all instances should have been upgraded who use this feature..