### PR TITLE
fix: string vs list to prevent failing requests

### DIFF
--- a/timesketch/api/v1/resources/sketch.py
+++ b/timesketch/api/v1/resources/sketch.py
@@ -455,7 +455,7 @@ class SketchResource(resources.ResourceMixin, Resource):
             for timeline in sketch.active_timelines:
                 index_name = timeline.searchindex.index_name
                 if indices_metadata[index_name].get("is_legacy", False):
-                    doc_count, _ = self.datastore.count(indices=index_name)
+                    doc_count, _ = self.datastore.count(indices=[index_name])
                     stats_per_timeline[timeline.id] = {"count": doc_count}
 
             count_agg_spec = {

--- a/timesketch/lib/datastores/opensearch.py
+++ b/timesketch/lib/datastores/opensearch.py
@@ -803,7 +803,8 @@ class OpenSearchDataStore:
         Args:
             sketch_id: The ID of the sketch the search is performed within. Used
                 for building label filters.
-            indices: A list of OpenSearch index names to query.
+            indices: A list of OpenSearch index names (or a single index name
+                string) to query.
             query_string: The query string to search for (e.g., "hostname:evil.com").
                 Defaults to an empty string.
             query_filter: An optional dictionary containing filters to apply to
@@ -837,6 +838,9 @@ class OpenSearchDataStore:
                 with the query or connection.
             DatastoreTimeoutError: If querying OpenSearch times out.
         """
+        if isinstance(indices, str):
+            indices = [indices]
+
         scroll_timeout = None
         if enable_scroll:
             scroll_timeout = "1m"  # Default to 1 minute scroll timeout
@@ -1195,7 +1199,8 @@ class OpenSearchDataStore:
         total size on disk for the provided list of indices.
 
         Args:
-            indices (list[str]): A list of OpenSearch index names to count.
+            indices: A list of OpenSearch index names (or a single index name
+                string) to count.
 
         Returns:
             tuple[int, int]: A tuple containing two integers:
@@ -1204,6 +1209,9 @@ class OpenSearchDataStore:
             Returns (0, 0) if the indices are not found or if there is a
             request error.
         """
+        if isinstance(indices, str):
+            indices = [indices]
+
         # Make sure that the list of index names is uniq.
         indices = list(set(indices))
 


### PR DESCRIPTION
Check for index count if a string as index name is passed or really a list of indexes.

When one string was passed, iteratting over each char caused one request per char, resulting in additional 32 requests.

There where many of those:

```
{"message": "Index 'a' not found. Skipping...", "severity": "WARNING", "level": "WARNING", "timestamp": "2026-05-05T10:21:38+0000", "logger": "timesketch.opensearch", "pid": 956, "module": "opensearch", "trace_id": "c86b6d2ac6c3532f4b0deab8a87d3294", "span_id": "e19f8e12da034b16", "logging.googleapis.com/trace": "projects/jaegeral-timesketch-946302/traces/c86b6d2ac6c3532f4b0deab8a87d3294", "logging.googleapis.com/spanId": "e19f8e12da034b16"}
{"message": "Index 'c' not found. Skipping...", "severity": "WARNING", "level": "WARNING", "timestamp": "2026-05-05T10:21:38+0000", "logger": "timesketch.opensearch", "pid": 956, "module": "opensearch", "trace_id": "c86b6d2ac6c3532f4b0deab8a87d3294", "span_id": "e19f8e12da034b16", "logging.googleapis.com/trace": "projects/jaegeral-timesketch-946302/traces/c86b6d2ac6c3532f4b0deab8a87d3294", "logging.googleapis.com/spanId": "e19f8e12da034b16"}
{"message": "Index 'e' not found. Skipping...", "severity": "WARNING", "level": "WARNING", "timestamp": "2026-05-05T10:21:38+0000", "logger": "timesketch.opensearch", "pid": 956, "module": "opensearch", "trace_id": "c86b6d2ac6c3532f4b0deab8a87d3294", "span_id": "e19f8e12da034b16", "logging.googleapis.com/trace": "projects/jaegeral-timesketch-946302/traces/c86b6d2ac6c3532f4b0deab8a87d3294", "logging.googleapis.com/spanId": "e19f8e12da034b16"}
{"message": "Index '2' not found. Skipping...", "severity": "WARNING", "level": "WARNING", "timestamp": "2026-05-05T10:21:38+0000", "logger": "timesketch.opensearch", "pid": 956, "module": "opensearch", "trace_id": "c86b6d2ac6c3532f4b0deab8a87d3294", "span_id": "e19f8e12da034b16", "logging.googleapis.com/trace": "projects/jaegeral-timesketch-946302/traces/c86b6d2ac6c3532f4b0deab8a87d3294", "logging.googleapis.com/spanId": "e19f8e12da034b16"}
{"message": "Index '3' not found. Skipping...", "severity": "WARNING", "level": "WARNING", "timestamp": "2026-05-05T10:21:38+0000", "logger": "timesketch.opensearch", "pid": 956, "module": "opensearch", "trace_id": "c86b6d2ac6c3532f4b0deab8a87d3294", "span_id": "e19f8e12da034b16", "logging.googleapis.com/trace": "projects/jaegeral-timesketch-946302/traces/c86b6d2ac6c3532f4b0deab8a87d3294", "logging.googleapis.com/spanId": "e19f8e12da034b16"}
{"message": "Index '1' not found. Skipping...", "severity": "WARNING", "level": "WARNING", "timestamp": "2026-05-05T10:21:38+0000", "logger": "timesketch.opensearch", "pid": 956, "module": "opensearch", "trace_id": "c86b6d2ac6c3532f4b0deab8a87d3294", "span_id": "e19f8e12da034b16", "logging.googleapis.com/trace": "projects/jaegeral-timesketch-946302/traces/c86b6d2ac6c3532f4b0deab8a87d3294", "logging.googleapis.com/spanId": "e19f8e12da034b16"}
{"message": "Index 'd' not found. Skipping...", "severity": "WARNING", "level": "WARNING", "timestamp": "2026-05-05T10:21:38+0000", "logger": "timesketch.opensearch", "pid": 956, "module": "opensearch", "trace_id": "c86b6d2ac6c3532f4b0deab8a87d3294", "span_id": "e19f8e12da034b16", "logging.googleapis.com/trace": "projects/jaegeral-timesketch-946302/traces/c86b6d2ac6c3532f4b0deab8a87d3294", "logging.googleapis.com/spanId": "e19f8e12da034b16"}
```
so it goes like:

```
indices = "e2bc98..."
for index_name in indices:
   # First iteration: index_name = "e" -> OpenSearch Request (FAIL)
   # Second iteration: index_name = "2" -> OpenSearch Request (FAIL)
  ..
```

Defensive Fix (opensearch.py): Added a type check at the start of count() and search() methods. If a string is passed, it is automatically wrapped in a list: indices = [indices].

Caller Fix (sketch.py): Updated the SketchResource to explicitly pass the index name as a list [index_name].