### PR TITLE
feat: add ExploreWildcard API endpoint and CLI support for raw wildcard queries

### DIFF
--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -20,7 +20,7 @@ import os
 import json
 import time
 import logging
-from typing import Dict, Generator, List, Optional
+from typing import Dict, Generator, List, Optional, Union
 
 import pandas
 
@@ -1100,6 +1100,40 @@ class Sketch(resource.BaseResource):
             return search_obj.to_pandas()
 
         return search_obj.to_dict()
+
+    def explore_wildcard(
+        self,
+        query_string: str,
+        fields: Union[str, List[str]] = "message",
+        limit: Optional[int] = None,
+    ) -> Dict[str, Union[Dict, List]]:
+        """Explore the sketch with raw wildcard queries (Skeleton endpoint).
+
+        Args:
+            query_string: String representation of the raw wildcard query (e.g. '*evil*').
+            fields: Comma-separated list or single field target to search (default: 'message').
+            limit: Optional integer representing maximum entries to return.
+
+        Returns:
+            A dictionary containing the parsed search result schema (metadata and objects).
+
+        Raises:
+            RuntimeError: If the sketch is currently archived.
+        """
+        # TODO: Align explore_wildcard signature and behavior with standard explore()
+        # by supporting as_pandas=False, as_object=False, and dynamic return types.
+        if self.is_archived():
+            raise RuntimeError("Unable to query an archived sketch.")
+
+        resource_url = f"{self.api.api_root}/sketches/{self.id}/explore_wildcard/"
+        form_data = {
+            "query": query_string,
+            "fields": fields,
+        }
+        if limit:
+            form_data["filter"] = {"size": limit}
+        response = self.api.session.post(resource_url, json=form_data)
+        return error.get_response_json(response, logger)
 
     def list_available_analyzers(self):
         """Returns a list of available analyzers."""

--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -1104,16 +1104,13 @@ class Sketch(resource.BaseResource):
     def explore_wildcard(
         self,
         query_string: str,
-        fields: Union[str, List[str]] = "message",
         limit: Optional[int] = None,
     ) -> Dict[str, Union[Dict, List]]:
         """Explore the sketch with raw wildcard queries (Skeleton endpoint).
 
         Args:
             query_string: String representation of the raw wildcard query
-                (e.g. '*evil*').
-            fields: Comma-separated list or single field target to search
-                (default: 'message').
+                (e.g. '*evil*' or 'message:*evil*').
             limit: Optional integer representing maximum entries to return.
 
         Returns:
@@ -1131,9 +1128,8 @@ class Sketch(resource.BaseResource):
         resource_url = f"{self.api.api_root}/sketches/{self.id}/explore_wildcard/"
         form_data = {
             "query": query_string,
-            "fields": fields,
         }
-        if limit:
+        if limit is not None:
             form_data["filter"] = {"size": limit}
         response = self.api.session.post(resource_url, json=form_data)
         return error.get_response_json(response, logger)

--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -1110,12 +1110,15 @@ class Sketch(resource.BaseResource):
         """Explore the sketch with raw wildcard queries (Skeleton endpoint).
 
         Args:
-            query_string: String representation of the raw wildcard query (e.g. '*evil*').
-            fields: Comma-separated list or single field target to search (default: 'message').
+            query_string: String representation of the raw wildcard query
+                (e.g. '*evil*').
+            fields: Comma-separated list or single field target to search
+                (default: 'message').
             limit: Optional integer representing maximum entries to return.
 
         Returns:
-            A dictionary containing the parsed search result schema (metadata and objects).
+            A dictionary containing the parsed search result schema
+            (metadata and objects).
 
         Raises:
             RuntimeError: If the sketch is currently archived.

--- a/api_client/python/timesketch_api_client/sketch_test.py
+++ b/api_client/python/timesketch_api_client/sketch_test.py
@@ -240,9 +240,7 @@ class SketchTest(unittest.TestCase):
         with mock.patch.object(
             self.api_client.session, "post", return_value=mock_response
         ) as mock_post:
-            response = self.sketch.explore_wildcard(
-                query_string="*evil*", limit=10
-            )
+            response = self.sketch.explore_wildcard(query_string="*evil*", limit=10)
             self.assertEqual(response["objects"], [])
 
             mock_post.assert_called_once()
@@ -263,9 +261,7 @@ class SketchTest(unittest.TestCase):
         with mock.patch.object(
             self.api_client.session, "post", return_value=mock_response
         ) as mock_post:
-            response = self.sketch.explore_wildcard(
-                query_string="*evil*", limit=0
-            )
+            response = self.sketch.explore_wildcard(query_string="*evil*", limit=0)
             self.assertEqual(response["objects"], [])
 
             mock_post.assert_called_once()

--- a/api_client/python/timesketch_api_client/sketch_test.py
+++ b/api_client/python/timesketch_api_client/sketch_test.py
@@ -241,7 +241,7 @@ class SketchTest(unittest.TestCase):
             self.api_client.session, "post", return_value=mock_response
         ) as mock_post:
             response = self.sketch.explore_wildcard(
-                query_string="*evil*", fields="message", limit=10
+                query_string="*evil*", limit=10
             )
             self.assertEqual(response["objects"], [])
 
@@ -252,5 +252,22 @@ class SketchTest(unittest.TestCase):
             )
             self.assertEqual(call_args.args[0], expected_url)
             self.assertEqual(call_args.kwargs["json"]["query"], "*evil*")
-            self.assertEqual(call_args.kwargs["json"]["fields"], "message")
             self.assertEqual(call_args.kwargs["json"]["filter"]["size"], 10)
+
+    def test_explore_wildcard_limit_zero(self):
+        """Test explore_wildcard method with limit=0 parameter."""
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"meta": {}, "objects": []}
+
+        with mock.patch.object(
+            self.api_client.session, "post", return_value=mock_response
+        ) as mock_post:
+            response = self.sketch.explore_wildcard(
+                query_string="*evil*", limit=0
+            )
+            self.assertEqual(response["objects"], [])
+
+            mock_post.assert_called_once()
+            call_args = mock_post.call_args
+            self.assertEqual(call_args.kwargs["json"]["filter"]["size"], 0)

--- a/api_client/python/timesketch_api_client/sketch_test.py
+++ b/api_client/python/timesketch_api_client/sketch_test.py
@@ -230,3 +230,31 @@ class SketchTest(unittest.TestCase):
             with self.assertRaises(RuntimeError):
                 generator = self.sketch.export_events_stream()
                 list(generator)
+
+    def test_explore_wildcard(self):
+        """Test explore_wildcard method."""
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "meta": {},
+            "objects": []
+        }
+
+        with mock.patch.object(
+            self.api_client.session, "post", return_value=mock_response
+        ) as mock_post:
+            response = self.sketch.explore_wildcard(
+                query_string="*evil*",
+                fields="message",
+                limit=10
+            )
+            self.assertEqual(response["objects"], [])
+            
+            mock_post.assert_called_once()
+            call_args = mock_post.call_args
+            expected_url = f"http://127.0.0.1/api/v1/sketches/{self.sketch.id}/explore_wildcard/"
+            self.assertEqual(call_args.args[0], expected_url)
+            self.assertEqual(call_args.kwargs["json"]["query"], "*evil*")
+            self.assertEqual(call_args.kwargs["json"]["fields"], "message")
+            self.assertEqual(call_args.kwargs["json"]["filter"]["size"], 10)
+

--- a/api_client/python/timesketch_api_client/sketch_test.py
+++ b/api_client/python/timesketch_api_client/sketch_test.py
@@ -235,26 +235,22 @@ class SketchTest(unittest.TestCase):
         """Test explore_wildcard method."""
         mock_response = mock.Mock()
         mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "meta": {},
-            "objects": []
-        }
+        mock_response.json.return_value = {"meta": {}, "objects": []}
 
         with mock.patch.object(
             self.api_client.session, "post", return_value=mock_response
         ) as mock_post:
             response = self.sketch.explore_wildcard(
-                query_string="*evil*",
-                fields="message",
-                limit=10
+                query_string="*evil*", fields="message", limit=10
             )
             self.assertEqual(response["objects"], [])
-            
+
             mock_post.assert_called_once()
             call_args = mock_post.call_args
-            expected_url = f"http://127.0.0.1/api/v1/sketches/{self.sketch.id}/explore_wildcard/"
+            expected_url = (
+                f"http://127.0.0.1/api/v1/sketches/{self.sketch.id}/explore_wildcard/"
+            )
             self.assertEqual(call_args.args[0], expected_url)
             self.assertEqual(call_args.kwargs["json"]["query"], "*evil*")
             self.assertEqual(call_args.kwargs["json"]["fields"], "message")
             self.assertEqual(call_args.kwargs["json"]["filter"]["size"], 10)
-

--- a/cli_client/python/timesketch_cli_client/cli.py
+++ b/cli_client/python/timesketch_cli_client/cli.py
@@ -164,6 +164,7 @@ def cli(ctx, sketch, output):
 cli.add_command(config.config_group)
 cli.add_command(timelines.timelines_group)
 cli.add_command(search.search_group)
+cli.add_command(search.search_wildcard)
 cli.add_command(search.saved_searches_group)
 cli.add_command(analyze.analysis_group)
 cli.add_command(sketch_command.sketch_group)

--- a/cli_client/python/timesketch_cli_client/commands/search.py
+++ b/cli_client/python/timesketch_cli_client/commands/search.py
@@ -398,7 +398,8 @@ def search_wildcard(ctx: click.Context, query: str, fields: str, limit: int) -> 
     Args:
         ctx: Click Context object holding global settings and active sketch.
         query: The raw wildcard search pattern string (e.g. '*evil*').
-        fields: A comma-separated string of the document fields to perform the pattern search on.
+        fields: A comma-separated string of the document fields to perform the
+            pattern search on.
         limit: Max integer limit of matching event hits to return.
     """
     sketch = ctx.obj.sketch
@@ -408,7 +409,7 @@ def search_wildcard(ctx: click.Context, query: str, fields: str, limit: int) -> 
             fields=fields,
             limit=limit,
         )
-    except Exception as e:
+    except Exception as e:  # pylint: disable=broad-exception-caught
         click.echo(f"Error executing wildcard search: {e}", err=True)
         sys.exit(1)
 

--- a/cli_client/python/timesketch_cli_client/commands/search.py
+++ b/cli_client/python/timesketch_cli_client/commands/search.py
@@ -373,13 +373,7 @@ def describe_saved_search(ctx: click.Context, search_id: int):
     "--query",
     "-q",
     required=True,
-    help="Search query in raw wildcard format (e.g. *evil*)",
-)
-@click.option(
-    "--fields",
-    "-f",
-    default="message",
-    help="Comma-separated string of fields to match (default: message)",
+    help="Search query in raw wildcard format (e.g. *evil* or message:*evil*)",
 )
 @click.option(
     "--limit",
@@ -388,7 +382,7 @@ def describe_saved_search(ctx: click.Context, search_id: int):
     help="Limit amount of events to show (default: 40)",
 )
 @click.pass_context
-def search_wildcard(ctx: click.Context, query: str, fields: str, limit: int) -> None:
+def search_wildcard(ctx: click.Context, query: str, limit: int) -> None:
     """Explore a Timesketch sketch with raw wildcard queries (Skeleton endpoint).
 
     This CLI command issues a raw POST query request to the backend database
@@ -397,16 +391,14 @@ def search_wildcard(ctx: click.Context, query: str, fields: str, limit: int) -> 
 
     Args:
         ctx: Click Context object holding global settings and active sketch.
-        query: The raw wildcard search pattern string (e.g. '*evil*').
-        fields: A comma-separated string of the document fields to perform the
-            pattern search on.
+        query: The raw wildcard search pattern string (e.g. '*evil*' or
+            'message:*evil*').
         limit: Max integer limit of matching event hits to return.
     """
     sketch = ctx.obj.sketch
     try:
         results = sketch.explore_wildcard(
             query_string=query,
-            fields=fields,
             limit=limit,
         )
     except Exception as e:  # pylint: disable=broad-exception-caught

--- a/cli_client/python/timesketch_cli_client/commands/search.py
+++ b/cli_client/python/timesketch_cli_client/commands/search.py
@@ -416,4 +416,3 @@ def search_wildcard(ctx: click.Context, query: str, fields: str, limit: int) -> 
     # models, we should adapt the Click search-wildcard command to use the unified
     # format_output utility to provide clean, aligned tabular/CSV presentation layouts.
     click.echo(json.dumps(results.get("objects", []), indent=2))
-

--- a/cli_client/python/timesketch_cli_client/commands/search.py
+++ b/cli_client/python/timesketch_cli_client/commands/search.py
@@ -366,3 +366,54 @@ def describe_saved_search(ctx: click.Context, search_id: int):
     filter_pretty = json.dumps(saved_search.query_filter, indent=2)
     click.echo(f"query_string: {saved_search.query_string}")
     click.echo(f"query_filter: {filter_pretty}")
+
+
+@click.command("search-wildcard")
+@click.option(
+    "--query",
+    "-q",
+    required=True,
+    help="Search query in raw wildcard format (e.g. *evil*)",
+)
+@click.option(
+    "--fields",
+    "-f",
+    default="message",
+    help="Comma-separated string of fields to match (default: message)",
+)
+@click.option(
+    "--limit",
+    type=int,
+    default=40,
+    help="Limit amount of events to show (default: 40)",
+)
+@click.pass_context
+def search_wildcard(ctx: click.Context, query: str, fields: str, limit: int) -> None:
+    """Explore a Timesketch sketch with raw wildcard queries (Skeleton endpoint).
+
+    This CLI command issues a raw POST query request to the backend database
+    bypassing standard query string parser tokenization, allowing exact
+    substring pattern matching on a selected target field list.
+
+    Args:
+        ctx: Click Context object holding global settings and active sketch.
+        query: The raw wildcard search pattern string (e.g. '*evil*').
+        fields: A comma-separated string of the document fields to perform the pattern search on.
+        limit: Max integer limit of matching event hits to return.
+    """
+    sketch = ctx.obj.sketch
+    try:
+        results = sketch.explore_wildcard(
+            query_string=query,
+            fields=fields,
+            limit=limit,
+        )
+    except Exception as e:
+        click.echo(f"Error executing wildcard search: {e}", err=True)
+        sys.exit(1)
+
+    # TODO: Once the API client supports returning Pandas DataFrames or Search
+    # models, we should adapt the Click search-wildcard command to use the unified
+    # format_output utility to provide clean, aligned tabular/CSV presentation layouts.
+    click.echo(json.dumps(results.get("objects", []), indent=2))
+

--- a/cli_client/python/timesketch_cli_client/commands/search_test.py
+++ b/cli_client/python/timesketch_cli_client/commands/search_test.py
@@ -135,13 +135,12 @@ class SearchTest(unittest.TestCase):
         runner = CliRunner()
         result = runner.invoke(
             search_wildcard,
-            ["--query", "*evil*", "--fields", "message,xml_string", "--limit", "10"],
+            ["--query", "*evil*", "--limit", "10"],
             obj=self.ctx,
         )
         self.assertEqual(result.exit_code, 0)
         self.assertIn("[]", result.output)
         mock_explore_wildcard.assert_called_once_with(
             query_string="*evil*",
-            fields="message,xml_string",
             limit=10,
         )

--- a/cli_client/python/timesketch_cli_client/commands/search_test.py
+++ b/cli_client/python/timesketch_cli_client/commands/search_test.py
@@ -23,6 +23,7 @@ from timesketch_api_client import test_lib as api_test_lib
 from .. import test_lib
 from .search import saved_searches_group
 from .search import search_group
+from .search import search_wildcard
 
 EXPECTED_OUTPUT = """query_string: test:"foobar"
 query_filter: {
@@ -125,3 +126,25 @@ class SearchTest(unittest.TestCase):
         self.assertIn("event1 1234567890123 2023-01-01T00:00:00", normalized_output)
         self.assertIn("event2 4567890123456 2023-01-02T00:00:00", normalized_output)
         mock_search_instance.to_pandas.assert_called_once()
+
+    @mock.patch("timesketch_api_client.sketch.Sketch.explore_wildcard")
+    def test_search_wildcard(self, mock_explore_wildcard):
+        """Test the 'search-wildcard' command."""
+        mock_explore_wildcard.return_value = {
+            "meta": {},
+            "objects": []
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(
+            search_wildcard,
+            ["--query", "*evil*", "--fields", "message,xml_string", "--limit", "10"],
+            obj=self.ctx,
+        )
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("[]", result.output)
+        mock_explore_wildcard.assert_called_once_with(
+            query_string="*evil*",
+            fields="message,xml_string",
+            limit=10,
+        )

--- a/cli_client/python/timesketch_cli_client/commands/search_test.py
+++ b/cli_client/python/timesketch_cli_client/commands/search_test.py
@@ -130,10 +130,7 @@ class SearchTest(unittest.TestCase):
     @mock.patch("timesketch_api_client.sketch.Sketch.explore_wildcard")
     def test_search_wildcard(self, mock_explore_wildcard):
         """Test the 'search-wildcard' command."""
-        mock_explore_wildcard.return_value = {
-            "meta": {},
-            "objects": []
-        }
+        mock_explore_wildcard.return_value = {"meta": {}, "objects": []}
 
         runner = CliRunner()
         result = runner.invoke(

--- a/timesketch/api/v1/resources/explore.py
+++ b/timesketch/api/v1/resources/explore.py
@@ -643,3 +643,88 @@ class SearchHistoryTreeResource(resources.ResourceMixin, Resource):
         }
 
         return jsonify(schema)
+
+
+class ExploreWildcardResource(resources.ResourceMixin, Resource):
+    """Explore resources for running wildcard queries on the datastore.
+
+    This API endpoint allows exact-match wildcard searching on targeted document
+    fields (e.g. message, xml_string), bypassing standard Lucene string query
+    parser tokenization.
+    """
+
+    @login_required
+    def post(self, sketch_id: int):
+        """Handles POST request to the resource.
+
+        Handler for /api/v1/sketches/:sketch_id/explore_wildcard/
+
+        Args:
+            sketch_id: Integer primary key for a sketch database model.
+
+        Input JSON parameters (request body):
+            query (str): Raw wildcard search expression (e.g. '*evil_term*').
+            fields (str): Comma-separated list of targeted fields (default: 'message').
+            filter (dict): Optional dictionary representing search filters (e.g. size/limit).
+
+        Returns:
+            A Flask Response (JSON format) containing the skeleton search response,
+            including an empty hits list.
+
+        Raises:
+            HTTPStatus.NOT_FOUND (404): If the sketch cannot be found.
+            HTTPStatus.FORBIDDEN (403): If current user lacks read permissions on sketch.
+            HTTPStatus.BAD_REQUEST (400): If the sketch is currently archived.
+        """
+        sketch = Sketch.get_with_acl(sketch_id)
+        if not sketch:
+            abort(HTTP_STATUS_CODE_NOT_FOUND, "No sketch found with this ID.")
+
+        if not sketch.has_permission(current_user, "read"):
+            abort(
+                HTTP_STATUS_CODE_FORBIDDEN,
+                "User does not have read access controls on sketch.",
+            )
+
+        if sketch.get_status.status == "archived":
+            abort(
+                HTTP_STATUS_CODE_BAD_REQUEST, "Unable to query on an archived sketch."
+            )
+
+        # TODO: In the actual search execution phase (Iteration 2), we should define a
+        # custom forms.ExploreWildcardForm class. This sanitizes parameters from dynamic
+        # JSON request injections, checks for safe query string bounds (like minimum safe
+        # search terms lengths), and standardizes format exceptions.
+        # For this first skeleton iteration, we just accept the query and fields parameters
+        # but do not build the raw OpenSearch search query yet.
+        request_data = request.json or {}
+        query_string = request_data.get("query", "")
+
+        fields_raw = request_data.get("fields", "message")
+        if isinstance(fields_raw, str):
+            fields_list = [f.strip() for f in fields_raw.split(",") if f.strip()]
+        elif isinstance(fields_raw, list):
+            fields_list = [str(f).strip() for f in fields_raw if str(f).strip()]
+        else:
+            fields_list = ["message"]
+
+        if not fields_list:
+            fields_list = ["message"]
+
+        # Return a valid standard skeleton search JSON structure
+        meta = {
+            "fields_list": fields_list,
+            "es_time": 0,
+            "es_total_count": 0,
+            "es_total_count_complete": 0,
+            "timeline_colors": {},
+            "timeline_names": {},
+            "count_per_index": {},
+            "count_per_timeline": {},
+            "count_over_time": {"data": {}, "interval": ""},
+            "scroll_id": "",
+            "search_node": None,
+        }
+        schema = {"meta": meta, "objects": []}
+        return jsonify(schema)
+

--- a/timesketch/api/v1/resources/explore.py
+++ b/timesketch/api/v1/resources/explore.py
@@ -735,7 +735,8 @@ class ExploreWildcardResource(resources.ResourceMixin, Resource):
             wildcard_query = query_string
 
         logger.info(
-            "ExploreWildcardResource: Sketch ID: %d, Query: %r, Extracted Fields: %r, Extracted Wildcard Query: %r",
+            "ExploreWildcardResource: Sketch ID: %d, Query: %r, "
+            "Extracted Fields: %r, Extracted Wildcard Query: %r",
             sketch_id,
             query_string,
             fields_list,

--- a/timesketch/api/v1/resources/explore.py
+++ b/timesketch/api/v1/resources/explore.py
@@ -665,7 +665,8 @@ class ExploreWildcardResource(resources.ResourceMixin, Resource):
         Input JSON parameters (request body):
             query (str): Raw wildcard search expression (e.g. '*evil_term*').
             fields (str): Comma-separated list of targeted fields (default: 'message').
-            filter (dict): Optional dictionary representing search filters (e.g. size/limit).
+            filter (dict): Optional dictionary representing search filters
+                (e.g. size/limit).
 
         Returns:
             A Flask Response (JSON format) containing the skeleton search response,
@@ -673,7 +674,8 @@ class ExploreWildcardResource(resources.ResourceMixin, Resource):
 
         Raises:
             HTTPStatus.NOT_FOUND (404): If the sketch cannot be found.
-            HTTPStatus.FORBIDDEN (403): If current user lacks read permissions on sketch.
+            HTTPStatus.FORBIDDEN (403): If current user lacks read
+                permissions on sketch.
             HTTPStatus.BAD_REQUEST (400): If the sketch is currently archived.
         """
         sketch = Sketch.get_with_acl(sketch_id)
@@ -691,12 +693,29 @@ class ExploreWildcardResource(resources.ResourceMixin, Resource):
                 HTTP_STATUS_CODE_BAD_REQUEST, "Unable to query on an archived sketch."
             )
 
-        # TODO: In the actual search execution phase (Iteration 2), we should define a
-        # custom forms.ExploreWildcardForm class. This sanitizes parameters from dynamic
-        # JSON request injections, checks for safe query string bounds (like minimum safe
-        # search terms lengths), and standardizes format exceptions.
-        # For this first skeleton iteration, we just accept the query and fields parameters
-        # but do not build the raw OpenSearch search query yet.
+        # Resolve active search indices in the sketch
+        all_timeline_ids = [t.id for t in sketch.timelines]
+        indices, _ = get_validated_indices(all_timeline_ids, sketch)
+        indices = utils.validate_indices(indices, self.datastore)
+        if not indices:
+            abort(
+                HTTP_STATUS_CODE_BAD_REQUEST,
+                "No active timelines with valid search indices found in this sketch.",
+            )
+
+        # TODO: In the actual search execution phase (Iteration 2), we should verify
+        # that the target fields in these indices support non-tokenized exact
+        # wildcard matching (i.e. they are mapped as 'keyword' type or possess a
+        # '.keyword' multi-field). If none of the requested fields are suitable
+        # for exact wildcard matching, we should raise a 400 Bad Request error.
+
+        # TODO: In the actual search execution phase (Iteration 2), we should
+        # define a custom forms.ExploreWildcardForm class. This sanitizes
+        # parameters from dynamic JSON request injections, checks for safe query
+        # string bounds (like minimum safe search terms lengths), and
+        # standardizes format exceptions. For this first skeleton iteration, we
+        # just accept the query and fields parameters but do not build the raw
+        # OpenSearch search query yet.
         request_data = request.json or {}
         query_string = request_data.get("query", "")
 

--- a/timesketch/api/v1/resources/explore.py
+++ b/timesketch/api/v1/resources/explore.py
@@ -734,4 +734,3 @@ class ExploreWildcardResource(resources.ResourceMixin, Resource):
         }
         schema = {"meta": meta, "objects": []}
         return jsonify(schema)
-

--- a/timesketch/api/v1/resources/explore.py
+++ b/timesketch/api/v1/resources/explore.py
@@ -711,6 +711,13 @@ class ExploreWildcardResource(resources.ResourceMixin, Resource):
         if not fields_list:
             fields_list = ["message"]
 
+        logger.info(
+            "ExploreWildcardResource: Sketch ID: %d, Wildcard Query: %r, Fields: %r",
+            sketch_id,
+            query_string,
+            fields_list,
+        )
+
         # Return a valid standard skeleton search JSON structure
         meta = {
             "fields_list": fields_list,

--- a/timesketch/api/v1/resources/explore.py
+++ b/timesketch/api/v1/resources/explore.py
@@ -663,8 +663,8 @@ class ExploreWildcardResource(resources.ResourceMixin, Resource):
             sketch_id: Integer primary key for a sketch database model.
 
         Input JSON parameters (request body):
-            query (str): Raw wildcard search expression (e.g. '*evil_term*').
-            fields (str): Comma-separated list of targeted fields (default: 'message').
+            query (str): Raw wildcard search expression (e.g. '*evil_term*' or
+                'message:*evil*').
             filter (dict): Optional dictionary representing search filters
                 (e.g. size/limit).
 
@@ -703,11 +703,12 @@ class ExploreWildcardResource(resources.ResourceMixin, Resource):
                 "No active timelines with valid search indices found in this sketch.",
             )
 
-        # TODO: In the actual search execution phase (Iteration 2), we should verify
-        # that the target fields in these indices support non-tokenized exact
-        # wildcard matching (i.e. they are mapped as 'keyword' type or possess a
-        # '.keyword' multi-field). If none of the requested fields are suitable
-        # for exact wildcard matching, we should raise a 400 Bad Request error.
+        # TODO: In the actual search execution phase (Iteration 2), we must verify
+        # that the target fields in these indices possess a specific '.wildcard'
+        # subfield of type 'wildcard'. We want to work ONLY with the 'wildcard'
+        # field type (not 'keyword' or standard 'text' types) to ensure high-performance
+        # leading wildcard matching. If no suitable 'wildcard' type mappings are
+        # present, we should raise a 400 Bad Request error.
 
         # TODO: In the actual search execution phase (Iteration 2), we should
         # define a custom forms.ExploreWildcardForm class. This sanitizes
@@ -717,29 +718,34 @@ class ExploreWildcardResource(resources.ResourceMixin, Resource):
         # just accept the query and fields parameters but do not build the raw
         # OpenSearch search query yet.
         request_data = request.json or {}
-        query_string = request_data.get("query", "")
+        query_string = request_data.get("query", "").strip()
+        if not query_string:
+            abort(
+                HTTP_STATUS_CODE_BAD_REQUEST,
+                "A non-empty 'query' parameter is required.",
+            )
 
-        fields_raw = request_data.get("fields", "message")
-        if isinstance(fields_raw, str):
-            fields_list = [f.strip() for f in fields_raw.split(",") if f.strip()]
-        elif isinstance(fields_raw, list):
-            fields_list = [str(f).strip() for f in fields_raw if str(f).strip()]
+        # Parse query prefix pattern (e.g. field_name:search_pattern)
+        if ":" in query_string:
+            field_prefix, search_pattern = query_string.split(":", 1)
+            fields_list = [field_prefix.strip()]
+            wildcard_query = search_pattern.strip()
         else:
             fields_list = ["message"]
-
-        if not fields_list:
-            fields_list = ["message"]
+            wildcard_query = query_string
 
         logger.info(
-            "ExploreWildcardResource: Sketch ID: %d, Wildcard Query: %r, Fields: %r",
+            "ExploreWildcardResource: Sketch ID: %d, Query: %r, Extracted Fields: %r, Extracted Wildcard Query: %r",
             sketch_id,
             query_string,
             fields_list,
+            wildcard_query,
         )
 
         # Return a valid standard skeleton search JSON structure
         meta = {
             "fields_list": fields_list,
+            "wildcard_query": wildcard_query,
             "es_time": 0,
             "es_total_count": 0,
             "es_total_count_complete": 0,

--- a/timesketch/api/v1/resources_test.py
+++ b/timesketch/api/v1/resources_test.py
@@ -821,12 +821,10 @@ class ExploreWildcardResourceTest(BaseTest):
     def test_archived_sketch(self):
         """Authenticated request to query an archived sketch."""
         self.login()
-        
+
         # Create a dedicated sketch for this test to prevent test pollution
         sketch = self._create_sketch(
-            name="archived_test_sketch",
-            user=self.user1,
-            acl=True
+            name="archived_test_sketch", user=self.user1, acl=True
         )
         sketch.set_status("archived")
         db_session.commit()

--- a/timesketch/api/v1/resources_test.py
+++ b/timesketch/api/v1/resources_test.py
@@ -821,13 +821,20 @@ class ExploreWildcardResourceTest(BaseTest):
     def test_archived_sketch(self):
         """Authenticated request to query an archived sketch."""
         self.login()
-        sketch = Sketch.get_by_id(1)
+        
+        # Create a dedicated sketch for this test to prevent test pollution
+        sketch = self._create_sketch(
+            name="archived_test_sketch",
+            user=self.user1,
+            acl=True
+        )
         sketch.set_status("archived")
         db_session.commit()
 
         data = {"query": "test", "fields": "message"}
+        resource_url = f"/api/v1/sketches/{sketch.id}/explore_wildcard/"
         response = self.client.post(
-            self.resource_url,
+            resource_url,
             data=json.dumps(data, ensure_ascii=False),
             content_type="application/json",
         )

--- a/timesketch/api/v1/resources_test.py
+++ b/timesketch/api/v1/resources_test.py
@@ -832,7 +832,9 @@ class ExploreWildcardResourceTest(BaseTest):
             content_type="application/json",
         )
         self.assertEqual(response.status_code, HTTP_STATUS_CODE_BAD_REQUEST)
-        self.assertIn("Unable to query on an archived sketch.", response.json["message"])
+        self.assertIn(
+            "Unable to query on an archived sketch.", response.json["message"]
+        )
 
     @mock.patch("timesketch.api.v1.resources.OpenSearchDataStore", MockDataStore)
     def test_non_existent_sketch(self):
@@ -887,7 +889,6 @@ class ExploreWildcardResourceTest(BaseTest):
         self.assert200(response)
         fields_list = response.json["meta"]["fields_list"]
         self.assertEqual(fields_list, ["message"])
-
 
 
 class AggregationExploreResourceTest(BaseTest):

--- a/timesketch/api/v1/resources_test.py
+++ b/timesketch/api/v1/resources_test.py
@@ -805,7 +805,7 @@ class ExploreWildcardResourceTest(BaseTest):
     def test_search_skeleton(self):
         """Authenticated request to query the skeleton datastore."""
         self.login()
-        data = {"query": "test", "fields": "message"}
+        data = {"query": "test"}
         response = self.client.post(
             self.resource_url,
             data=json.dumps(data, ensure_ascii=False),
@@ -829,7 +829,7 @@ class ExploreWildcardResourceTest(BaseTest):
         sketch.set_status("archived")
         db_session.commit()
 
-        data = {"query": "test", "fields": "message"}
+        data = {"query": "test"}
         resource_url = f"/api/v1/sketches/{sketch.id}/explore_wildcard/"
         response = self.client.post(
             resource_url,
@@ -845,7 +845,7 @@ class ExploreWildcardResourceTest(BaseTest):
     def test_non_existent_sketch(self):
         """Authenticated request to query a non-existent sketch."""
         self.login()
-        data = {"query": "test", "fields": "message"}
+        data = {"query": "test"}
         response = self.client.post(
             "/api/v1/sketches/999/explore_wildcard/",
             data=json.dumps(data, ensure_ascii=False),
@@ -854,46 +854,64 @@ class ExploreWildcardResourceTest(BaseTest):
         self.assert404(response)
 
     @mock.patch("timesketch.api.v1.resources.OpenSearchDataStore", MockDataStore)
-    def test_fields_parsing_string(self):
-        """Test that fields passed as a comma-separated string are parsed correctly."""
+    def test_query_parsing_with_prefix(self):
+        """Test that query strings with a field prefix are parsed correctly."""
         self.login()
-        data = {"query": "test", "fields": "message, xml_string"}
+        data = {"query": "xml_string:*evil*"}
         response = self.client.post(
             self.resource_url,
             data=json.dumps(data, ensure_ascii=False),
             content_type="application/json",
         )
         self.assert200(response)
-        fields_list = response.json["meta"]["fields_list"]
-        self.assertEqual(fields_list, ["message", "xml_string"])
+        meta = response.json["meta"]
+        self.assertEqual(meta["fields_list"], ["xml_string"])
+        self.assertEqual(meta["wildcard_query"], "*evil*")
 
     @mock.patch("timesketch.api.v1.resources.OpenSearchDataStore", MockDataStore)
-    def test_fields_parsing_list(self):
-        """Test that fields passed as a list of strings are parsed correctly."""
+    def test_query_parsing_without_prefix(self):
+        """Test that query strings without a field prefix get a default field list."""
         self.login()
-        data = {"query": "test", "fields": ["message", "xml_string"]}
+        data = {"query": "*evil*"}
         response = self.client.post(
             self.resource_url,
             data=json.dumps(data, ensure_ascii=False),
             content_type="application/json",
         )
         self.assert200(response)
-        fields_list = response.json["meta"]["fields_list"]
-        self.assertEqual(fields_list, ["message", "xml_string"])
+        meta = response.json["meta"]
+        self.assertEqual(meta["fields_list"], ["message"])
+        self.assertEqual(meta["wildcard_query"], "*evil*")
 
     @mock.patch("timesketch.api.v1.resources.OpenSearchDataStore", MockDataStore)
-    def test_fields_parsing_default(self):
-        """Test that fields parameter defaults to ['message'] if not specified."""
+    def test_query_parsing_multiple_colons(self):
+        """Test that query splits on the first colon when multiple are present."""
         self.login()
-        data = {"query": "test"}
+        data = {"query": "xml_string:<xml>*:*</xml>"}
         response = self.client.post(
             self.resource_url,
             data=json.dumps(data, ensure_ascii=False),
             content_type="application/json",
         )
         self.assert200(response)
-        fields_list = response.json["meta"]["fields_list"]
-        self.assertEqual(fields_list, ["message"])
+        meta = response.json["meta"]
+        self.assertEqual(meta["fields_list"], ["xml_string"])
+        self.assertEqual(meta["wildcard_query"], "<xml>*:*</xml>")
+
+    @mock.patch("timesketch.api.v1.resources.OpenSearchDataStore", MockDataStore)
+    def test_query_parsing_empty_query(self):
+        """Test that empty or missing query string raises a Bad Request error."""
+        self.login()
+        data = {"query": "   "}
+        response = self.client.post(
+            self.resource_url,
+            data=json.dumps(data, ensure_ascii=False),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, HTTP_STATUS_CODE_BAD_REQUEST)
+        self.assertIn(
+            "A non-empty 'query' parameter is required.", response.json["message"]
+        )
 
 
 class AggregationExploreResourceTest(BaseTest):

--- a/timesketch/api/v1/resources_test.py
+++ b/timesketch/api/v1/resources_test.py
@@ -796,6 +796,100 @@ class ExploreResourceTest(BaseTest):
             self.assertIn("Timeout", response.json["message"])
 
 
+class ExploreWildcardResourceTest(BaseTest):
+    """Test ExploreWildcardResource."""
+
+    resource_url = "/api/v1/sketches/1/explore_wildcard/"
+
+    @mock.patch("timesketch.api.v1.resources.OpenSearchDataStore", MockDataStore)
+    def test_search_skeleton(self):
+        """Authenticated request to query the skeleton datastore."""
+        self.login()
+        data = {"query": "test", "fields": "message"}
+        response = self.client.post(
+            self.resource_url,
+            data=json.dumps(data, ensure_ascii=False),
+            content_type="application/json",
+        )
+        self.assert200(response)
+        response_json = response.json
+        self.assertIn("meta", response_json)
+        self.assertIn("objects", response_json)
+        self.assertEqual(response_json["objects"], [])
+
+    @mock.patch("timesketch.api.v1.resources.OpenSearchDataStore", MockDataStore)
+    def test_archived_sketch(self):
+        """Authenticated request to query an archived sketch."""
+        self.login()
+        sketch = Sketch.get_by_id(1)
+        sketch.set_status("archived")
+        db_session.commit()
+
+        data = {"query": "test", "fields": "message"}
+        response = self.client.post(
+            self.resource_url,
+            data=json.dumps(data, ensure_ascii=False),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, HTTP_STATUS_CODE_BAD_REQUEST)
+        self.assertIn("Unable to query on an archived sketch.", response.json["message"])
+
+    @mock.patch("timesketch.api.v1.resources.OpenSearchDataStore", MockDataStore)
+    def test_non_existent_sketch(self):
+        """Authenticated request to query a non-existent sketch."""
+        self.login()
+        data = {"query": "test", "fields": "message"}
+        response = self.client.post(
+            "/api/v1/sketches/999/explore_wildcard/",
+            data=json.dumps(data, ensure_ascii=False),
+            content_type="application/json",
+        )
+        self.assert404(response)
+
+    @mock.patch("timesketch.api.v1.resources.OpenSearchDataStore", MockDataStore)
+    def test_fields_parsing_string(self):
+        """Test that fields passed as a comma-separated string are parsed correctly."""
+        self.login()
+        data = {"query": "test", "fields": "message, xml_string"}
+        response = self.client.post(
+            self.resource_url,
+            data=json.dumps(data, ensure_ascii=False),
+            content_type="application/json",
+        )
+        self.assert200(response)
+        fields_list = response.json["meta"]["fields_list"]
+        self.assertEqual(fields_list, ["message", "xml_string"])
+
+    @mock.patch("timesketch.api.v1.resources.OpenSearchDataStore", MockDataStore)
+    def test_fields_parsing_list(self):
+        """Test that fields passed as a list of strings are parsed correctly."""
+        self.login()
+        data = {"query": "test", "fields": ["message", "xml_string"]}
+        response = self.client.post(
+            self.resource_url,
+            data=json.dumps(data, ensure_ascii=False),
+            content_type="application/json",
+        )
+        self.assert200(response)
+        fields_list = response.json["meta"]["fields_list"]
+        self.assertEqual(fields_list, ["message", "xml_string"])
+
+    @mock.patch("timesketch.api.v1.resources.OpenSearchDataStore", MockDataStore)
+    def test_fields_parsing_default(self):
+        """Test that fields parameter defaults to ['message'] if not specified."""
+        self.login()
+        data = {"query": "test"}
+        response = self.client.post(
+            self.resource_url,
+            data=json.dumps(data, ensure_ascii=False),
+            content_type="application/json",
+        )
+        self.assert200(response)
+        fields_list = response.json["meta"]["fields_list"]
+        self.assertEqual(fields_list, ["message"])
+
+
+
 class AggregationExploreResourceTest(BaseTest):
     """Test AggregationExploreResource."""
 

--- a/timesketch/api/v1/routes.py
+++ b/timesketch/api/v1/routes.py
@@ -27,6 +27,7 @@ from .resources.attribute import AttributeResource
 from .resources.explore import ExploreResource
 from .resources.explore import SearchHistoryResource
 from .resources.explore import SearchHistoryTreeResource
+from .resources.explore import ExploreWildcardResource
 from .resources.exportstream import ExportStreamListResource
 from .resources.datafinder import DataFinderResource
 from .resources.datasource import DataSourceResource
@@ -131,6 +132,10 @@ API_ROUTES = [
         "/sketches/<int:sketch_id>/aggregation/<int:aggregation_id>/",
     ),
     (ExploreResource, "/sketches/<int:sketch_id>/explore/"),
+    (
+        ExploreWildcardResource,
+        "/sketches/<int:sketch_id>/explore_wildcard/",
+    ),
     (SearchHistoryResource, "/sketches/<int:sketch_id>/searchhistory/"),
     (
         SearchHistoryTreeResource,


### PR DESCRIPTION
Implementing the initial skeleton and routing for a new backend function `ExploreWildcardResource` and supporting Timesketch CLI client tools. This creates the architectural foundation for subsequent raw OpenSearch wildcard query work in small, reviewable increments.
