### PR TITLE
Add backend versions to tsctl info

### DIFF
--- a/timesketch/tsctl.py
+++ b/timesketch/tsctl.py
@@ -972,7 +972,9 @@ def info():
     try:
         db_uri = current_app.config.get("SQLALCHEMY_DATABASE_URI", "")
         if "postgresql" in db_uri:
-            version_row = db_session.execute(sqlalchemy.text("SELECT version();")).fetchone()
+            version_row = db_session.execute(
+                sqlalchemy.text("SELECT version();")
+            ).fetchone()
             print(f"Postgres version: {version_row[0]}")
         else:
             print("Database: Not using PostgreSQL")


### PR DESCRIPTION
Add OpenSearch, Redis and Postgres versions to tsctl info command

- Display OpenSearch version using OpenSearchDataStore
- Display Redis version using celery broker configuration
- Display PostgreSQL version using database session
- Handle connection errors gracefully and print status messages

**Closing issues**

closes  #3704
