### PR TITLE
frontend: Restore active search mode when loading saved view or history

### DIFF
--- a/timesketch/frontend-ng/src/views/Explore.vue
+++ b/timesketch/frontend-ng/src/views/Explore.vue
@@ -532,7 +532,7 @@ export default {
           let view = response.data.objects[0]
           this.currentQueryString = view.query_string
           this.currentQueryFilter = JSON.parse(view.query_filter)
-          if (this.currentQueryFilter.use_wildcard_fields) {
+          if (this.currentQueryFilter && this.currentQueryFilter.use_wildcard_fields) {
             this.localSearchMode = 'wildcard'
           } else {
             this.localSearchMode = 'query_string'
@@ -720,7 +720,7 @@ export default {
     jumpInHistory: function (node) {
       this.currentQueryString = node.query_string
       this.currentQueryFilter = JSON.parse(node.query_filter)
-      if (this.currentQueryFilter.use_wildcard_fields) {
+      if (this.currentQueryFilter && this.currentQueryFilter.use_wildcard_fields) {
         this.localSearchMode = 'wildcard'
       } else {
         this.localSearchMode = 'query_string'

--- a/timesketch/frontend-ng/src/views/Explore.vue
+++ b/timesketch/frontend-ng/src/views/Explore.vue
@@ -532,6 +532,11 @@ export default {
           let view = response.data.objects[0]
           this.currentQueryString = view.query_string
           this.currentQueryFilter = JSON.parse(view.query_filter)
+          if (this.currentQueryFilter.use_wildcard_fields) {
+            this.localSearchMode = 'wildcard'
+          } else {
+            this.localSearchMode = 'query_string'
+          }
           if (!this.currentQueryFilter.fields || !this.currentQueryFilter.fields.length) {
             this.currentQueryFilter.fields = [{ field: 'message', type: 'text' }]
           }
@@ -715,6 +720,11 @@ export default {
     jumpInHistory: function (node) {
       this.currentQueryString = node.query_string
       this.currentQueryFilter = JSON.parse(node.query_filter)
+      if (this.currentQueryFilter.use_wildcard_fields) {
+        this.localSearchMode = 'wildcard'
+      } else {
+        this.localSearchMode = 'query_string'
+      }
       if (!this.currentQueryFilter.fields || !this.currentQueryFilter.fields.length) {
         this.currentQueryFilter.fields = [{ field: 'message', type: 'text' }]
       }


### PR DESCRIPTION
With the introduction of the wildcard search mode, loading a saved search or jumping to a search history node did not restore the active search mode. The UI would continue using the current active search mode, and subsequent searches would overwrite the saved mode inside the query filter.

This PR fixes the issue by updating `localSearchMode` based on the `use_wildcard_fields` attribute parsed from the loaded view filter or history node:
* If `use_wildcard_fields` is `true`, the UI search mode is set to `wildcard`.
* If it is `false` or `undefined` (e.g. legacy searches created before the wildcard feature), it correctly falls back to the classic `'query_string'` (Classic) mode.