### PR TITLE
Upgrade some frontend-ng dependencies

### DIFF
--- a/timesketch/frontend-ng/package.json
+++ b/timesketch/frontend-ng/package.json
@@ -16,7 +16,8 @@
     "fast-uri": "3.1.2",
     "js-cookie": "3.0.8",
     "node-forge": "1.4.0",
-    "@babel/plugin-transform-modules-systemjs": "7.29.7"
+    "@babel/plugin-transform-modules-systemjs": "7.29.7",
+    "shell-quote": "1.8.4"
   },
   "dependencies": {
     "@mdi/font": "^7.1.96",

--- a/timesketch/frontend-ng/package.json
+++ b/timesketch/frontend-ng/package.json
@@ -11,7 +11,7 @@
   },
   "resolutions": {
     "qs": "6.14.1",
-    "serialize-javascript": "^7.0.3",
+    "serialize-javascript": "^7.0.5",
     "minimatch": "^9.0.7",
     "fast-uri": "3.1.2",
     "js-cookie": "3.0.8",

--- a/timesketch/frontend-ng/package.json
+++ b/timesketch/frontend-ng/package.json
@@ -18,7 +18,8 @@
     "node-forge": "1.4.0",
     "@babel/plugin-transform-modules-systemjs": "7.29.7",
     "shell-quote": "1.8.4",
-    "uuid": "11.1.1"
+    "uuid": "11.1.1",
+    "postcss": "^8.5.15"
   },
   "dependencies": {
     "@mdi/font": "^7.1.96",

--- a/timesketch/frontend-ng/package.json
+++ b/timesketch/frontend-ng/package.json
@@ -17,7 +17,8 @@
     "js-cookie": "3.0.8",
     "node-forge": "1.4.0",
     "@babel/plugin-transform-modules-systemjs": "7.29.7",
-    "shell-quote": "1.8.4"
+    "shell-quote": "1.8.4",
+    "uuid": "11.1.1"
   },
   "dependencies": {
     "@mdi/font": "^7.1.96",

--- a/timesketch/frontend-ng/src/utils/ThreatIntelMetadata.js
+++ b/timesketch/frontend-ng/src/utils/ThreatIntelMetadata.js
@@ -1,5 +1,5 @@
 const IOCTypes = [
-    { regex: /^(\/[\S]+)+$/i, type: 'fs_path', humanReadable: 'Filesystem path' },
+    { regex: /^(\/[^\s/]+)+$/i, type: 'fs_path', humanReadable: 'Filesystem path' },
     { regex: /^([-\w]+\.)+[a-z]{2,}$/i, type: 'hostname', humanReadable: 'Hostname' },
     {
       regex: /^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/g,

--- a/timesketch/frontend-ng/yarn.lock
+++ b/timesketch/frontend-ng/yarn.lock
@@ -7485,10 +7485,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@^1.8.3:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.3.tgz#55e40ef33cf5c689902353a3d8cd1a6725f08b4b"
-  integrity sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==
+shell-quote@1.8.4, shell-quote@^1.8.3:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.4.tgz#2edd9a4dcefc96649e2e2cb12f637b1f1d92a190"
+  integrity sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==
 
 side-channel-list@^1.0.0:
   version "1.0.0"

--- a/timesketch/frontend-ng/yarn.lock
+++ b/timesketch/frontend-ng/yarn.lock
@@ -7377,10 +7377,10 @@ send@~0.19.0, send@~0.19.1:
     range-parser "~1.2.1"
     statuses "~2.0.2"
 
-serialize-javascript@^6.0.0, serialize-javascript@^6.0.2, serialize-javascript@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.3.tgz#c92008d8a21bc7b2307c2e885a4bd0f03b2aee6c"
-  integrity sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==
+serialize-javascript@^6.0.0, serialize-javascript@^6.0.2, serialize-javascript@^7.0.5:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.5.tgz#c798cc0552ffbb08981914a42a8756e339d0d5b1"
+  integrity sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==
 
 serve-index@^1.9.1:
   version "1.9.2"

--- a/timesketch/frontend-ng/yarn.lock
+++ b/timesketch/frontend-ng/yarn.lock
@@ -8178,10 +8178,10 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@11.1.1, uuid@^8.3.2:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 v-calendar@2.4.1:
   version "2.4.1"

--- a/timesketch/frontend-ng/yarn.lock
+++ b/timesketch/frontend-ng/yarn.lock
@@ -6582,11 +6582,6 @@ pathval@^2.0.0:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-2.0.1.tgz#8855c5a2899af072d6ac05d11e46045ad0dc605d"
   integrity sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==
 
-picocolors@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-0.2.1.tgz#570670f793646851d1ba135996962abad587859f"
-  integrity sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==
-
 picocolors@^1.0.0, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
@@ -6877,15 +6872,7 @@ postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^7.0.36:
-  version "7.0.39"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.39.tgz#9624375d965630e2e1f2c02a935c82a59cb48309"
-  integrity sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==
-  dependencies:
-    picocolors "^0.2.1"
-    source-map "^0.6.1"
-
-postcss@^8.2.6, postcss@^8.3.5, postcss@^8.4.14, postcss@^8.4.33, postcss@^8.5.3, postcss@^8.5.6:
+postcss@^7.0.36, postcss@^8.2.6, postcss@^8.3.5, postcss@^8.4.14, postcss@^8.4.33, postcss@^8.5.15, postcss@^8.5.3, postcss@^8.5.6:
   version "8.5.15"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.15.tgz#d1eaf677a324e9ec02196da2d3fecf4a0b9a735c"
   integrity sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==


### PR DESCRIPTION
This PR updates the dependencies for `shell-quote`, `uuid`, `postcss` and `serialize-janascript`.

+ A small fix for an in-efficient regex section.