### PR TITLE
fix: modify the export test to remove the zip if it already exists to enab…

### DIFF
--- a/end_to_end_tests/client_test.py
+++ b/end_to_end_tests/client_test.py
@@ -136,8 +136,8 @@ level: high
         """Client Sigma object tests."""
         sketch = self.api.create_sketch(name="test_sigmarule_create_get")
         sketch.add_event("event message", "2021-01-01T00:00:00", "timestamp_desc")
-        rule = self.api.create_sigmarule(
-            rule_yaml=f"""
+
+        rule_yaml = f"""
 title: Suspicious Installation of eeeee
 id: {self.RULEID2}
 description: Detects suspicious installation of eeeee
@@ -158,7 +158,7 @@ falsepositives:
     - Unknown
 level: high
 """
-        )
+        rule = self.api.create_sigmarule(rule_yaml=rule_yaml)
         self.assertions.assertIsNotNone(rule)
 
         rule = self.api.get_sigmarule(rule_uuid=self.RULEID2)


### PR DESCRIPTION
This pull request refactors the `test_export_sketch` function in `end_to_end_tests/client_test.py` to improve test reliability. Specifically, it ensures that a temporary export ZIP file is removed before and after the test execution, preventing failures when the test is re-run. 

The changes also include a minor refactoring of a Sigma rule YAML definition in `test_sigmarule_create_get` for better readability and to avoid back and forth of black formatters.