### PR TITLE
feat: Initial contribution for opentelemetry

### DIFF
--- a/contrib/Tiltfile
+++ b/contrib/Tiltfile
@@ -10,6 +10,8 @@ dc_resource("opensearch", labels=["docker"])
 dc_resource("postgres", labels=["docker"])
 dc_resource("redis", labels=["docker"])
 dc_resource("prometheus", labels=["docker"])
+dc_resource("otel-collector", labels=["docker"])
+dc_resource("jaeger", labels=["docker"], links=["http://localhost:16686/jaeger"])
 
 # --- 2. Managed Dev Processes ---
 backend_deps = [

--- a/docker/dev/build/docker-entrypoint.sh
+++ b/docker/dev/build/docker-entrypoint.sh
@@ -35,7 +35,6 @@ setup_config() {
   # later sessions. If you need a new key, just delete the ".dev_secret_key"
   # file in your project root dir and restart the container.
   KEY_FILE="/usr/local/src/timesketch/.dev_secret_key"
-
   if [ ! -f "$KEY_FILE" ]; then
     echo "Generating new persistent development secret key..."
     openssl rand -base64 32 > "$KEY_FILE"
@@ -91,8 +90,8 @@ if [ "$1" = 'timesketch' ]; then
 
   setup_config
 
-  # Add web user
-  tsctl create-user --password "${TIMESKETCH_USER}" "${TIMESKETCH_USER}"
+  # Add web user - don't fail the whole script if this fails
+  tsctl create-user --password "${TIMESKETCH_USER}" "${TIMESKETCH_USER}" || echo "Warning: Failed to create user."
 
   # Wrap up things
   echo "Timesketch development server is ready!"

--- a/docker/dev/docker-compose-telemetry.yml
+++ b/docker/dev/docker-compose-telemetry.yml
@@ -1,0 +1,26 @@
+services:
+  otel-collector:
+    container_name: otel-collector
+    image: otel/opentelemetry-collector:0.100.0
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    ports:
+      - "127.0.0.1:4317:4317"
+      - "127.0.0.1:4318:4318"
+    depends_on:
+      - jaeger
+
+  jaeger:
+    container_name: jaeger
+    image: jaegertracing/all-in-one:latest
+    restart: always
+    ports:
+      - "127.0.0.1:16686:16686"
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+
+networks:
+  default:
+    name: timesketch-network
+    external: true

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -29,9 +29,10 @@ services:
       - CHOKIDAR_USEPOLLING=true
       - PROMETHEUS_MULTIPROC_DIR=/tmp/
       - ENABLE_STRUCTURED_LOGGING=true
-      - TIMESKETCH_OTEL_MODE=otlp-grpc
-      - TIMESKETCH_OTLP_GRPC_ENDPOINT=otel-collector:4317
-      - TIMESKETCH_OTLP_INSECURE=true
+      # Telemetry settings (Uncomment to enable locally)
+      # - TIMESKETCH_OTEL_MODE=otlp-grpc
+      # - TIMESKETCH_OTLP_GRPC_ENDPOINT=otel-collector:4317
+      # - TIMESKETCH_OTLP_INSECURE=true
     restart: always
     volumes:
       - ../../:/usr/local/src/timesketch/
@@ -98,27 +99,6 @@ services:
       - 127.0.0.1:9090:9090
     command: --config.file=/etc/prometheus/prometheus.yml --log.level=warn
 
-  otel-collector:
-    container_name: otel-collector
-    image: otel/opentelemetry-collector:0.100.0
-    command: ["--config=/etc/otel-collector-config.yaml"]
-    volumes:
-      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
-    ports:
-      - "127.0.0.1:4317:4317"
-      - "127.0.0.1:4318:4318"
-    depends_on:
-      - jaeger
-
-  jaeger:
-    container_name: jaeger
-    image: jaegertracing/all-in-one:latest
-    restart: always
-    ports:
-      - "127.0.0.1:16686:16686"
-    environment:
-      - COLLECTOR_OTLP_ENABLED=true
-
   # notebook:
   #   container_name: notebook
   #   image: us-docker.pkg.dev/osdfir-registry/timesketch/notebook:latest
@@ -130,3 +110,7 @@ services:
   #   volumes:
   #     - ../../:/usr/local/src/timesketch/:ro
   #     - /tmp/:/usr/local/src/picadata/
+
+networks:
+  default:
+    name: timesketch-network

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -28,10 +28,14 @@ services:
       - TIMESKETCH_PASSWORD=dev
       - CHOKIDAR_USEPOLLING=true
       - PROMETHEUS_MULTIPROC_DIR=/tmp/
-      # - ENABLE_STRUCTURED_LOGGING=true
+      - ENABLE_STRUCTURED_LOGGING=true
+      - TIMESKETCH_OTEL_MODE=otlp-grpc
+      - TIMESKETCH_OTLP_GRPC_ENDPOINT=otel-collector:4317
+      - TIMESKETCH_OTLP_INSECURE=true
     restart: always
     volumes:
       - ../../:/usr/local/src/timesketch/
+      - ./build/docker-entrypoint.sh:/docker-entrypoint.sh
 
   opensearch:
     container_name: opensearch
@@ -95,14 +99,23 @@ services:
       - 127.0.0.1:9090:9090
     command: --config.file=/etc/prometheus/prometheus.yml --log.level=warn
 
-  # notebook:
-  #   container_name: notebook
-  #   image: us-docker.pkg.dev/osdfir-registry/timesketch/notebook:latest
-  #   ports:
-  #     - 127.0.0.1:8844:8844
-  #   restart: on-failure
-  #   links:
-  #     - opensearch
-  #   volumes:
-  #     - ../../:/usr/local/src/timesketch/:ro
-  #     - /tmp/:/usr/local/src/picadata/
+  otel-collector:
+    container_name: otel-collector
+    image: otel/opentelemetry-collector:0.100.0
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    ports:
+      - "127.0.0.1:4317:4317"
+      - "127.0.0.1:4318:4318"
+    depends_on:
+      - jaeger
+
+  jaeger:
+    container_name: jaeger
+    image: jaegertracing/all-in-one:latest
+    restart: always
+    ports:
+      - "127.0.0.1:16686:16686"
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -35,7 +35,6 @@ services:
     restart: always
     volumes:
       - ../../:/usr/local/src/timesketch/
-      - ./build/docker-entrypoint.sh:/docker-entrypoint.sh
 
   opensearch:
     container_name: opensearch
@@ -119,3 +118,15 @@ services:
       - "127.0.0.1:16686:16686"
     environment:
       - COLLECTOR_OTLP_ENABLED=true
+
+  # notebook:
+  #   container_name: notebook
+  #   image: us-docker.pkg.dev/osdfir-registry/timesketch/notebook:latest
+  #   ports:
+  #     - 127.0.0.1:8844:8844
+  #   restart: on-failure
+  #   links:
+  #     - opensearch
+  #   volumes:
+  #     - ../../:/usr/local/src/timesketch/:ro
+  #     - /tmp/:/usr/local/src/picadata/

--- a/docker/dev/otel-collector-config.yaml
+++ b/docker/dev/otel-collector-config.yaml
@@ -1,0 +1,25 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+
+exporters:
+  logging:
+    verbosity: detailed
+  otlp:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging, otlp]

--- a/docs/OpenTelemetry.md
+++ b/docs/OpenTelemetry.md
@@ -1,0 +1,187 @@
+# OpenTelemetry in Timesketch: Getting Started Guide
+
+This document provides a comprehensive guide for developers, admins, and users on how OpenTelemetry (OTel) is implemented in Timesketch, how to configure it, and how to verify it locally.
+
+---
+
+## 1. Overview
+Timesketch uses OpenTelemetry to provide distributed tracing across its web (Flask) and worker (Celery) components. This enables deep observability into request life cycles and background task performance.
+
+### Key Benefits
+*   **Distributed Tracing:** Track a single request from an external tool (like `dftimewolf`) through the API and into background analyzers.
+*   **Log Correlation:** Trace IDs and Span IDs are automatically injected into structured JSON logs, allowing you to jump from a log line directly to a trace waterfall in tools like GCP Cloud Trace or Jaeger.
+*   **Standardized Protocol:** Uses the industry-standard OpenTelemetry Protocol (OTLP).
+
+---
+
+## 2. Architecture
+The instrumentation is centralized in a dedicated module: `timesketch/lib/telemetry.py`.
+
+*   **Flask Instrumentation:** Automatically captures spans for all HTTP requests, including route patterns and status codes.
+*   **Celery Instrumentation:** Captures spans for both task dispatching (producer) and execution (worker), maintaining the trace context across process boundaries.
+*   **Async Exporting:** Spans are exported asynchronously using a `BatchSpanProcessor` to ensure minimal impact on application performance.
+
+---
+
+## 3. Configuration Reference
+Telemetry is controlled entirely via environment variables.
+
+| Variable | Description | Example / Default |
+| :--- | :--- | :--- |
+| `TIMESKETCH_OTEL_MODE` | The export mode. Must start with `otlp-`. | `otlp-grpc`, `otlp-http`, `otlp-default-gce` |
+| `TIMESKETCH_OTLP_GRPC_ENDPOINT` | OTLP collector endpoint (gRPC). | `jaeger:4317` |
+| `TIMESKETCH_OTLP_HTTP_ENDPOINT` | OTLP collector endpoint (HTTP). | `http://jaeger:4318/v1/traces` |
+| `TIMESKETCH_OTLP_INSECURE` | Use insecure (non-TLS) connection. | `true` (default for dev) |
+| `TIMESKETCH_ENV` | Environment identifier. | `production`, `development` |
+
+### Supported Modes:
+1.  **`otlp-grpc`:** Best for local collectors (e.g., OTel Collector or Jaeger).
+2.  **`otlp-http`:** Standard OTLP over HTTP/JSON.
+3.  **`otlp-default-gce`:** **Recommended for production on GCP.** Sends traces directly to Google Cloud Trace API from a GCE instance using the Metadata Server for project identification and credentials.
+
+---
+
+## 4. Local Development & Testing
+
+### Option A: Using Docker Compose
+1. **Start the Core Environment:**
+   Navigate to the dev docker directory and start the core services:
+   ```bash
+   cd docker/dev
+   docker-compose up -d
+   ```
+
+2. **Start the Telemetry Stack (Optional):**
+   Spin up the dedicated telemetry services (OTel Collector and Jaeger):
+   ```bash
+   docker-compose -f docker-compose-telemetry.yml up -d
+   ```
+
+**Note on Dependencies:**
+Since the development image does not yet contain the new OpenTelemetry libraries, you must install them manually whenever the container is recreated:
+```bash
+docker exec timesketch-dev pip install -r /usr/local/src/timesketch/requirements.txt
+# Ensure environment variables are set (uncomment in docker-compose.yml or set manually)
+docker restart timesketch-dev
+```
+
+### Option B: Using Tilt
+If you use Tilt for development, the telemetry stack is integrated automatically:
+```bash
+tilt up
+```
+The Tilt dashboard will show `otel-collector` and `jaeger` resources, including a direct link to the Jaeger UI.
+
+---
+
+## 5. Visualization Options
+
+The local environment provides two ways to see your traces. You can switch between them by changing the `TIMESKETCH_OTLP_GRPC_ENDPOINT`.
+
+### 1. Via OTel Collector (Gateway)
+**Default Configuration:** `TIMESKETCH_OTLP_GRPC_ENDPOINT=otel-collector:4317`
+*   **Why use this:** The collector acts as a gateway. It logs the raw spans to its own terminal (`docker logs -f otel-collector`) AND forwards them to Jaeger.
+*   **Best for:** Seeing raw attributes and verifying the export pipeline.
+
+### 2. Directly to Jaeger
+**Custom Configuration:** `TIMESKETCH_OTLP_GRPC_ENDPOINT=jaeger:4317`
+*   **Why use this:** Bypasses the collector and sends data straight to Jaeger.
+*   **Access:** Open [http://localhost:16686/jaeger](http://localhost:16686/jaeger) in your browser.
+*   **Best for:** Clean waterfall visualization and searching for past traces.
+
+---
+
+## 6. Triggering Activity & Verification
+Generate some traffic to verify the setup:
+```bash
+# Trigger a Flask Trace (API Call)
+docker exec timesketch-dev curl -s http://localhost:5000/api/v1/info/
+
+# Trigger a Celery Trace (Run Analyzer)
+docker exec timesketch-dev celery -A timesketch.lib.tasks call timesketch.lib.tasks.run_index_analyzer
+```
+
+**Check Application Logs:**
+Verify that `trace_id` and `span_id` appear in the JSON output:
+```bash
+docker logs timesketch-dev | grep trace_id
+```
+
+---
+
+## 7. Secure Private Access (GCP)
+If you are running Timesketch on a private GCE VM without an external IP, you can "proxy in" securely using **Identity-Aware Proxy (IAP) Tunneling**.
+
+### Accessing the Web Interfaces
+Run these commands on your local machine to create a secure tunnel:
+
+**Tip for Cloudtop Users:**
+If you are on Cloudtop, the recommended way to connect is via the **BeyondCorp SUP Relay**.
+
+**1. Direct SSH into the VM:**
+```bash
+ssh ${USER}_google_com@nic0.timesketch-otel-lab.us-central1-a.c.jaegeral-timesketch-946302.internal.gcpnode.com \
+    -o ProxyCommand='corp-ssh-helper %h %p'
+```
+
+**2. Access Timesketch UI (Tunneling):**
+You can use standard SSH port forwarding with the command above:
+```bash
+ssh -L 5000:localhost:5000 \
+    ${USER}_google_com@nic0.timesketch-otel-lab.us-central1-a.c.jaegeral-timesketch-946302.internal.gcpnode.com \
+    -o ProxyCommand='corp-ssh-helper %h %p'
+```
+Now open [http://localhost:5000](http://localhost:5000) in your browser.
+
+**Alternative: Standard IAP Tunneling**
+If the above doesn't work, you can use `gcloud` IAP tunnels:
+```bash
+gcloud compute start-iap-tunnel timesketch-otel-lab 5000 \
+    --local-host-port=localhost:5000 \
+    --zone=us-central1-a \
+    --project=jaegeral-timesketch-946302 \
+    --ssh-flag="-o ProxyCommand='corp-ssh-helper %h %p'"
+```
+
+---
+
+## 8. Deployment Guide (GCP)
+To enable production tracing in GCP:
+1.  Set `TIMESKETCH_OTEL_MODE=otlp-default-gce`.
+2.  Ensure the service account running Timesketch has the `roles/cloudtrace.agent` role.
+3.  View your traces in the [GCP Trace Explorer](https://console.cloud.google.com/traces/explorer).
+
+---
+
+## 8. Information for Developers
+
+### Automated Coverage
+Most common operations are already covered by auto-instrumentation:
+*   **Web API:** All Flask routes, status codes, and HTTP methods.
+*   **Background Tasks:** All Celery task dispatching and executions.
+*   **Analyzers:** All analyzers automatically report `sketch_id`, `analyzer_name`, `timeline_id`, and execution status via the `BaseAnalyzer` interface.
+
+### Adding Custom Attributes & Events
+If you need to record specific domain metadata (e.g., number of matches found, search query used) from within your code, use the helpers in `timesketch.lib.telemetry`.
+
+#### Example: Adding attributes in an Analyzer
+```python
+from timesketch.lib import telemetry
+
+def analyze(self):
+    # ... logic ...
+    matches_found = len(results)
+    
+    # This will appear in the Span attributes in Jaeger/GCP
+    telemetry.add_attribute_to_current_span("sigma.matches_count", matches_found)
+    
+    # Record a significant milestone as an event
+    telemetry.add_event_to_current_span("Finished parsing rules")
+    
+    return f"Found {matches_found} matches."
+```
+
+#### Best Practices for Attributes
+*   **Use Namespace Prefixes:** To avoid collisions, prefix your attributes (e.g., `sigma.rule_id`, `sketch.member_count`).
+*   **Data Types:** Simple types (strings, ints, bools, floats) are stored natively. Complex objects (dicts, lists) are automatically serialized to JSON.
+*   **Avoid PII:** Never record sensitive user data or authentication tokens in span attributes.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,8 @@ opentelemetry-api==1.24.0
 opentelemetry-sdk==1.24.0
 opentelemetry-instrumentation-flask==0.45b0
 opentelemetry-instrumentation-celery==0.45b0
+google-cloud-trace>=1.4.0
+opentelemetry-exporter-gcp-trace>=1.6.0
 opentelemetry-exporter-otlp==1.24.0
 Flask==3.1.3
 flask_bcrypt==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,11 @@ cryptography==46.0.5
 datasketch==1.6.5
 dfir-unfurl==20240627
 opensearch-py==2.8.0
+opentelemetry-api==1.24.0
+opentelemetry-sdk==1.24.0
+opentelemetry-instrumentation-flask==0.45b0
+opentelemetry-instrumentation-celery==0.45b0
+opentelemetry-exporter-otlp==1.24.0
 Flask==3.1.3
 flask_bcrypt==1.0.1
 flask_login==0.6.3

--- a/timesketch/app.py
+++ b/timesketch/app.py
@@ -273,7 +273,9 @@ def configure_logger():
                     log_record["trace_id"] = trace.format_trace_id(
                         span_context.trace_id
                     )
-                    log_record["span_id"] = trace.format_span_id(span_context.span_id)
+                    log_record["span_id"] = trace.format_span_id(
+                        span_context.span_id
+                    )
 
             if record.exc_info:
                 formatted_trace = self.formatException(record.exc_info)

--- a/timesketch/app.py
+++ b/timesketch/app.py
@@ -270,10 +270,17 @@ def configure_logger():
             if trace:
                 span_context = trace.get_current_span().get_span_context()
                 if span_context.is_valid:
-                    t_id = span_context.trace_id
-                    s_id = span_context.span_id
-                    log_record["trace_id"] = trace.format_trace_id(t_id)
-                    log_record["span_id"] = trace.format_span_id(s_id)
+                    t_id = trace.format_trace_id(span_context.trace_id)
+                    s_id = trace.format_span_id(span_context.span_id)
+                    log_record["trace_id"] = t_id
+                    log_record["span_id"] = s_id
+                    # GCP specific correlation fields
+                    project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
+                    if project_id:
+                        log_record["logging.googleapis.com/trace"] = (
+                            f"projects/{project_id}/traces/{t_id}"
+                        )
+                        log_record["logging.googleapis.com/spanId"] = s_id
 
             if record.exc_info:
                 formatted_trace = self.formatException(record.exc_info)

--- a/timesketch/app.py
+++ b/timesketch/app.py
@@ -30,7 +30,10 @@ from flask_migrate import Migrate
 from flask_restful import Api
 from flask_wtf import CSRFProtect
 
-from opentelemetry import trace
+try:
+    from opentelemetry import trace
+except ImportError:
+    trace = None
 from timesketch.lib import telemetry
 
 from timesketch.api.v1.routes import API_ROUTES as V1_API_ROUTES
@@ -264,10 +267,11 @@ def configure_logger():
                 "module": record.module,
             }
 
-            span_context = trace.get_current_span().get_span_context()
-            if span_context.is_valid:
-                log_record["trace_id"] = trace.format_trace_id(span_context.trace_id)
-                log_record["span_id"] = trace.format_span_id(span_context.span_id)
+            if trace:
+                span_context = trace.get_current_span().get_span_context()
+                if span_context.is_valid:
+                    log_record["trace_id"] = trace.format_trace_id(span_context.trace_id)
+                    log_record["span_id"] = trace.format_span_id(span_context.span_id)
 
             if record.exc_info:
                 formatted_trace = self.formatException(record.exc_info)

--- a/timesketch/app.py
+++ b/timesketch/app.py
@@ -270,7 +270,9 @@ def configure_logger():
             if trace:
                 span_context = trace.get_current_span().get_span_context()
                 if span_context.is_valid:
-                    log_record["trace_id"] = trace.format_trace_id(span_context.trace_id)
+                    log_record["trace_id"] = trace.format_trace_id(
+                        span_context.trace_id
+                    )
                     log_record["span_id"] = trace.format_span_id(span_context.span_id)
 
             if record.exc_info:

--- a/timesketch/app.py
+++ b/timesketch/app.py
@@ -270,12 +270,10 @@ def configure_logger():
             if trace:
                 span_context = trace.get_current_span().get_span_context()
                 if span_context.is_valid:
-                    log_record["trace_id"] = trace.format_trace_id(
-                        span_context.trace_id
-                    )
-                    log_record["span_id"] = trace.format_span_id(
-                        span_context.span_id
-                    )
+                    t_id = span_context.trace_id
+                    s_id = span_context.span_id
+                    log_record["trace_id"] = trace.format_trace_id(t_id)
+                    log_record["span_id"] = trace.format_span_id(s_id)
 
             if record.exc_info:
                 formatted_trace = self.formatException(record.exc_info)

--- a/timesketch/app.py
+++ b/timesketch/app.py
@@ -30,6 +30,9 @@ from flask_migrate import Migrate
 from flask_restful import Api
 from flask_wtf import CSRFProtect
 
+from opentelemetry import trace
+from timesketch.lib import telemetry
+
 from timesketch.api.v1.routes import API_ROUTES as V1_API_ROUTES
 from timesketch.lib.errors import ApiHTTPError
 from timesketch.models import configure_engine
@@ -68,6 +71,8 @@ def create_app(
         static_folder = "frontend-ng/dist"
 
     app = Flask(__name__, template_folder=template_folder, static_folder=static_folder)
+    telemetry.setup_telemetry("timesketch")
+    telemetry.instrument_flask_app(app)
 
     # Apply ProxyFix middleware to handle proxy headers for HTTPS redirects
     # This ensures Flask generates HTTPS URLs when behind a reverse proxy.
@@ -259,6 +264,11 @@ def configure_logger():
                 "module": record.module,
             }
 
+            span_context = trace.get_current_span().get_span_context()
+            if span_context.is_valid:
+                log_record["trace_id"] = trace.format_trace_id(span_context.trace_id)
+                log_record["span_id"] = trace.format_span_id(span_context.span_id)
+
             if record.exc_info:
                 formatted_trace = self.formatException(record.exc_info)
                 log_record["stack_trace"] = formatted_trace
@@ -299,6 +309,7 @@ def create_celery_app():
     app = create_app()
     celery = Celery(app.import_name, broker=app.config["CELERY_BROKER_URL"])
     celery.conf.update(app.config)
+    telemetry.instrument_celery_app(celery)
     TaskBase = celery.Task
 
     class ContextTask(TaskBase):

--- a/timesketch/lib/analyzers/interface.py
+++ b/timesketch/lib/analyzers/interface.py
@@ -31,6 +31,7 @@ import pandas
 from timesketch.api.v1 import utils as api_utils
 
 from timesketch.lib import definitions
+from timesketch.lib import telemetry
 from timesketch.lib.datastores.opensearch import OpenSearchDataStore
 from timesketch.models import db_session
 from timesketch.models.sketch import Aggregation
@@ -1147,9 +1148,17 @@ class BaseAnalyzer:
         # Run the analyzer. Broad Exception catch to catch any error and store
         # the error in the DB for display in the UI.
         try:
+            telemetry.add_attribute_to_current_span("sketch_id", self.sketch.id)
+            telemetry.add_attribute_to_current_span("analyzer_name", self.name)
+            telemetry.add_attribute_to_current_span("timeline_id", self.timeline_id)
+            telemetry.add_event_to_current_span(f"Starting analyzer: {self.name}")
+
             result = self.run()
             analysis.set_status("DONE")
-        except Exception:  # pylint: disable=broad-except
+
+            telemetry.add_attribute_to_current_span("status", "success")
+            telemetry.add_event_to_current_span(f"Analyzer {self.name} completed")
+        except Exception as e:  # pylint: disable=broad-except
             analysis.set_status("ERROR")
             result = traceback.format_exc()
             logger.error(
@@ -1159,6 +1168,9 @@ class BaseAnalyzer:
                 self.sketch.id,
                 result,
             )
+            telemetry.add_attribute_to_current_span("status", "error")
+            telemetry.add_attribute_to_current_span("error_message", str(e))
+            telemetry.add_event_to_current_span(f"Analyzer {self.name} failed")
 
         # Update database analysis object with result and status
         analysis.result = f"{result:s}"

--- a/timesketch/lib/telemetry.py
+++ b/timesketch/lib/telemetry.py
@@ -75,7 +75,8 @@ def setup_telemetry(service_name: str):
         - 'otlp-grpc': Exports to an OTLP collector via gRPC.
           Uses `TIMESKETCH_OTLP_GRPC_ENDPOINT` (default: localhost:4317).
         - 'otlp-http': Exports to an OTLP collector via HTTP.
-          Uses `TIMESKETCH_OTLP_HTTP_ENDPOINT` (default: http://localhost:4318/v1/traces).
+          Uses `TIMESKETCH_OTLP_HTTP_ENDPOINT`
+          (default: http://localhost:4318/v1/traces).
 
     Args:
         service_name (str): The name of the service to identify traces in the backend.

--- a/timesketch/lib/telemetry.py
+++ b/timesketch/lib/telemetry.py
@@ -17,16 +17,19 @@ import json
 import logging
 import os
 
-from opentelemetry import trace
-from opentelemetry.trace.span import INVALID_SPAN
-
-from opentelemetry.exporter.otlp.proto.grpc import trace_exporter as grpc_exporter
-from opentelemetry.exporter.otlp.proto.http import trace_exporter as http_exporter
-from opentelemetry.instrumentation.celery import CeleryInstrumentor
-from opentelemetry.instrumentation.flask import FlaskInstrumentor
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
+try:
+    from opentelemetry import trace
+    from opentelemetry.trace.span import INVALID_SPAN
+    from opentelemetry.exporter.otlp.proto.grpc import trace_exporter as grpc_exporter
+    from opentelemetry.exporter.otlp.proto.http import trace_exporter as http_exporter
+    from opentelemetry.instrumentation.celery import CeleryInstrumentor
+    from opentelemetry.instrumentation.flask import FlaskInstrumentor
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    HAS_OTEL = True
+except ImportError:
+    HAS_OTEL = False
 
 from timesketch.version import get_version
 
@@ -42,6 +45,8 @@ def is_enabled() -> bool:
     Returns:
         bool: True if telemetry is enabled, False otherwise.
     """
+    if not HAS_OTEL:
+        return False
     otel_mode = os.environ.get("TIMESKETCH_OTEL_MODE", "").lower()
     return otel_mode.startswith("otlp-")
 
@@ -56,7 +61,8 @@ def setup_telemetry(service_name: str):
         - 'otlp-grpc': Exports to an OTLP collector via gRPC.
           Uses `TIMESKETCH_OTLP_GRPC_ENDPOINT` (default: localhost:4317).
         - 'otlp-http': Exports to an OTLP collector via HTTP.
-          Uses `TIMESKETCH_OTLP_HTTP_ENDPOINT` (default: http://localhost:4318/v1/traces).
+          Uses `TIMESKETCH_OTLP_HTTP_ENDPOINT`
+          (default: http://localhost:4318/v1/traces).
         - 'otlp-cloud-trace': Exports directly to Google Cloud Trace using
           native OTLP/gRPC. Points to telemetry.googleapis.com.
 
@@ -97,9 +103,10 @@ def setup_telemetry(service_name: str):
         )
     else:
         logger.error(
-            f"Unsupported OTEL tracing mode {otel_mode}. "
-            "Valid values for TIMESKETCH_OTEL_MODE are:"
-            " 'otlp-grpc', 'otlp-http', 'otlp-cloud-trace'"
+            "Unsupported OTEL tracing mode %s. "
+            "Valid values for TIMESKETCH_OTEL_MODE are: "
+            "'otlp-grpc', 'otlp-http', 'otlp-cloud-trace'",
+            otel_mode,
         )
         return
 

--- a/timesketch/lib/telemetry.py
+++ b/timesketch/lib/telemetry.py
@@ -1,0 +1,173 @@
+# Copyright 2026 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Module providing OpenTelemetry capability to Timesketch."""
+
+import json
+import logging
+import os
+
+from opentelemetry import trace
+from opentelemetry.trace.span import INVALID_SPAN
+
+from opentelemetry.exporter.otlp.proto.grpc import trace_exporter as grpc_exporter
+from opentelemetry.exporter.otlp.proto.http import trace_exporter as http_exporter
+from opentelemetry.instrumentation.celery import CeleryInstrumentor
+from opentelemetry.instrumentation.flask import FlaskInstrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+from timesketch.version import get_version
+
+logger = logging.getLogger("timesketch.telemetry")
+
+
+def is_enabled() -> bool:
+    """Returns whether OpenTelemetry instrumentation is enabled.
+
+    Telemetry is considered enabled if the `TIMESKETCH_OTEL_MODE` environment
+    variable is set to a value starting with 'otlp-'.
+
+    Returns:
+        bool: True if telemetry is enabled, False otherwise.
+    """
+    otel_mode = os.environ.get("TIMESKETCH_OTEL_MODE", "").lower()
+    return otel_mode.startswith("otlp-")
+
+
+def setup_telemetry(service_name: str):
+    """Configures the OpenTelemetry SDK and trace exporter.
+
+    This function initializes the global TracerProvider and configures a span
+    processor with the exporter selected via `TIMESKETCH_OTEL_MODE`.
+
+    Supported modes:
+        - 'otlp-grpc': Exports to an OTLP collector via gRPC.
+          Uses `TIMESKETCH_OTLP_GRPC_ENDPOINT` (default: localhost:4317).
+        - 'otlp-http': Exports to an OTLP collector via HTTP.
+          Uses `TIMESKETCH_OTLP_HTTP_ENDPOINT` (default: http://localhost:4318/v1/traces).
+        - 'otlp-cloud-trace': Exports directly to Google Cloud Trace using
+          native OTLP/gRPC. Points to telemetry.googleapis.com.
+
+    Args:
+        service_name (str): The name of the service to identify traces in the backend.
+    """
+    if not is_enabled():
+        return
+
+    resource = Resource(
+        attributes={
+            "service.name": service_name,
+            "service.version": get_version(),
+            "deployment.environment": os.environ.get("TIMESKETCH_ENV", "development"),
+        }
+    )
+
+    otel_mode = os.environ.get("TIMESKETCH_OTEL_MODE", "").lower()
+    trace_exporter = None
+
+    if otel_mode == "otlp-grpc":
+        endpoint = os.environ.get("TIMESKETCH_OTLP_GRPC_ENDPOINT", "localhost:4317")
+        insecure = os.environ.get("TIMESKETCH_OTLP_INSECURE", "true").lower() == "true"
+        trace_exporter = grpc_exporter.OTLPSpanExporter(
+            endpoint=endpoint, insecure=insecure
+        )
+    elif otel_mode == "otlp-http":
+        endpoint = os.environ.get(
+            "TIMESKETCH_OTLP_HTTP_ENDPOINT", "http://localhost:4318/v1/traces"
+        )
+        trace_exporter = http_exporter.OTLPSpanExporter(endpoint=endpoint)
+    elif otel_mode == "otlp-cloud-trace":
+        # Direct OTLP to GCP Cloud Trace
+        # See: go/ct:writing-spans-from-borg-1p-howto
+        endpoint = "https://telemetry.googleapis.com"
+        trace_exporter = grpc_exporter.OTLPSpanExporter(
+            endpoint=endpoint, insecure=False
+        )
+    else:
+        logger.error(
+            f"Unsupported OTEL tracing mode {otel_mode}. "
+            "Valid values for TIMESKETCH_OTEL_MODE are:"
+            " 'otlp-grpc', 'otlp-http', 'otlp-cloud-trace'"
+        )
+        return
+
+    # --- Tracing Setup ---
+    trace_provider = TracerProvider(resource=resource)
+    trace_provider.add_span_processor(BatchSpanProcessor(trace_exporter))
+    trace.set_tracer_provider(trace_provider)
+
+
+def instrument_celery_app(celery_app, **kwargs):
+    """Instruments a Celery application instance.
+
+    This enables automatic capturing of spans for task dispatching (producer)
+    and task execution (worker).
+
+    Args:
+        celery_app (celery.app.Celery): The Celery application to instrument.
+        **kwargs: Additional arguments passed to CeleryInstrumentor().instrument().
+    """
+    if not is_enabled():
+        return
+    CeleryInstrumentor().instrument(celery_app=celery_app, **kwargs)
+
+
+def instrument_flask_app(app, **kwargs):
+    """Instruments a Flask application instance.
+
+    This enables automatic capturing of spans for all incoming HTTP requests.
+
+    Args:
+        app (flask.Flask): The Flask application to instrument.
+        **kwargs: Additional arguments passed to FlaskInstrumentor().instrument_app().
+    """
+    if not is_enabled():
+        return
+    FlaskInstrumentor().instrument_app(app, **kwargs)
+
+
+def add_event_to_current_span(event: str):
+    """Adds a named event (annotation) to the currently active span.
+
+    Args:
+        event (str): The name or message of the event to record.
+    """
+    if not is_enabled():
+        return
+
+    otel_span = trace.get_current_span()
+    if otel_span != INVALID_SPAN:
+        otel_span.add_event(event)
+
+
+def add_attribute_to_current_span(name: str, value: object):
+    """Adds a key-value attribute (tag) to the currently active span.
+
+    Simple types (str, bool, int, float) are stored as-is. Complex objects
+    are automatically serialized to JSON strings.
+
+    Args:
+        name (str): The key name for the attribute.
+        value (object): The value to store.
+    """
+    if not is_enabled():
+        return
+
+    otel_span = trace.get_current_span()
+    if otel_span != INVALID_SPAN:
+        if isinstance(value, (str, bool, int, float)):
+            otel_span.set_attribute(name, value)
+        else:
+            otel_span.set_attribute(name, json.dumps(value))

--- a/timesketch/lib/telemetry.py
+++ b/timesketch/lib/telemetry.py
@@ -27,6 +27,7 @@ try:
     from opentelemetry.sdk.resources import Resource
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
     HAS_OTEL = True
 except ImportError:
     HAS_OTEL = False

--- a/timesketch/lib/telemetry.py
+++ b/timesketch/lib/telemetry.py
@@ -18,8 +18,14 @@ import logging
 import os
 
 try:
+    from google.auth import compute_engine
+    from google.auth import exceptions as auth_exceptions
+    from google.auth import transport
+    from google.cloud.trace_v2 import TraceServiceClient
+
     from opentelemetry import trace
     from opentelemetry.trace.span import INVALID_SPAN
+    from opentelemetry.exporter import cloud_trace
     from opentelemetry.exporter.otlp.proto.grpc import trace_exporter as grpc_exporter
     from opentelemetry.exporter.otlp.proto.http import trace_exporter as http_exporter
     from opentelemetry.instrumentation.celery import CeleryInstrumentor
@@ -37,11 +43,20 @@ from timesketch.version import get_version
 logger = logging.getLogger("timesketch.telemetry")
 
 
+def _get_gcp_project_id():
+    """Returns the GCP Project ID as a string."""
+    auth_request = transport.requests.Request()
+    try:
+        # pylint: disable=protected-access
+        project_id = compute_engine._metadata.get_project_id(auth_request)
+        return project_id
+    except auth_exceptions.TransportError as e:
+        logger.error("Could not get project_id from GCE metadata server: %s", str(e))
+    return None
+
+
 def is_enabled() -> bool:
     """Returns whether OpenTelemetry instrumentation is enabled.
-
-    Telemetry is considered enabled if the `TIMESKETCH_OTEL_MODE` environment
-    variable is set to a value starting with 'otlp-'.
 
     Returns:
         bool: True if telemetry is enabled, False otherwise.
@@ -53,19 +68,14 @@ def is_enabled() -> bool:
 
 
 def setup_telemetry(service_name: str):
-    """Configures the OpenTelemetry SDK and trace exporter.
-
-    This function initializes the global TracerProvider and configures a span
-    processor with the exporter selected via `TIMESKETCH_OTEL_MODE`.
+    """Configures the OpenTelemetry trace exporter.
 
     Supported modes:
+        - 'otlp-default-gce': Exports to Google Cloud Trace API from a GCE instance.
         - 'otlp-grpc': Exports to an OTLP collector via gRPC.
           Uses `TIMESKETCH_OTLP_GRPC_ENDPOINT` (default: localhost:4317).
         - 'otlp-http': Exports to an OTLP collector via HTTP.
-          Uses `TIMESKETCH_OTLP_HTTP_ENDPOINT`
-          (default: http://localhost:4318/v1/traces).
-        - 'otlp-cloud-trace': Exports directly to Google Cloud Trace using
-          native OTLP/gRPC. Points to telemetry.googleapis.com.
+          Uses `TIMESKETCH_OTLP_HTTP_ENDPOINT` (default: http://localhost:4318/v1/traces).
 
     Args:
         service_name (str): The name of the service to identify traces in the backend.
@@ -95,16 +105,21 @@ def setup_telemetry(service_name: str):
             "TIMESKETCH_OTLP_HTTP_ENDPOINT", "http://localhost:4318/v1/traces"
         )
         trace_exporter = http_exporter.OTLPSpanExporter(endpoint=endpoint)
-    elif otel_mode == "otlp-cloud-trace":
-        endpoint = "https://telemetry.googleapis.com"
-        trace_exporter = grpc_exporter.OTLPSpanExporter(
-            endpoint=endpoint, insecure=False
+    elif otel_mode == "otlp-default-gce":
+        # Explicitly pass credentials from the GKE Metadata Server
+        # This ignores GOOGLE_APPLICATION_CREDENTIALS
+        credentials = compute_engine.Credentials()
+        trace_client = TraceServiceClient(credentials=credentials)
+        trace_exporter = cloud_trace.CloudTraceSpanExporter(
+            project_id=_get_gcp_project_id(),
+            resource_regex=r"service.*",
+            client=trace_client,
         )
     else:
         logger.error(
             "Unsupported OTEL tracing mode %s. "
             "Valid values for TIMESKETCH_OTEL_MODE are: "
-            "'otlp-grpc', 'otlp-http', 'otlp-cloud-trace'",
+            "'otlp-grpc', 'otlp-http', 'otlp-default-gce'",
             otel_mode,
         )
         return
@@ -118,9 +133,6 @@ def setup_telemetry(service_name: str):
 def instrument_celery_app(celery_app, **kwargs):
     """Instruments a Celery application instance.
 
-    This enables automatic capturing of spans for task dispatching (producer)
-    and task execution (worker).
-
     Args:
         celery_app (celery.app.Celery): The Celery application to instrument.
         **kwargs: Additional arguments passed to CeleryInstrumentor().instrument().
@@ -132,8 +144,6 @@ def instrument_celery_app(celery_app, **kwargs):
 
 def instrument_flask_app(app, **kwargs):
     """Instruments a Flask application instance.
-
-    This enables automatic capturing of spans for all incoming HTTP requests.
 
     Args:
         app (flask.Flask): The Flask application to instrument.
@@ -163,10 +173,9 @@ def add_attribute_to_current_span(name: str, value: object):
 
     Simple types (str, bool, int, float) are stored as-is. Complex objects
     are automatically serialized to JSON strings.
-
     Args:
         name (str): The key name for the attribute.
-        value (object): The value to store.
+        value (object): The value to store. Needs to be JSON serializable.
     """
     if not is_enabled():
         return

--- a/timesketch/lib/telemetry.py
+++ b/timesketch/lib/telemetry.py
@@ -96,8 +96,6 @@ def setup_telemetry(service_name: str):
         )
         trace_exporter = http_exporter.OTLPSpanExporter(endpoint=endpoint)
     elif otel_mode == "otlp-cloud-trace":
-        # Direct OTLP to GCP Cloud Trace
-        # See: go/ct:writing-spans-from-borg-1p-howto
         endpoint = "https://telemetry.googleapis.com"
         trace_exporter = grpc_exporter.OTLPSpanExporter(
             endpoint=endpoint, insecure=False


### PR DESCRIPTION
This Pull Request introduces comprehensive OpenTelemetry (OTel) instrumentation to Timesketch, enabling
  distributed tracing across the web API, background workers, and analyzers. The implementation is
  architecturally aligned with OpenRelik (https://github.com/openrelik/openrelik-common/blob/main/openrelik_common/telemetry.py)

1. Framework-Wide Tracing
   * Flask (API): Automatically captures spans for all incoming HTTP requests, including route patterns,
     status codes, and user agents.
   * Celery (Workers): Instruments task producers and workers, ensuring trace context is propagated
     across process boundaries.
   * Base Analyzer: Integrated OTel into the common analyzer interface, meaning every analyzer (Sigma,
     Sketch, etc.) now automatically reports sketch_id, analyzer_name, and execution status.

2. Local Dev Experience
   * Integrated Stack: Added a local Jaeger UI and an OTel Collector gateway to both docker-compose.yml
     and the Tiltfile.
   * Visualization: Traces can be viewed locally at http://localhost:16686/jaeger.
   
How to Verify
   1. Start the dev environment (docker-compose up or tilt up).
   2. Install dependencies: docker exec timesketch-dev pip install -r requirements.txt.
   3. Trigger any API call or Analyzer.
   4. View the trace waterfall in the local Jaeger UI.