### PR TITLE
Fixes an issue where the Sec-Gemini feature fails to process events using the +0000 UTC offset format

### DIFF
--- a/data/timesketch.conf
+++ b/data/timesketch.conf
@@ -447,21 +447,22 @@ LLM_PROVIDER_CONFIGS = {
         # a dedicated log analyzer agent service!
         # Read more: https://timesketch.org/developers/log-analyzer-agent/
         # Did you install `pip3 install sec-gemini` in your Timesketch containers?
-        'secgemini_log_analyzer_agent': {
-            'logs_processor_api_url': '',
-            'api_key': '',
-            'model': 'logs_analysis_agent-1.1',
-            'base_url': '',
-            'wss_url': '',
+        "secgemini_log_analyzer_agent": {
+            "logs_processor_api_url": "",
+            "api_key": "",
+            "model": "logs_analysis_agent-1.1",
+            "base_url": "",
+            "wss_url": "",
             # Configuration for individual agents. This is a dictionary where the
             # key is the agent name and the value is another dictionary with
             # agent-specific configuration parameters.
             # Example:
-            # 'agents_config': {
-            #     'logs_analysis_loop_agent': {
-            #         'max_iterations': 10,
+            # "agents_config": {
+            #     "logs_analysis_loop_agent": {
+            #         "max_iterations": 10,
             # }
             "agents_config": {},
+            "enable_logging": False,
         }
     },
     "default": {

--- a/timesketch/lib/llms/providers/secgemini_log_analyzer_agent.py
+++ b/timesketch/lib/llms/providers/secgemini_log_analyzer_agent.py
@@ -92,7 +92,7 @@ class SecGeminiLogAnalyzer(interface.LLMProvider):
             "enrichment": "tag",
             "timestamp": "datetime",
         }
-        self.enable_logging = self.config.get("enable_logging", True)
+        self.enable_logging = self.config.get("enable_logging", False)
         self._events_sent = 0
         self._session = None
         self.session_id = None
@@ -256,7 +256,7 @@ class SecGeminiLogAnalyzer(interface.LLMProvider):
                     specific_fields = {"_id": event.get("_id", "")}
                     source = event.get("_source", event)
 
-                    # Sec-Gemini cannot handle +0000 timezone offsets, convert to Z
+                    # Sec-Gemini cannot handle +0000 timezone offsets, convert to +00:00
                     for key in ["data_type", "datetime", "message", "timestamp_desc"]:
                         value = source.get(key, "")
                         if (
@@ -264,7 +264,7 @@ class SecGeminiLogAnalyzer(interface.LLMProvider):
                             and isinstance(value, str)
                             and value.endswith("+0000")
                         ):
-                            value = value.replace("+0000", "Z")
+                            value = value.replace("+0000", "+00:00")
                         specific_fields[key] = value
 
                     # Explicitly stringify the tag field for now


### PR DESCRIPTION
`1970-01-01T00:00:00.000000+0000` becomes `1970-01-01T00:00:00.000000Z`

Other timestamps of course remain unchanged:

`2025-01-01T12:00:00.000000+00:00` remains unchanged.
`2025-06-05T10:27:07.000Z` remains unchanged