### PR TITLE
Fix chunked upload inconsistent file size

### DIFF
--- a/timesketch/api/v1/resources/upload.py
+++ b/timesketch/api/v1/resources/upload.py
@@ -485,7 +485,8 @@ class UploadFileResource(resources.ResourceMixin, Resource):
             file_path = utils.format_upload_path(upload_folder, uuid.uuid4().hex)
 
         try:
-            with open(file_path, "ab") as fh:
+            fd = os.open(file_path, os.O_RDWR | os.O_CREAT, 0o600)
+            with os.fdopen(fd, "rb+") as fh:
                 fh.seek(chunk_byte_offset)
                 fh.write(file_storage.read())
         except OSError as e:


### PR DESCRIPTION
Fixes inconsistent file size and corruption in chunked uploads by replacing `open(..., "ab")` with `os.open` and `os.fdopen` to support random access writes, ensuring chunks are written to the correct offset even if received out of order. Added regression test.

---
*PR created automatically by Jules for task [3689544134454389040](https://jules.google.com/task/3689544134454389040) started by @jaegeral*