### PR TITLE
ci: Restrict default GITHUB_TOKEN permissions to read-only across all workflows

### DIFF
--- a/.github/workflows/build_frontend-ng.yml
+++ b/.github/workflows/build_frontend-ng.yml
@@ -9,6 +9,9 @@ on:
       - '!timesketch/frontend-ng/dist/**' # Exclude changes in the dist folder
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-frontend-ng:
     timeout-minutes: 30

--- a/.github/workflows/build_frontend-v3.yml
+++ b/.github/workflows/build_frontend-v3.yml
@@ -9,6 +9,9 @@ on:
       - '!timesketch/frontend-v3/dist/**' # Exclude changes in the dist folder
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-frontend-v3:
     timeout-minutes: 30

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -7,6 +7,10 @@ on:
     paths:
       - 'docs/**'
   workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -11,6 +11,9 @@ on:
       - 'timesketch/frontend-ng/**'
       - 'timesketch/frontend-v3/**'
 
+permissions:
+  contents: read
+
 jobs:
   PyPi-plaso-stable-opensearch-v2-ubuntu2604:
     runs-on: ubuntu-latest

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   PyLint:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,6 +8,9 @@ on:
       - '.gitignore'
       - 'README.md'
 
+permissions:
+  contents: read
+
 jobs:
   # Backend tests (Python/Flask)
   Python:


### PR DESCRIPTION
This PR adds an explicit `permissions: { contents: read }` block to all 6 GitHub Actions workflows in `.github/workflows/`. 

This addresses the GitHub CodeQL warning `actions/missing-workflow-permissions` by enforcing the principle of least privilege, ensuring that the default `GITHUB_TOKEN` generated for workflow runs does not inherit write permissions.

#### **Why is this safe?**
None of the workflows rely on the default `GITHUB_TOKEN` for write operations:
* **Build/Deploy Workflows** (`build_frontend-ng.yml`, `build_frontend-v3.yml`, and `documentation.yml`): These workflows perform write operations (pushing back to the repository or deploying to GitHub Pages), but they are configured to authenticate via an SSH Deploy Key (`secrets.DEPLOY_KEY`) rather than using the default `GITHUB_TOKEN`.
* **Testing/Linting Workflows** (`e2e-tests.yml`, `linters.yml`, and `unit-tests.yml`): These workflows only perform read operations (checking out the code, running tests, and running linters) and have no need for write permissions.

By explicitly declaring `contents: read`, we document the exact permissions required by these workflows and safeguard them against future default permission changes in GitHub.
