### PR TITLE
fix(sigma): add ownership authorization check to PUT and DELETE

### DIFF
--- a/timesketch/api/v1/resources/sigma.py
+++ b/timesketch/api/v1/resources/sigma.py
@@ -200,6 +200,7 @@ class SigmaRuleResource(resources.ResourceMixin, Resource):
 
         Returns:
             HTTP_STATUS_CODE_NOT_FOUND if rule not found.
+            HTTP_STATUS_CODE_FORBIDDEN if the user is not the owner or admin.
             HTTP_STATUS_CODE_OK if rule deleted.
         """
         rule = SigmaRule.query.filter_by(rule_uuid=rule_uuid).first()
@@ -210,6 +211,12 @@ class SigmaRuleResource(resources.ResourceMixin, Resource):
             abort(
                 HTTP_STATUS_CODE_NOT_FOUND,
                 error_msg,
+            )
+
+        if rule.user_id != current_user.id and not current_user.admin:
+            abort(
+                HTTP_STATUS_CODE_FORBIDDEN,
+                "You do not have permission to delete this Sigma rule.",
             )
 
         db_session.delete(rule)
@@ -263,6 +270,12 @@ class SigmaRuleResource(resources.ResourceMixin, Resource):
             error_msg = f"Sigma rule with UUID: {rule_uuid!s} not found"
             logger.error(error_msg)
             abort(HTTP_STATUS_CODE_NOT_FOUND, error_msg)
+
+        if sigma_rule_from_db.user_id != current_user.id and not current_user.admin:
+            abort(
+                HTTP_STATUS_CODE_FORBIDDEN,
+                "You do not have permission to modify this Sigma rule.",
+            )
 
         sigma_rule_from_db.rule_yaml = rule_yaml
         sigma_rule_from_db.title = parsed_rule.get("title")


### PR DESCRIPTION
## What problem does this PR solve?

Fixes an **IDOR vulnerability (CWE-862)** in `SigmaRuleResource` where 
any authenticated user could modify or delete Sigma rules owned by other users.

`DELETE` and `PUT` methods in `timesketch/api/v1/resources/sigma.py` 
enforced authentication (`@login_required`) but had **zero ownership checks**.

## Fix

Added authorization check in both methods:
- Non-owners now receive `HTTP 403 Forbidden`
- Admin users retain full access

## Affected Endpoints
- `DELETE /api/v1/sigmarules/<uuid>/`
- `PUT    /api/v1/sigmarules/<uuid>/`

## Checks
- [x] Unit tests exist for Sigma resources in `timesketch/api/v1/resources/sigma_test.py`
