### PR TITLE
Better genai API error messages

### DIFF
--- a/timesketch/lib/llms/providers/google_genai.py
+++ b/timesketch/lib/llms/providers/google_genai.py
@@ -19,6 +19,7 @@ from typing import Any, Optional
 
 from google import genai
 from google.genai import types
+from google.genai import errors
 from timesketch.lib.llms.providers import interface
 from timesketch.lib.llms.providers import manager
 
@@ -100,6 +101,10 @@ class GoogleGenAI(interface.LLMProvider):
                 contents=prompt,
                 config=generate_config,
             )
+        except errors.APIError as e:
+            error_msg = f"{e.code} {e.status}: {getattr(e, 'message', 'N/A')}"
+            logger.error("API error during content generation: %s", str(e))
+            raise ValueError(f"Error generating content: {error_msg}") from e
         except Exception as e:
             logger.error("Error generating content with Google GenAI: %s", e)
             raise ValueError(f"Error generating content: {e}") from e


### PR DESCRIPTION
Before:
```
   1 Error generating content: 400 INVALID_ARGUMENT. {'error': {'code': 400, 'message': 'API key not valid.
   2 Please pass a valid API key.', 'status': 'INVALID_ARGUMENT', 'details': [{'@type':
   3 'type.googleapis.com/google.rpc.ErrorInfo', 'reason': 'API_KEY_INVALID', 'domain': 'googleapis.com',
   4 'metadata': {'service': 'generativelanguage.googleapis.com'}}, {'@type':
   5 'type.googleapis.com/google.rpc.LocalizedMessage', 'locale': 'en-US', 'message': 'API key not valid.
   6 Please pass a valid API key.'}, {'@type': 'type.googleapis.com/google.rpc.DebugInfo', 'detail':
   7 'Invalid API key: INVALID_KEY_BLAH'}]}}
```

After:
```
   1 Error generating content: 400 INVALID_ARGUMENT: API key not valid. Please pass a valid API key.
```