### PR TITLE
Improve wildcard search guidance, error handling, and event detail formatting

### DIFF
--- a/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
@@ -275,8 +275,8 @@ export default {
     checkContextLinkDisplay(key, value) {
       const fieldConfList = this.contextLinkConf[key.toLowerCase()] ? this.contextLinkConf[key.toLowerCase()] : []
       for (const confItem of fieldConfList) {
-        if (confItem['validation_regex'] !== '' && confItem['validation_regex'] !== undefined) {
-          let validationPattern = confItem['validation_regex']
+        if (confItem.validation_regex !== '' && confItem.validation_regex !== undefined) {
+          let validationPattern = confItem.validation_regex
           let regexIdentifiers = validationPattern.slice(validationPattern.lastIndexOf('/') + 1)
           let regexPattern = validationPattern.slice(
             validationPattern.indexOf('/') + 1,
@@ -297,29 +297,29 @@ export default {
     contextLinkRedirect(key, item, value) {
       const fieldConfList = this.contextLinkConf[key.toLowerCase()] ? this.contextLinkConf[key.toLowerCase()] : []
       for (const confItem of fieldConfList) {
-        if (confItem['short_name'] === item) {
-          if (confItem['type'] === 'hardcoded_modules') {
-            if (confItem['module'] === 'xml_formatter') {
+        if (confItem.short_name === item) {
+          if (confItem.type === 'hardcoded_modules') {
+            if (confItem.module === 'xml_formatter') {
               this.formatXMLString = true
               this.contextValue = value
               return
             }
-            if (confItem['module'] === 'unfurl_graph') {
+            if (confItem.module === 'unfurl_graph') {
               this.dfirUnfurlDialog = true
               this.contextValue = value
               return
             }
-            if (confItem['module'] === 'threat_intel') {
+            if (confItem.module === 'threat_intel') {
               EventBus.$emit('addIndicator', value)
               return
             }
           } else {
-            if (confItem['redirect_warning']) {
+            if (confItem.redirect_warning) {
               this.redirectWarnDialog = true
               this.contextValue = value
-              this.contextUrl = confItem['context_link'].replace('<ATTR_VALUE>', encodeURIComponent(value))
+              this.contextUrl = confItem.context_link.replace('<ATTR_VALUE>', encodeURIComponent(value))
             } else {
-              window.open(confItem['context_link'].replace('<ATTR_VALUE>', encodeURIComponent(value)), '_blank')
+              window.open(confItem.context_link.replace('<ATTR_VALUE>', encodeURIComponent(value)), '_blank')
               this.redirectWarnDialog = false
             }
           }
@@ -329,17 +329,17 @@ export default {
     getContextLinkType(key, item) {
       const fieldConfList = this.contextLinkConf[key.toLowerCase()] ? this.contextLinkConf[key.toLowerCase()] : []
       for (const confItem of fieldConfList) {
-        if (confItem['short_name'] === item) {
-          return confItem['type']
+        if (confItem.short_name === item) {
+          return confItem.type
         }
       }
     },
     getContextLinkRedirectState(key, item) {
       const fieldConfList = this.contextLinkConf[key.toLowerCase()] ? this.contextLinkConf[key.toLowerCase()] : []
       for (const confItem of fieldConfList) {
-        if (confItem['short_name'] === item) {
-          if (confItem['redirect_warning']) {
-            return confItem['redirect_warning']
+        if (confItem.short_name === item) {
+          if (confItem.redirect_warning) {
+            return confItem.redirect_warning
           } else {
             return false
           }
@@ -365,9 +365,9 @@ export default {
       eventData.doSearch = true
       let chip = {
         field: key,
-        value: value,
+        value,
         type: 'term',
-        operator: operator,
+        operator,
         active: true,
       }
       eventData.chip = chip

--- a/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
@@ -144,7 +144,7 @@ limitations under the License.
                   </td>
 
                   <!-- Event field value -->
-                  <td width="100%" class="pl-0">
+                  <td width="100%" class="pl-0 event-detail-value">
                     {{ value }}
                   </td>
                 </tr>
@@ -384,5 +384,11 @@ export default {
 .flexcard {
   display: flex;
   flex-direction: column;
+}
+.event-detail-value {
+  word-break: break-all;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
 }
 </style>

--- a/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventDetail.vue
@@ -386,8 +386,6 @@ export default {
   flex-direction: column;
 }
 .event-detail-value {
-  word-break: break-all;
-  word-break: break-word;
   overflow-wrap: anywhere;
   white-space: pre-wrap;
 }

--- a/timesketch/frontend-ng/src/components/Explore/EventList.vue
+++ b/timesketch/frontend-ng/src/components/Explore/EventList.vue
@@ -1005,8 +1005,13 @@ export default {
             e.response.data.message.includes('too_many_nested_clauses') ||
             e.response.data.message.includes('query_shard_exception')
           ) {
-            msg =
-              'Sorry, your query is too complex. Use field-specific search (like "message:(<query terms>)") and try again.'
+            if (this.searchMode === 'wildcard') {
+              msg =
+                'Sorry, your query is too complex. Use field-specific search (like "message:*<search term>*") and try again.'
+            } else {
+              msg =
+                'Sorry, your query is too complex. Use field-specific search (like "message:(<query terms>)") and try again.'
+            }
             this.warningSnackBar(msg)
           } else {
             this.errorSnackBar(msg)

--- a/timesketch/frontend-ng/src/components/Explore/SearchErrorCard.vue
+++ b/timesketch/frontend-ng/src/components/Explore/SearchErrorCard.vue
@@ -34,9 +34,10 @@ limitations under the License.
           </p>
           <p>Suggestions:</p>
           <ul v-if="searchMode === 'wildcard'">
-            <li>Encase terms containing colons (like URLs, paths, or MACs) in double-quotes, e.g. <code>"*count: 1*"</code>.</li>
+            <li>Ensure search terms contain wildcard characters (e.g. <code>*searchterm*</code>).</li>
+            <li>Do not escape special characters with backslashes. Matches are literal.</li>
+            <li>Encase terms containing <code>:</code> (like URLs, paths, or MACs) in double-quotes, e.g. <code>"*count: 1*"</code>.</li>
             <li>Check for field typos: Ensure that target fields (e.g. <code>message:</code>) are spelled correctly and support wildcard searches.</li>
-            <li>Verify that all parentheses <code>()</code> are balanced.</li>
             <li>Ensure boolean operators (<code>AND</code>, <code>OR</code>, <code>NOT</code>) are capitalized and correctly positioned.</li>
             <li>Try some of the wildcard search examples below.</li>
           </ul>

--- a/timesketch/frontend-ng/src/components/Explore/SearchGuideCard.vue
+++ b/timesketch/frontend-ng/src/components/Explore/SearchGuideCard.vue
@@ -188,10 +188,10 @@ limitations under the License.
                       <tr>
                         <td>Search a phrase containing spaces (must be wrapped in quotes)</td>
                         <td>
-                          <a href="#" @click.prevent="emitSetQueryAndFilter('\&quot;*count: 1*\&quot;')">
+                          <a href="#" @click.prevent="emitSetQueryAndFilter('&quot;*count: 1*&quot;')">
                             <code>"*count: 1*"</code> </a
                           ><br />
-                          <a href="#" @click.prevent="emitSetQueryAndFilter('message:\&quot;*count: 1*\&quot;')">
+                          <a href="#" @click.prevent="emitSetQueryAndFilter('message:&quot;*count: 1*&quot;')">
                             <code>message:"*count: 1*"</code>
                           </a>
                         </td>
@@ -237,7 +237,7 @@ limitations under the License.
                       <tr>
                         <td>Search an exact term (no need to escape special characters)</td>
                         <td>
-                          <a href="#" @click.prevent="emitSetQueryAndFilter('url:\&quot;http://google.com/\&quot;')">
+                          <a href="#" @click.prevent="emitSetQueryAndFilter('url:&quot;http://google.com/&quot;')">
                             <code>url:"http://google.com/"</code>
                           </a>
                         </td>

--- a/timesketch/frontend-ng/src/components/Explore/SearchGuideCard.vue
+++ b/timesketch/frontend-ng/src/components/Explore/SearchGuideCard.vue
@@ -170,7 +170,7 @@ limitations under the License.
                         </td>
                       </tr>
                       <tr>
-                        <td>Search for a substring in any string type field (case-sensitive)</td>
+                        <td>Search for a substring in any text based field (case-insensitive)</td>
                         <td>
                           <a href="#" @click.prevent="emitSetQueryAndFilter('*evil*')">
                             <code>*evil*</code>
@@ -237,7 +237,7 @@ limitations under the License.
                       <tr>
                         <td>Search an exact term (no need to escape special characters)</td>
                         <td>
-                          <a href="#" @click.prevent="emitSetQueryAndFilter('url:http://google.com/')">
+                          <a href="#" @click.prevent="emitSetQueryAndFilter('url:\&quot;http://google.com/\&quot;')">
                             <code>url:"http://google.com/"</code>
                           </a>
                         </td>

--- a/timesketch/frontend-v3/src/components/Explore/EventDetail.vue
+++ b/timesketch/frontend-v3/src/components/Explore/EventDetail.vue
@@ -175,7 +175,7 @@ limitations under the License.
                   </td>
 
                   <!-- Event field value -->
-                  <td width="100%" class="pl-0">
+                  <td width="100%" class="pl-0 event-detail-value">
                     {{ value }}
                   </td>
                 </tr>
@@ -444,5 +444,11 @@ export default {
 .flexcard {
   display: flex;
   flex-direction: column;
+}
+.event-detail-value {
+  word-break: break-all;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
 }
 </style>

--- a/timesketch/frontend-v3/src/components/Explore/EventDetail.vue
+++ b/timesketch/frontend-v3/src/components/Explore/EventDetail.vue
@@ -446,8 +446,6 @@ export default {
   flex-direction: column;
 }
 .event-detail-value {
-  word-break: break-all;
-  word-break: break-word;
   overflow-wrap: anywhere;
   white-space: pre-wrap;
 }

--- a/timesketch/lib/datastores/opensearch.py
+++ b/timesketch/lib/datastores/opensearch.py
@@ -1290,7 +1290,7 @@ class OpenSearchDataStore:
                 )
         except ConnectionTimeout as e:
             wildcard_warning = ""
-            if query_string.startswith("*"):
+            if query_string.startswith("*") and not use_wildcard_fields:
                 wildcard_warning = (
                     " IMPORTANT: Avoid leading wildcards (e.g. *searchterm) in "
                     "your search query as these are very resource expensive."

--- a/timesketch/lib/datastores/opensearch.py
+++ b/timesketch/lib/datastores/opensearch.py
@@ -1290,7 +1290,11 @@ class OpenSearchDataStore:
                 )
         except ConnectionTimeout as e:
             wildcard_warning = ""
-            if query_string and query_string.startswith("*") and not use_wildcard_fields:
+            if (
+                query_string
+                and query_string.startswith("*")
+                and not use_wildcard_fields
+            ):
                 wildcard_warning = (
                     " IMPORTANT: Avoid leading wildcards (e.g. *searchterm) in "
                     "your search query as these are very resource expensive."

--- a/timesketch/lib/datastores/opensearch.py
+++ b/timesketch/lib/datastores/opensearch.py
@@ -1290,7 +1290,7 @@ class OpenSearchDataStore:
                 )
         except ConnectionTimeout as e:
             wildcard_warning = ""
-            if query_string.startswith("*") and not use_wildcard_fields:
+            if query_string and query_string.startswith("*") and not use_wildcard_fields:
                 wildcard_warning = (
                     " IMPORTANT: Avoid leading wildcards (e.g. *searchterm) in "
                     "your search query as these are very resource expensive."

--- a/timesketch/lib/datastores/opensearch_test.py
+++ b/timesketch/lib/datastores/opensearch_test.py
@@ -73,6 +73,13 @@ class OpenSearchDataStoreTest(BaseTest):
         self.assertIn("The search timed out", str(cm.exception))
         self.assertNotIn("Avoid leading wildcards", str(cm.exception))
 
+        # Test timeout message when query_string is None
+        with self.assertRaises(DatastoreTimeoutError) as cm:
+            ds.search(sketch_id=1, indices=["test"], query_string=None)
+
+        self.assertIn("The search timed out", str(cm.exception))
+        self.assertNotIn("Avoid leading wildcards", str(cm.exception))
+
     @mock.patch("timesketch.lib.datastores.opensearch.OpenSearch")
     def test_proactive_flush_on_size(self, mock_client):
         """Test that indexing flushes proactively when byte size limit is reached."""

--- a/timesketch/lib/datastores/opensearch_test.py
+++ b/timesketch/lib/datastores/opensearch_test.py
@@ -45,6 +45,7 @@ class OpenSearchDataStoreTest(BaseTest):
 
         # Ensure the client in the datastore is indeed our mock (it should be)
         ds.client = mock_es_instance
+        ds.get_wildcard_fields = mock.Mock(return_value=["message"])
 
         # Test generic timeout message
         with self.assertRaises(DatastoreTimeoutError) as cm:
@@ -59,6 +60,18 @@ class OpenSearchDataStoreTest(BaseTest):
 
         self.assertIn("The search timed out", str(cm.exception))
         self.assertIn("Avoid leading wildcards", str(cm.exception))
+
+        # Test wildcard search mode specific message
+        with self.assertRaises(DatastoreTimeoutError) as cm:
+            ds.search(
+                sketch_id=1,
+                indices=["test"],
+                query_string="*test",
+                use_wildcard_fields=True,
+            )
+
+        self.assertIn("The search timed out", str(cm.exception))
+        self.assertNotIn("Avoid leading wildcards", str(cm.exception))
 
     @mock.patch("timesketch.lib.datastores.opensearch.OpenSearch")
     def test_proactive_flush_on_size(self, mock_client):


### PR DESCRIPTION
This PR addresses several UI and messaging issues in wildcard search mode:

- **Formatting:** Added `overflow-wrap: anywhere` and `white-space: pre-wrap` with a `2px` right padding to expanded event values in both `frontend-ng` and `frontend-v3` to prevent horizontal screen overflow on long strings.
- **Timeout Messages:** Updated the datastore search timeout to hide the "avoid leading wildcards" warning when the user is explicitly in wildcard search mode. Added corresponding tests.
- **Query Complexity Messages:** Updated the "too complex query" warning to recommend field-specific wildcards (`message:*<term>*`) rather than query-string grouping (`message:(...)`) when wildcard mode is active.
- **Error Card & Guide Corrections:** Refined wildcard suggestions based on benchmark results (advising against backslash escapes and ensuring wildcard characters are present) and fixed the exact URL example in `SearchGuideCard.vue` to emit quotes correctly.