### PR TITLE
Optimize E2E Test Suite Execution Time

### DIFF
--- a/end_to_end_tests/interface.py
+++ b/end_to_end_tests/interface.py
@@ -14,6 +14,7 @@
 """Interface for end-to-end tests."""
 
 import collections
+import datetime
 import inspect
 import os
 import json
@@ -68,7 +69,9 @@ class BaseEndToEndTest(object):
         self._imported_files = []
         self._imported_sketch_timelines = set()
 
-    def import_timeline(self, filename, index_name=None, sketch=None):
+    def import_timeline(
+        self, filename, index_name=None, sketch=None, entry_threshold=None
+    ):
         """Import a Plaso, CSV or JSONL file.
 
         Args:
@@ -76,6 +79,7 @@ class BaseEndToEndTest(object):
             index_name (str): The OpenSearch index to store the documents in.
             sketch (Sketch): Optional sketch object to add the timeline to.
                         if no sketch is provided, the default sketch is used.
+            entry_threshold (int): Optional chunk size threshold for imports.
 
         Raises:
             TimeoutError if import takes too long.
@@ -95,6 +99,8 @@ class BaseEndToEndTest(object):
             streamer.set_timeline_name(file_path)
             streamer.set_index_name(index_name)
             streamer.set_provider("e2e test interface")
+            if entry_threshold is not None:
+                streamer.set_entry_threshold(entry_threshold)
             streamer.add_file(file_path)
             timeline = streamer.timeline
             if not timeline:
@@ -288,7 +294,15 @@ class BaseEndToEndTest(object):
         print("*** {0:s} ***".format(self.NAME))
         for test_name, test_func in self._get_test_methods():
             self._counter["tests"] += 1
-            print("Running test: {0:s} ...".format(test_name), end="", flush=True)
+            if os.environ.get("GITHUB_ACTIONS"):
+                print("Running test: {0:s} ...".format(test_name), end="", flush=True)
+            else:
+                now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                print(
+                    "{0:s} Running test: {1:s} ...".format(now, test_name),
+                    end="",
+                    flush=True,
+                )
             try:
                 test_func()
             except Exception:  # pylint: disable=broad-except

--- a/end_to_end_tests/interface.py
+++ b/end_to_end_tests/interface.py
@@ -291,18 +291,14 @@ class BaseEndToEndTest(object):
         Returns:
             Counter of number of tests and errors.
         """
-        print("*** {0:s} ***".format(self.NAME))
+        print(f"*** {self.NAME} ***")
         for test_name, test_func in self._get_test_methods():
             self._counter["tests"] += 1
             if os.environ.get("GITHUB_ACTIONS"):
-                print("Running test: {0:s} ...".format(test_name), end="", flush=True)
+                print(f"Running test: {test_name} ...", end="", flush=True)
             else:
                 now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-                print(
-                    "{0:s} Running test: {1:s} ...".format(now, test_name),
-                    end="",
-                    flush=True,
-                )
+                print(f"{now} Running test: {test_name} ...", end="", flush=True)
             try:
                 test_func()
             except Exception:  # pylint: disable=broad-except

--- a/end_to_end_tests/upload_test.py
+++ b/end_to_end_tests/upload_test.py
@@ -84,11 +84,18 @@ class UploadTest(interface.BaseEndToEndTest):
 
         search_obj = search.Search(sketch)
         search_obj.query_string = "data_type:foobarjson"
+        search_obj._scrolling = True  # pylint: disable=protected-access
+        search_obj.max_entries = 4123
+        search_obj.query_filter = {"size": 1000}
         search_obj.commit()
         self.assertions.assertEqual(len(search_obj.table), 4123)
 
         # check that the number of events is correct with a different method
-        events = sketch.explore("data_type:foobarjson", as_pandas=True)
+        search_obj_pandas = sketch.explore("data_type:foobarjson", as_object=True)
+        search_obj_pandas._scrolling = True  # pylint: disable=protected-access
+        search_obj_pandas.max_entries = 4123
+        search_obj_pandas.query_filter = {"size": 1000}
+        events = search_obj_pandas.to_pandas()
         self.assertions.assertEqual(len(events), 4123)
 
     def test_upload_jsonl_mapping_exceeds_limit(self):
@@ -159,11 +166,11 @@ class UploadTest(interface.BaseEndToEndTest):
         file_path = "/tmp/verylarge.jsonl"
 
         with open(file_path, "w", encoding="utf-8") as file_object:
-            for i in range(74251):
+            for i in range(12000):
                 line_string = f'{{"message":"Count {i} {rand}","timestamp":"123456789","datetime":"2015-07-24T19:01:01+00:00","timestamp_desc":"Write time","data_type":"foobarjsonverlarge"}}\n'  # pylint: disable=line-too-long
                 file_object.write(line_string)
 
-        self.import_timeline(file_path, sketch=sketch)
+        self.import_timeline(file_path, sketch=sketch, entry_threshold=5000)
         os.remove(file_path)
 
         timeline = sketch.list_timelines()[0]
@@ -177,18 +184,7 @@ class UploadTest(interface.BaseEndToEndTest):
 
         # normal max query limit
         self.assertions.assertEqual(len(search_obj.table), 10000)
-        self.assertions.assertEqual(search_obj.expected_size, 74251)
-
-        # increase max entries returned:
-        search_obj.max_entries = 100000
-        search_obj.commit()
-        self.assertions.assertEqual(len(search_obj.table), 74251)
-
-        # check that the number of events is correct with a different method
-        events = sketch.explore(
-            "data_type:foobarjsonverlarge", as_pandas=True, max_entries=100000
-        )
-        self.assertions.assertEqual(len(events), 74251)
+        self.assertions.assertEqual(search_obj.expected_size, 12000)
 
     def test_large_upload_csv(self):
         """Test uploading a timeline with an a lot of events.
@@ -253,7 +249,7 @@ class UploadTest(interface.BaseEndToEndTest):
                 '"message","timestamp","datetime","timestamp_desc","data_type"\n'
             )
 
-            for i in range(73251):
+            for i in range(12000):
                 # write a line with random values for message
                 line_string = (
                     f'"CSV Count: {i} {rand}","123456789",'
@@ -261,7 +257,7 @@ class UploadTest(interface.BaseEndToEndTest):
                 )
                 file_object.write(line_string)
 
-        self.import_timeline("/tmp/verylarge.csv", sketch=sketch)
+        self.import_timeline("/tmp/verylarge.csv", sketch=sketch, entry_threshold=5000)
         os.remove(file_path)
 
         timeline = sketch.list_timelines()[0]
@@ -275,16 +271,7 @@ class UploadTest(interface.BaseEndToEndTest):
 
         # normal max query limit
         self.assertions.assertEqual(len(search_obj.table), 10000)
-        self.assertions.assertEqual(search_obj.expected_size, 73251)
-
-        # increase max entries returned:
-        search_obj.max_entries = 100000
-        search_obj.commit()
-        self.assertions.assertEqual(len(search_obj.table), 73251)
-
-        # check that the number of events is correct with a different method
-        events = sketch.explore("data_type:73kcsv", as_pandas=True, max_entries=100000)
-        self.assertions.assertEqual(len(events), 73251)
+        self.assertions.assertEqual(search_obj.expected_size, 12000)
 
     def test_datetime_out_of_normal_range_in_csv(self):
         """Test uploading a file with events from way back and some

--- a/end_to_end_tests/upload_test.py
+++ b/end_to_end_tests/upload_test.py
@@ -86,7 +86,9 @@ class UploadTest(interface.BaseEndToEndTest):
         search_obj.query_string = "data_type:foobarjson"
         search_obj.scrolling_enable()
         search_obj.max_entries = 4123
-        search_obj.query_filter = {"size": 1000}
+        query_filter = search_obj.query_filter
+        query_filter["size"] = 1000
+        search_obj.query_filter = query_filter
         search_obj.commit()
         self.assertions.assertEqual(len(search_obj.table), 4123)
 
@@ -94,7 +96,9 @@ class UploadTest(interface.BaseEndToEndTest):
         search_obj_pandas = sketch.explore("data_type:foobarjson", as_object=True)
         search_obj_pandas.scrolling_enable()
         search_obj_pandas.max_entries = 4123
-        search_obj_pandas.query_filter = {"size": 1000}
+        query_filter_pandas = search_obj_pandas.query_filter
+        query_filter_pandas["size"] = 1000
+        search_obj_pandas.query_filter = query_filter_pandas
         events = search_obj_pandas.to_pandas()
         self.assertions.assertEqual(len(events), 4123)
 

--- a/end_to_end_tests/upload_test.py
+++ b/end_to_end_tests/upload_test.py
@@ -84,7 +84,7 @@ class UploadTest(interface.BaseEndToEndTest):
 
         search_obj = search.Search(sketch)
         search_obj.query_string = "data_type:foobarjson"
-        search_obj._scrolling = True  # pylint: disable=protected-access
+        search_obj.scrolling_enable()
         search_obj.max_entries = 4123
         search_obj.query_filter = {"size": 1000}
         search_obj.commit()
@@ -92,7 +92,7 @@ class UploadTest(interface.BaseEndToEndTest):
 
         # check that the number of events is correct with a different method
         search_obj_pandas = sketch.explore("data_type:foobarjson", as_object=True)
-        search_obj_pandas._scrolling = True  # pylint: disable=protected-access
+        search_obj_pandas.scrolling_enable()
         search_obj_pandas.max_entries = 4123
         search_obj_pandas.query_filter = {"size": 1000}
         events = search_obj_pandas.to_pandas()
@@ -257,7 +257,7 @@ class UploadTest(interface.BaseEndToEndTest):
                 )
                 file_object.write(line_string)
 
-        self.import_timeline("/tmp/verylarge.csv", sketch=sketch, entry_threshold=5000)
+        self.import_timeline(file_path, sketch=sketch, entry_threshold=5000)
         os.remove(file_path)
 
         timeline = sketch.list_timelines()[0]


### PR DESCRIPTION
This PR optimizes the Timesketch end-to-end tests, specifically targeting the `upload_test` suite. It reduces execution time by working with smaller test datasets, configuring lower chunking thresholds, and avoiding redundant scroll downloads. 

It also adds optional, environment-aware timestamps to local test progress logs.

## Problem
Two tests, `test_large_upload_csv_over_flush_limit` and `test_very_large_upload_jsonl`, took up to 8 minutes because they generated ~74k events and retrieved them all back twice via scroll queries. This caused high JSON serialization overhead and CPU bottlenecks.

## Solution
1. **Configurable Importer Thresholds:** Updated `BaseEndToEndTest.import_timeline()` to support an optional `entry_threshold` parameter.
2. **Smaller Datasets for Chunking:** Reduced the test dataset for the large tests to **12,000** events and set the importer threshold to **5,000**. This tests the chunked upload code path (3 chunks) without indexing massive amounts of data.
3. **Dedicated Scroll Test:** Removed the large scroll retrievals from the very large tests. Instead, configured `test_large_upload_jsonl` (4,123 events) with a page size filter of `{"size": 1000}` to test API client scrolling over multiple pages quickly.
4. **Environment-Aware Timestamps:** Added timestamps to local test outputs. Timestamps are suppressed on GitHub Actions (`GITHUB_ACTIONS=true`) to avoid redundant logging in CI.