### PR TITLE
Add dependency for feature extraction in domain analyzer

### DIFF
--- a/timesketch/lib/analyzers/domain.py
+++ b/timesketch/lib/analyzers/domain.py
@@ -21,7 +21,7 @@ class DomainSketchPlugin(interface.BaseAnalyzer):
         "domains as well as mark known CDNs"
     )
 
-    DEPENDENCIES = frozenset()
+    DEPENDENCIES = frozenset(["feature_extraction"])
 
     def run(self):
         """Entry point for the analyzer.


### PR DESCRIPTION
Right now the domain analyzer only supports fields called `url` and `domain`. With this change we allow operators to add a config in [regex_features.yaml](https://github.com/google/timesketch/blob/master/data/regex_features.yaml) to either extract domains or rename URL fields to work with the domain analyzer in their custom logs.

This change ensures the feature extraction is run before the domain analyzer runs.