### PR TITLE
api: enforce cross-sketch ownership on event fact conclusions

### DIFF
--- a/timesketch/api/v1/resources/event.py
+++ b/timesketch/api/v1/resources/event.py
@@ -1143,6 +1143,13 @@ class EventAnnotationResource(resources.ResourceMixin, Resource):
                             HTTP_STATUS_CODE_BAD_REQUEST,
                             "Conclusion ID is required to add a fact.",
                         )
+                    # Enforce that the conclusion belongs to the sketch in the
+                    # URL to prevent cross-sketch linkage of facts.
+                    if conclusion.investigativequestion.sketch.id != sketch.id:
+                        abort(
+                            HTTP_STATUS_CODE_NOT_FOUND,
+                            "No conclusion found with this ID.",
+                        )
                     # Adding facts to conclusions
                     if not form.remove.data:
                         event.conclusions.append(conclusion)


### PR DESCRIPTION
Follow-up to #3822 (merged), as invited by @jkppr.

## Problem
`EventAnnotationResource.post` (the `__ts_fact` branch in `event.py`) loads an `InvestigativeQuestionConclusion` by a request-body `conclusion_id` and links/unlinks it to the event **without verifying the conclusion belongs to the sketch in the URL**:

```python
conclusion = InvestigativeQuestionConclusion.get_by_id(conclusion_id)
...
event.conclusions.append(conclusion)   # or .remove(conclusion)
```

A user with write access to sketch A can therefore attach or detach a fact linkage against an `InvestigativeQuestionConclusion` that belongs to a different sketch B — the same cross-sketch ownership class fixed in #3822 / #3777 / #3821 / #3823, but this sibling path was not covered by any of them.

## Fix
Mirror the ownership check already used in `scenarios.py`: if the conclusion's investigative question does not belong to the current sketch, abort with 404.

```python
if conclusion.investigativequestion.sketch.id != sketch.id:
    abort(HTTP_STATUS_CODE_NOT_FOUND, "No conclusion found with this ID.")
```

The relationship chain is the same one already used elsewhere in this file (`InvestigativeQuestionConclusion.investigativequestion` → `InvestigativeQuestion.sketch`), so no new imports or queries are introduced. Branch is based on latest master.