### PR TITLE
Fix deployment scripts

### DIFF
--- a/contrib/deploy_timesketch.ps1
+++ b/contrib/deploy_timesketch.ps1
@@ -56,7 +56,7 @@ Function Get-RandomString {
 # config parameters
 Write-Host "* Setting default config parameters.."
 $POSTGRES_USER="timesketch"
-$POSTGRES_PASSWORD=Get-RandomString -length 42 
+$POSTGRES_PASSWORD=Get-RandomString -length 42
 $POSTGRES_ADDRESS="postgres"
 $POSTGRES_PORT="5432"
 $SECRET_KEY=Get-RandomString -length 42
@@ -94,21 +94,20 @@ Write-Host "OK"
 Write-Host "* Edit configuration files."
 $timesketchconf = 'timesketch\etc\timesketch\timesketch.conf'
 $convfenv = 'timesketch\config.env'
-(Get-Content $timesketchconf).replace("SECRET_KEY = '<KEY_GOES_HERE>'", "SECRET_KEY = '$SECRET_KEY'") | Set-Content $timesketchconf
+(Get-Content $timesketchconf).replace('SECRET_KEY = "<KEY_GOES_HERE>"', "SECRET_KEY = ""$SECRET_KEY""") | Set-Content $timesketchconf
 
 # Set up the OpenSearch connection
-(Get-Content $timesketchconf).replace("OPENSEARCH_HOST = '127.0.0.1'", "ELASTIC_HOST = '$OPENSEARCH_ADDRESS'") | Set-Content $timesketchconf
-(Get-Content $timesketchconf).replace("OPENSEARCH_PORT = 9200", "ELASTIC_PORT = $OPENSEARCH_PORT") | Set-Content $timesketchconf
+(Get-Content $timesketchconf).replace('OPENSEARCH_HOSTS = [{"host": "opensearch", "port": 9200}]', 'OPENSEARCH_HOSTS = [{"host": "' + $OPENSEARCH_ADDRESS + '", "port": ' + $OPENSEARCH_PORT + '}]') | Set-Content $timesketchconf
 
 # Set up the Redis connection
-(Get-Content $timesketchconf).replace("UPLOAD_ENABLED = False", "UPLOAD_ENABLED = True") | Set-Content $timesketchconf
-(Get-Content $timesketchconf).replace("UPLOAD_FOLDER = '/tmp'", "UPLOAD_FOLDER = '/usr/share/timesketch/upload'") | Set-Content $timesketchconf
+(Get-Content $timesketchconf).replace('UPLOAD_ENABLED = False', 'UPLOAD_ENABLED = True') | Set-Content $timesketchconf
+(Get-Content $timesketchconf).replace('UPLOAD_FOLDER = "/tmp"', 'UPLOAD_FOLDER = "/usr/share/timesketch/upload"') | Set-Content $timesketchconf
 
-(Get-Content $timesketchconf).replace("CELERY_BROKER_URL = 'redis://127.0.0.1:6379'", "CELERY_BROKER_URL = 'redis://$($REDIS_ADDRESS):$($REDIS_PORT)'") | Set-Content $timesketchconf
-(Get-Content $timesketchconf).replace("CELERY_RESULT_BACKEND = 'redis://127.0.0.1:6379'", "CELERY_RESULT_BACKEND = 'redis://$($REDIS_ADDRESS):$($REDIS_PORT)'") | Set-Content $timesketchconf
+(Get-Content $timesketchconf).replace('CELERY_BROKER_URL = "redis://127.0.0.1:6379"', "CELERY_BROKER_URL = ""redis://$($REDIS_ADDRESS):$($REDIS_PORT)""") | Set-Content $timesketchconf
+(Get-Content $timesketchconf).replace('CELERY_RESULT_BACKEND = "redis://127.0.0.1:6379"', "CELERY_RESULT_BACKEND = ""redis://$($REDIS_ADDRESS):$($REDIS_PORT)""") | Set-Content $timesketchconf
 
 # Set up the Postgres connection
-(Get-Content $timesketchconf).replace("SQLALCHEMY_DATABASE_URI = 'postgresql://<USERNAME>:<PASSWORD>@localhost/timesketch'", "SQLALCHEMY_DATABASE_URI = 'postgresql://$($POSTGRES_USER):$($POSTGRES_PASSWORD)@$($POSTGRES_ADDRESS):$($POSTGRES_PORT)/timesketch'") | Set-Content $timesketchconf
+(Get-Content $timesketchconf).replace('SQLALCHEMY_DATABASE_URI = "postgresql://<USERNAME>:<PASSWORD>@localhost/timesketch"', "SQLALCHEMY_DATABASE_URI = ""postgresql://$($POSTGRES_USER):$($POSTGRES_PASSWORD)@$($POSTGRES_ADDRESS):$($POSTGRES_PORT)/timesketch""") | Set-Content $timesketchconf
 
 (Get-Content $convfenv).replace("POSTGRES_PASSWORD=", "POSTGRES_PASSWORD=$POSTGRES_PASSWORD") | Set-Content $convfenv
 (Get-Content $convfenv).replace("OPENSEARCH_MEM_USE_GB=", "OPENSEARCH_MEM_USE_GB=$OPENSEARCH_MEM_USE_GB") | Set-Content $convfenv

--- a/contrib/deploy_timesketch.sh
+++ b/contrib/deploy_timesketch.sh
@@ -112,18 +112,17 @@ echo "OK"
 
 # Create a minimal Timesketch config
 echo -n "* Edit configuration files.."
-sed -i 's#SECRET_KEY = \x27\x3CKEY_GOES_HERE\x3E\x27#SECRET_KEY = \x27'$SECRET_KEY'\x27#' timesketch/etc/timesketch/timesketch.conf
+sed -i 's#SECRET_KEY = "<KEY_GOES_HERE>"#SECRET_KEY = "'$SECRET_KEY'"#' timesketch/etc/timesketch/timesketch.conf
 
 # Set up the OpenSearch connection
-sed -i 's#^OPENSEARCH_HOST = \x27127.0.0.1\x27#OPENSEARCH_HOST = \x27'$OPENSEARCH_ADDRESS'\x27#' timesketch/etc/timesketch/timesketch.conf
-sed -i 's#^OPENSEARCH_PORT = 9200#OPENSEARCH_PORT = '$OPENSEARCH_PORT'#' timesketch/etc/timesketch/timesketch.conf
+sed -i 's#OPENSEARCH_HOSTS = \[{"host": "opensearch", "port": 9200}\]#OPENSEARCH_HOSTS = [{"host": "'$OPENSEARCH_ADDRESS'", "port": '$OPENSEARCH_PORT'}]#' timesketch/etc/timesketch/timesketch.conf
 
 # Set up the Redis connection
 sed -i 's#^UPLOAD_ENABLED = False#UPLOAD_ENABLED = True#' timesketch/etc/timesketch/timesketch.conf
-sed -i 's#^UPLOAD_FOLDER = \x27/tmp\x27#UPLOAD_FOLDER = \x27/usr/share/timesketch/upload\x27#' timesketch/etc/timesketch/timesketch.conf
+sed -i 's#^UPLOAD_FOLDER = "/tmp"#UPLOAD_FOLDER = "/usr/share/timesketch/upload"#' timesketch/etc/timesketch/timesketch.conf
 
-sed -i 's#^CELERY_BROKER_URL =.*#CELERY_BROKER_URL = \x27redis://'$REDIS_ADDRESS':'$REDIS_PORT'\x27#' timesketch/etc/timesketch/timesketch.conf
-sed -i 's#^CELERY_RESULT_BACKEND =.*#CELERY_RESULT_BACKEND = \x27redis://'$REDIS_ADDRESS':'$REDIS_PORT'\x27#' timesketch/etc/timesketch/timesketch.conf
+sed -i 's#^CELERY_BROKER_URL =.*#CELERY_BROKER_URL = "redis://'$REDIS_ADDRESS':'$REDIS_PORT'"#' timesketch/etc/timesketch/timesketch.conf
+sed -i 's#^CELERY_RESULT_BACKEND =.*#CELERY_RESULT_BACKEND = "redis://'$REDIS_ADDRESS':'$REDIS_PORT'"#' timesketch/etc/timesketch/timesketch.conf
 
 # Set up the Postgres connection
 sed -i 's#postgresql://<USERNAME>:<PASSWORD>@localhost#postgresql://'$POSTGRES_USER':'$POSTGRES_PASSWORD'@'$POSTGRES_ADDRESS':'$POSTGRES_PORT'#' timesketch/etc/timesketch/timesketch.conf


### PR DESCRIPTION
This PR fixes the replace commands in the deployment scripts to work with the updated (black formatted) version of the timesketch.conf that was introduced in https://github.com/google/timesketch/pull/3674 

Without this change the replace actions are not working and resulting in a broken new deployment.