### PR TITLE
dependency: upgrade PyJWT to 2.12.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ numpy==1.26.4
 scipy>=1.10.0
 oauthlib==3.3.1
 pandas==2.2.3
-PyJWT==2.4.0
+PyJWT==2.12.0
 python_dateutil==2.9.0
 PyYAML==6.0.1
 redis==4.4.4

--- a/timesketch/lib/google_auth.py
+++ b/timesketch/lib/google_auth.py
@@ -290,13 +290,18 @@ def get_public_key_for_jwt(encoded_jwt: str, url: str):
         url: URL where keys can be fetched.
 
     Raises:
-        JwTKeyError if keys cannot be fetched.
+        JwtKeyError: if keys cannot be fetched.
+        JwtValidationError: if the JWT token cannot be parsed.
 
     Returns:
         Key as string.
     """
     # Get the Key ID from the JWT header.
-    key_id = jwt.get_unverified_header(encoded_jwt).get("kid")
+    try:
+        key_id = jwt.get_unverified_header(encoded_jwt).get("kid")
+    except jwt.exceptions.InvalidTokenError as e:
+        raise JwtValidationError(f"Invalid JWT header: {e}") from e
+
     if not key_id:
         raise JwtKeyError("Missing key ID field in token header")
     key_cache = get_public_key_for_jwt.key_cache

--- a/timesketch/lib/google_auth_test.py
+++ b/timesketch/lib/google_auth_test.py
@@ -379,6 +379,22 @@ class TestGoogleCloudIAP(BaseTest):
             IAP_VALID_AUDIENCE,
         )
 
+    def test_crit_header_raises_jwt_validation_error(self):
+        """Test to validate a JWT with an unknown critical header."""
+        header = create_default_header(IAP_JWT_ALGORITHM, "iap_1234")
+        header["crit"] = ["x-custom-policy"]
+        header["x-custom-policy"] = "require-mfa"
+        test_jwt = create_mock_jwt(
+            MOCK_EC_PRIVATE_KEY,
+            algorithm=IAP_JWT_ALGORITHM,
+            key_id="iap_1234",
+            audience=IAP_VALID_AUDIENCE,
+            issuer=IAP_VALID_ISSUER,
+            header=header,
+        )
+        with self.assertRaises(JwtValidationError):
+            get_public_key_for_jwt(test_jwt, IAP_PUBLIC_KEY_URL)
+
 
 @mock.patch(
     "timesketch.lib.google_auth._fetch_public_keys", mock_fetch_oidc_public_keys


### PR DESCRIPTION
PyJWT versions <= 2.11.0 do not validate the 'crit' (Critical) Header Parameter as defined in RFC 7515 §4.1.11. This violates the requirement that a JWS must be rejected if it contains extensions listed in 'crit' that are not understood by the recipient.

This change:
- Upgrades PyJWT to 2.12.0 in requirements.txt.
- Updates `timesketch/lib/google_auth.py` to catch `InvalidTokenError` during unverified header parsing. PyJWT 2.12.0 now raises this exception if the 'crit' header contains unsupported extensions.
- Adds a unit test in `google_auth_test.py` to verify that tokens with unknown critical extensions are correctly rejected.
