### PR TITLE
feat(otel): Add basic OpenSearch Telemetry

### DIFF
--- a/end_to_end_tests/telemetry_test.py
+++ b/end_to_end_tests/telemetry_test.py
@@ -39,7 +39,7 @@ class TelemetryTest(interface.BaseEndToEndTest):
             except requests.exceptions.RequestException as e:
                 last_error = e
                 time.sleep(1)
-        
+
         self.assertions.fail(
             f"Jaeger is not reachable at {jaeger_api_url}: {last_error}"
         )
@@ -111,7 +111,9 @@ class TelemetryTest(interface.BaseEndToEndTest):
                         tags = {
                             t.get("key"): t.get("value") for t in span.get("tags", [])
                         }
-                        if "db.opensearch.took_ms" in tags and str(tags.get("timesketch.sketch_id")) == str(self.sketch.id):
+                        if "db.opensearch.took_ms" in tags and str(
+                            tags.get("timesketch.sketch_id")
+                        ) == str(self.sketch.id):
                             found_took_ms = True
                             break
                     if found_took_ms:

--- a/end_to_end_tests/telemetry_test.py
+++ b/end_to_end_tests/telemetry_test.py
@@ -27,27 +27,31 @@ class TelemetryTest(interface.BaseEndToEndTest):
 
     NAME = "telemetry_test"
 
-    def setup(self):
-        """Import a test timeline to ensure search works."""
-        self.import_timeline("evtx_direct.csv")
-
-    def test_telemetry_connectivity(self):
-        """Verify that OpenTelemetry spans are successfully exported to Jaeger."""
-        # 1. Check if Jaeger API is reachable.
+    def _wait_for_jaeger(self):
+        """Wait for Jaeger API to become reachable."""
         jaeger_api_url = "http://jaeger:16686/api"
         last_error = None
         for _ in range(30):
             try:
                 response = requests.get(f"{jaeger_api_url}/services", timeout=5)
                 response.raise_for_status()
-                break
+                return
             except requests.exceptions.RequestException as e:
                 last_error = e
                 time.sleep(1)
-        else:
-            self.assertions.fail(
-                f"Jaeger is not reachable at {jaeger_api_url}: {last_error}"
-            )
+        
+        self.assertions.fail(
+            f"Jaeger is not reachable at {jaeger_api_url}: {last_error}"
+        )
+
+    def setup(self):
+        """Import a test timeline to ensure search works."""
+        self._wait_for_jaeger()
+        self.import_timeline("evtx_direct.csv")
+
+    def test_telemetry_connectivity(self):
+        """Verify that OpenTelemetry spans are successfully exported to Jaeger."""
+        jaeger_api_url = "http://jaeger:16686/api"
 
         # 2. Trigger a simple API request to generate some telemetry
         self.api.list_sketches()
@@ -107,7 +111,7 @@ class TelemetryTest(interface.BaseEndToEndTest):
                         tags = {
                             t.get("key"): t.get("value") for t in span.get("tags", [])
                         }
-                        if "db.opensearch.took_ms" in tags:
+                        if "db.opensearch.took_ms" in tags and str(tags.get("timesketch.sketch_id")) == str(self.sketch.id):
                             found_took_ms = True
                             break
                     if found_took_ms:

--- a/end_to_end_tests/telemetry_test.py
+++ b/end_to_end_tests/telemetry_test.py
@@ -80,16 +80,17 @@ class TelemetryTest(interface.BaseEndToEndTest):
         )
         print("Telemetry infrastructure E2E connectivity verified successfully!")
 
-
     def test_opensearch_telemetry(self):
         """Verify that OpenSearch telemetry spans are exported."""
         jaeger_api_url = "http://jaeger:16686/api"
-        
+
         # 1. Trigger a search to generate OpenSearch telemetry
         self.sketch.explore("hello_opensearch_telemetry")
-        
+
         # 2. Poll Jaeger API for opensearch.search spans
-        query_url = f"{jaeger_api_url}/traces?service=timesketch&operation=opensearch.search"
+        query_url = (
+            f"{jaeger_api_url}/traces?service=timesketch&operation=opensearch.search"
+        )
         traces = []
         last_error = None
         for _ in range(30):
@@ -118,8 +119,11 @@ class TelemetryTest(interface.BaseEndToEndTest):
                 if "db.opensearch.took_ms" in tags:
                     found_took_ms = True
                     break
-        
-        self.assertions.assertTrue(found_took_ms, "Expected db.opensearch.took_ms tag in OpenSearch spans.")
+
+        self.assertions.assertTrue(
+            found_took_ms, "Expected db.opensearch.took_ms tag in OpenSearch spans."
+        )
+
 
 if os.environ.get("TIMESKETCH_OTEL_MODE", "").lower().startswith("otlp-"):
     manager.EndToEndTestManager.register_test(TelemetryTest)

--- a/end_to_end_tests/telemetry_test.py
+++ b/end_to_end_tests/telemetry_test.py
@@ -27,6 +27,10 @@ class TelemetryTest(interface.BaseEndToEndTest):
 
     NAME = "telemetry_test"
 
+    def setup(self):
+        """Import a test timeline to ensure search works."""
+        self.import_timeline("evtx_direct.csv")
+
     def test_telemetry_connectivity(self):
         """Verify that OpenTelemetry spans are successfully exported to Jaeger."""
         # 1. Check if Jaeger API is reachable.
@@ -76,6 +80,46 @@ class TelemetryTest(interface.BaseEndToEndTest):
         )
         print("Telemetry infrastructure E2E connectivity verified successfully!")
 
+
+    def test_opensearch_telemetry(self):
+        """Verify that OpenSearch telemetry spans are exported."""
+        jaeger_api_url = "http://jaeger:16686/api"
+        
+        # 1. Trigger a search to generate OpenSearch telemetry
+        self.sketch.explore("hello_opensearch_telemetry")
+        
+        # 2. Poll Jaeger API for opensearch.search spans
+        query_url = f"{jaeger_api_url}/traces?service=timesketch&operation=opensearch.search"
+        traces = []
+        last_error = None
+        for _ in range(30):
+            try:
+                response = requests.get(query_url, timeout=5)
+                response.raise_for_status()
+                traces_data = response.json()
+                traces = traces_data.get("data", [])
+                if traces:
+                    break
+            except requests.exceptions.RequestException as e:
+                last_error = e
+            time.sleep(1)
+
+        # 3. Assert trace exists
+        error_msg = "No opensearch.search telemetry traces found in Jaeger"
+        if last_error and not traces:
+            error_msg += f" (Last connection error: {last_error})"
+        self.assertions.assertGreater(len(traces), 0, error_msg)
+
+        # 4. Verify specific attributes exist in the spans
+        found_took_ms = False
+        for trace in traces:
+            for span in trace.get("spans", []):
+                tags = {t.get("key"): t.get("value") for t in span.get("tags", [])}
+                if "db.opensearch.took_ms" in tags:
+                    found_took_ms = True
+                    break
+        
+        self.assertions.assertTrue(found_took_ms, "Expected db.opensearch.took_ms tag in OpenSearch spans.")
 
 if os.environ.get("TIMESKETCH_OTEL_MODE", "").lower().startswith("otlp-"):
     manager.EndToEndTestManager.register_test(TelemetryTest)

--- a/end_to_end_tests/telemetry_test.py
+++ b/end_to_end_tests/telemetry_test.py
@@ -93,32 +93,37 @@ class TelemetryTest(interface.BaseEndToEndTest):
         )
         traces = []
         last_error = None
+        found_took_ms = False
         for _ in range(30):
             try:
                 response = requests.get(query_url, timeout=5)
                 response.raise_for_status()
                 traces_data = response.json()
                 traces = traces_data.get("data", [])
-                if traces:
+
+                # Check if we found the took_ms tag in any span
+                for trace in traces:
+                    for span in trace.get("spans", []):
+                        tags = {
+                            t.get("key"): t.get("value") for t in span.get("tags", [])
+                        }
+                        if "db.opensearch.took_ms" in tags:
+                            found_took_ms = True
+                            break
+                    if found_took_ms:
+                        break
+
+                if found_took_ms:
                     break
             except requests.exceptions.RequestException as e:
                 last_error = e
             time.sleep(1)
 
-        # 3. Assert trace exists
+        # 3. Assert trace exists and has the attribute
         error_msg = "No opensearch.search telemetry traces found in Jaeger"
         if last_error and not traces:
             error_msg += f" (Last connection error: {last_error})"
         self.assertions.assertGreater(len(traces), 0, error_msg)
-
-        # 4. Verify specific attributes exist in the spans
-        found_took_ms = False
-        for trace in traces:
-            for span in trace.get("spans", []):
-                tags = {t.get("key"): t.get("value") for t in span.get("tags", [])}
-                if "db.opensearch.took_ms" in tags:
-                    found_took_ms = True
-                    break
 
         self.assertions.assertTrue(
             found_took_ms, "Expected db.opensearch.took_ms tag in OpenSearch spans."

--- a/timesketch/lib/datastores/opensearch.py
+++ b/timesketch/lib/datastores/opensearch.py
@@ -45,6 +45,7 @@ import prometheus_client
 from timesketch.lib.definitions import HTTP_STATUS_CODE_NOT_FOUND
 from timesketch.lib.definitions import METRICS_NAMESPACE
 from timesketch.lib import errors
+from timesketch.lib import telemetry
 
 # Setup logging
 os_logger = logging.getLogger("timesketch.opensearch")
@@ -1105,6 +1106,7 @@ class OpenSearchDataStore:
         return {"must": [final_node], "must_not": [], "filter": []}
 
     # pylint: disable=too-many-arguments
+    @telemetry.instrument_search
     def search(
         self,
         sketch_id: int,

--- a/timesketch/lib/telemetry.py
+++ b/timesketch/lib/telemetry.py
@@ -40,6 +40,8 @@ try:
 except (ImportError, ModuleNotFoundError) as e:
     HAS_OTEL = False
     trace = None
+    StatusCode = None
+    INVALID_SPAN = None
     logger = logging.getLogger("timesketch.telemetry")
     logger.warning(
         "OpenTelemetry is not installed. Some features may crash. Error: %s", e
@@ -58,7 +60,7 @@ def instrument_search(func):
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        if not HAS_OTEL:
+        if not is_enabled():
             return func(*args, **kwargs)
 
         tracer = trace.get_tracer("timesketch.lib.datastores.opensearch")
@@ -69,10 +71,15 @@ def instrument_search(func):
             if sketch_id is not None:
                 span.set_attribute("timesketch.sketch_id", sketch_id)
 
-            result = func(*args, **kwargs)
-            if isinstance(result, dict) and "took" in result:
-                span.set_attribute("db.opensearch.took_ms", result.get("took", 0))
-            return result
+            try:
+                result = func(*args, **kwargs)
+                if isinstance(result, dict) and "took" in result:
+                    span.set_attribute("db.opensearch.took_ms", result.get("took", 0))
+                return result
+            except Exception as e:
+                span.set_status(StatusCode.ERROR, str(e))
+                span.record_exception(e)
+                raise
 
     return wrapper
 
@@ -134,6 +141,10 @@ def setup_telemetry(service_name: str):
         service_name (str): The name of the service to identify traces in the backend.
     """
     if not is_enabled():
+        return
+
+    # Prevent overriding if already set (e.g. by Flask auto-reloader)
+    if isinstance(trace.get_tracer_provider(), TracerProvider):
         return
 
     resource = Resource(
@@ -219,7 +230,7 @@ def set_status_on_current_span(status_name: str, description: str = None):
         return
 
     otel_span = trace.get_current_span()
-    if otel_span != INVALID_SPAN:
+    if otel_span.is_recording():
         code = getattr(StatusCode, status_name.upper(), StatusCode.UNSET)
         otel_span.set_status(code, description)
 
@@ -235,7 +246,7 @@ def add_event_to_current_span(event: str):
         return
 
     otel_span = trace.get_current_span()
-    if otel_span != INVALID_SPAN:
+    if otel_span.is_recording():
         otel_span.add_event(event)
 
 
@@ -253,7 +264,7 @@ def add_attribute_to_current_span(name: str, value: object):
         return
 
     otel_span = trace.get_current_span()
-    if otel_span != INVALID_SPAN:
+    if otel_span.is_recording():
         if isinstance(value, (str, bool, int, float)):
             otel_span.set_attribute(name, value)
         else:

--- a/timesketch/lib/telemetry.py
+++ b/timesketch/lib/telemetry.py
@@ -41,10 +41,9 @@ except (ImportError, ModuleNotFoundError) as e:
     HAS_OTEL = False
     trace = None
     StatusCode = None
-    INVALID_SPAN = None
     logger = logging.getLogger("timesketch.telemetry")
-    logger.warning(
-        "OpenTelemetry is not installed. Some features may crash. Error: %s", e
+    logger.info(
+        "OpenTelemetry is not installed. Error: %s", e
     )
 
 from timesketch.version import get_version

--- a/timesketch/lib/telemetry.py
+++ b/timesketch/lib/telemetry.py
@@ -42,9 +42,7 @@ except (ImportError, ModuleNotFoundError) as e:
     trace = None
     StatusCode = None
     logger = logging.getLogger("timesketch.telemetry")
-    logger.info(
-        "OpenTelemetry is not installed. Error: %s", e
-    )
+    logger.info("OpenTelemetry is not installed. Error: %s", e)
 
 from timesketch.version import get_version
 

--- a/timesketch/lib/telemetry.py
+++ b/timesketch/lib/telemetry.py
@@ -53,9 +53,23 @@ logger = logging.getLogger("timesketch.telemetry")
 
 
 def instrument_search(func):
-    """Decorator to instrument OpenSearch search calls.
+    """Decorator to instrument OpenSearch search calls with OpenTelemetry.
 
-    If OpenTelemetry is not installed, it safely runs the function without spans.
+    This decorator wraps OpenSearch search methods to automatically create
+    telemetry spans ("opensearch.search") for each query. It extracts useful
+    context from the query, such as the `sketch_id`, and records it as an
+    attribute (`timesketch.sketch_id`) to help correlate backend performance
+    with specific user sketches.
+
+    Additionally, if the OpenSearch client returns a dictionary containing a
+    "took" field, the decorator captures this value and adds it to the span
+    under the attribute `db.opensearch.took_ms`.
+
+    If the query fails and raises an exception, the exception is recorded
+    on the span and the span's status is set to ERROR.
+
+    If OpenTelemetry is not installed or enabled via `TIMESKETCH_OTEL_MODE`,
+    this decorator acts as a no-op and safely runs the function without spans.
     """
 
     @functools.wraps(func)

--- a/timesketch/lib/telemetry.py
+++ b/timesketch/lib/telemetry.py
@@ -49,11 +49,13 @@ from timesketch.version import get_version
 
 logger = logging.getLogger("timesketch.telemetry")
 
+
 def instrument_search(func):
     """Decorator to instrument OpenSearch search calls.
-    
+
     If OpenTelemetry is not installed, it safely runs the function without spans.
     """
+
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         if not HAS_OTEL:
@@ -71,6 +73,7 @@ def instrument_search(func):
             if isinstance(result, dict) and "took" in result:
                 span.set_attribute("db.opensearch.took_ms", result.get("took", 0))
             return result
+
     return wrapper
 
 

--- a/timesketch/lib/telemetry.py
+++ b/timesketch/lib/telemetry.py
@@ -61,6 +61,12 @@ def instrument_search(func):
 
         tracer = trace.get_tracer("timesketch.lib.datastores.opensearch")
         with tracer.start_as_current_span("opensearch.search") as span:
+            sketch_id = kwargs.get("sketch_id")
+            if sketch_id is None and len(args) > 1:
+                sketch_id = args[1]
+            if sketch_id is not None:
+                span.set_attribute("timesketch.sketch_id", sketch_id)
+
             result = func(*args, **kwargs)
             if isinstance(result, dict) and "took" in result:
                 span.set_attribute("db.opensearch.took_ms", result.get("took", 0))

--- a/timesketch/lib/telemetry.py
+++ b/timesketch/lib/telemetry.py
@@ -14,6 +14,7 @@
 """Module providing OpenTelemetry capability to Timesketch."""
 
 import json
+import functools
 import logging
 import os
 
@@ -26,7 +27,6 @@ try:
 
     from opentelemetry import trace
     from opentelemetry.trace import StatusCode
-    from opentelemetry.trace.span import INVALID_SPAN
     from opentelemetry.exporter import cloud_trace
     from opentelemetry.exporter.otlp.proto.grpc import trace_exporter as grpc_exporter
     from opentelemetry.exporter.otlp.proto.http import trace_exporter as http_exporter
@@ -37,15 +37,35 @@ try:
     from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
     HAS_OTEL = True
-except (ImportError, ModuleNotFoundError):
+except (ImportError, ModuleNotFoundError) as e:
     HAS_OTEL = False
     trace = None
-    StatusCode = None
-    INVALID_SPAN = None
+    logger = logging.getLogger("timesketch.telemetry")
+    logger.warning(
+        "OpenTelemetry is not installed. Some features may crash. Error: %s", e
+    )
 
 from timesketch.version import get_version
 
 logger = logging.getLogger("timesketch.telemetry")
+
+def instrument_search(func):
+    """Decorator to instrument OpenSearch search calls.
+    
+    If OpenTelemetry is not installed, it safely runs the function without spans.
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        if not HAS_OTEL:
+            return func(*args, **kwargs)
+
+        tracer = trace.get_tracer("timesketch.lib.datastores.opensearch")
+        with tracer.start_as_current_span("opensearch.search") as span:
+            result = func(*args, **kwargs)
+            if isinstance(result, dict) and "took" in result:
+                span.set_attribute("db.opensearch.took_ms", result.get("took", 0))
+            return result
+    return wrapper
 
 
 def safe_telemetry_call(func):


### PR DESCRIPTION
This pull request introduces OpenSearch search telemetry instrumentation by adding an instrument_search decorator in `timesketch/lib/telemetry.py` and applying it to the OpenSearch datastore's search method.

* Time taken for a search
* sketch-id


<img width="1576" height="734" alt="Screenshot 2026-06-10 at 15 07 49" src="https://github.com/user-attachments/assets/22a63028-b8e4-41d9-82f1-af6c6de2f03e" />
