### PR TITLE
fix(api-client):  Introduce auth_timeout=None,as new argument in the API client.

### DIFF
--- a/api_client/python/timesketch_api_client/client.py
+++ b/api_client/python/timesketch_api_client/client.py
@@ -95,6 +95,7 @@ class TimesketchApi:
         create_session=True,
         retry_count=DEFAULT_RETRY_COUNT,
         backoff_factor=0.5,
+        auth_timeout=None,
     ):
         """Initializes the TimesketchApi object.
 
@@ -114,6 +115,7 @@ class TimesketchApi:
             retry_count: Number of retries for HTTP requests and internal API
                 request retries. Defaults to DEFAULT_RETRY_COUNT.
             backoff_factor: The backoff factor to use for retries. Defaults to 0.5.
+            auth_timeout: Optional timeout in seconds for the authentication.
 
         Raises:
             ConnectionError: If the Timesketch server is unreachable.
@@ -145,6 +147,7 @@ class TimesketchApi:
                 auth_mode=auth_mode,
                 retry_count=self._retry_count,
                 backoff_factor=self._backoff_factor,
+                auth_timeout=auth_timeout,
             )
         except ConnectionError as exc:
             raise ConnectionError("Timesketch server unreachable") from exc
@@ -256,6 +259,7 @@ class TimesketchApi:
         open_browser=False,
         run_server=True,
         skip_open=False,
+        timeout_seconds=None,
     ):
         """Return an OAuth session.
 
@@ -273,6 +277,8 @@ class TimesketchApi:
             skip_open (bool): A booelan, if set to True (defaults to False) an
                 authorization URL is printed on the screen to visit. This is
                 only valid if run_server is set to False.
+            timeout_seconds (int): Optional timeout in seconds for the authentication.
+                If set to None (default), it will wait indefinitely.
 
         Return:
             session: Instance of requests.Session.
@@ -312,7 +318,22 @@ class TimesketchApi:
             flow.redirect_uri = self.DEFAULT_OAUTH_LOCALHOST_URL
 
         if run_server:
-            _ = flow.run_local_server(host=host, port=port, open_browser=open_browser)
+            try:
+                _ = flow.run_local_server(
+                    host=host,
+                    port=port,
+                    open_browser=open_browser,
+                    timeout_seconds=timeout_seconds,
+                )
+            except AttributeError as e:
+                # Handle cases where run_local_server returns without a request
+                # being made, e.g. on timeout.
+                if "NoneType" in str(e) and "replace" in str(e):
+                    raise RuntimeError(
+                        "Authentication failed: No authorization response received. "
+                        "Did you authorize the application in the browser?"
+                    ) from e
+                raise
         else:
             if not sys.stdout.isatty() or not sys.stdin.isatty():
                 msg = (
@@ -377,6 +398,7 @@ class TimesketchApi:
         auth_mode,
         retry_count,
         backoff_factor,
+        auth_timeout,
     ):
         """Create authenticated HTTP session for server communication.
 
@@ -391,13 +413,16 @@ class TimesketchApi:
                 (HTTP Basic authentication) and oauth
             retry_count (int): Number of retries for HTTP requests.
             backoff_factor (float): The backoff factor to use for retries.
+            auth_timeout (int): Optional timeout in seconds for the authentication.
 
         Returns:
             Instance of requests.Session.
         """
         if auth_mode == "oauth":
             return self._create_oauth_session(
-                client_id=client_id, client_secret=client_secret
+                client_id=client_id,
+                client_secret=client_secret,
+                timeout_seconds=auth_timeout,
             )
 
         if auth_mode == "oauth_local":
@@ -406,6 +431,7 @@ class TimesketchApi:
                 client_secret=client_secret,
                 run_server=False,
                 skip_open=True,
+                timeout_seconds=auth_timeout,
             )
 
         session = requests.Session()

--- a/api_client/python/timesketch_api_client/client_test.py
+++ b/api_client/python/timesketch_api_client/client_test.py
@@ -162,7 +162,7 @@ class TimesketchApiRetryTest(unittest.TestCase):
         )
 
         with self.assertRaises(RuntimeError) as cm:
-            api._create_oauth_session(client_id="abc", client_secret="def")
+            api._create_oauth_session(client_id="abc", client_secret="def")  # pylint: disable=protected-access
 
         self.assertIn(
             "Authentication failed: No authorization response received",
@@ -180,7 +180,7 @@ class TimesketchApiRetryTest(unittest.TestCase):
         )
 
         with mock.patch.object(api, "authenticate_oauth_session") as mock_auth:
-            api._create_oauth_session(
+            api._create_oauth_session(  # pylint: disable=protected-access
                 client_id="abc", client_secret="def", timeout_seconds=42
             )
             mock_auth.assert_called_once()

--- a/api_client/python/timesketch_api_client/client_test.py
+++ b/api_client/python/timesketch_api_client/client_test.py
@@ -16,7 +16,7 @@
 from __future__ import unicode_literals
 
 import unittest
-import mock
+from unittest import mock
 
 from . import client
 from . import sketch as sketch_lib
@@ -140,4 +140,72 @@ class TimesketchApiRetryTest(unittest.TestCase):
             str(context.exception),
             "Unable to connect to server, error: Authentication failed: "
             "Invalid username or password.",
+        )
+
+    @mock.patch("timesketch_api_client.client.googleauth_flow.InstalledAppFlow")
+    def test_oauth_timeout_error(self, mock_flow_class):
+        """Test reproduction of b/446157404 where AttributeError is raised."""
+        mock_flow = mock.MagicMock()
+        mock_flow_class.from_client_config.return_value = mock_flow
+
+        # Simulate the bug in google_auth_oauthlib where run_local_server
+        # raises AttributeError when wsgi_app.last_request_uri is None
+        def mock_run_local_server(**unused_kwargs):
+            # This is what happens in google_auth_oauthlib/flow.py
+            last_request_uri = None
+            last_request_uri.replace("http", "https")
+
+        mock_flow.run_local_server.side_effect = mock_run_local_server
+
+        api = client.TimesketchApi(
+            "http://localhost", "user", auth_mode="oauth", create_session=False
+        )
+
+        with self.assertRaises(RuntimeError) as cm:
+            api._create_oauth_session(client_id="abc", client_secret="def")
+
+        self.assertIn(
+            "Authentication failed: No authorization response received",
+            str(cm.exception),
+        )
+
+    @mock.patch("timesketch_api_client.client.googleauth_flow.InstalledAppFlow")
+    def test_oauth_timeout_parameter(self, mock_flow_class):
+        """Test that timeout_seconds is passed to run_local_server."""
+        mock_flow = mock.MagicMock()
+        mock_flow_class.from_client_config.return_value = mock_flow
+
+        api = client.TimesketchApi(
+            "http://localhost", "user", auth_mode="oauth", create_session=False
+        )
+
+        with mock.patch.object(api, "authenticate_oauth_session") as mock_auth:
+            api._create_oauth_session(
+                client_id="abc", client_secret="def", timeout_seconds=42
+            )
+            mock_auth.assert_called_once()
+
+        mock_flow.run_local_server.assert_called_once_with(
+            host="localhost",
+            port=8080,
+            open_browser=False,
+            timeout_seconds=42,
+        )
+
+    @mock.patch("timesketch_api_client.client.googleauth_flow.InstalledAppFlow")
+    def test_constructor_auth_timeout(self, mock_flow_class):
+        """Test that auth_timeout in constructor is passed down."""
+        mock_flow = mock.MagicMock()
+        mock_flow_class.from_client_config.return_value = mock_flow
+
+        with mock.patch.object(client.TimesketchApi, "authenticate_oauth_session"):
+            client.TimesketchApi(
+                "http://localhost", "user", auth_mode="oauth", auth_timeout=123
+            )
+
+        mock_flow.run_local_server.assert_called_once_with(
+            host="localhost",
+            port=8080,
+            open_browser=False,
+            timeout_seconds=123,
         )

--- a/api_client/python/timesketch_api_client/client_test.py
+++ b/api_client/python/timesketch_api_client/client_test.py
@@ -163,9 +163,7 @@ class TimesketchApiRetryTest(unittest.TestCase):
 
         with self.assertRaises(RuntimeError) as cm:
             # pylint: disable=protected-access
-            api._create_oauth_session(
-                client_id="abc", client_secret="def"
-            )
+            api._create_oauth_session(client_id="abc", client_secret="def")
 
         self.assertIn(
             "Authentication failed: No authorization response received",

--- a/api_client/python/timesketch_api_client/client_test.py
+++ b/api_client/python/timesketch_api_client/client_test.py
@@ -162,9 +162,10 @@ class TimesketchApiRetryTest(unittest.TestCase):
         )
 
         with self.assertRaises(RuntimeError) as cm:
+            # pylint: disable=protected-access
             api._create_oauth_session(
                 client_id="abc", client_secret="def"
-            )  # pylint: disable=protected-access
+            )
 
         self.assertIn(
             "Authentication failed: No authorization response received",
@@ -182,7 +183,8 @@ class TimesketchApiRetryTest(unittest.TestCase):
         )
 
         with mock.patch.object(api, "authenticate_oauth_session") as mock_auth:
-            api._create_oauth_session(  # pylint: disable=protected-access
+            # pylint: disable=protected-access
+            api._create_oauth_session(
                 client_id="abc", client_secret="def", timeout_seconds=42
             )
             mock_auth.assert_called_once()

--- a/api_client/python/timesketch_api_client/client_test.py
+++ b/api_client/python/timesketch_api_client/client_test.py
@@ -162,7 +162,9 @@ class TimesketchApiRetryTest(unittest.TestCase):
         )
 
         with self.assertRaises(RuntimeError) as cm:
-            api._create_oauth_session(client_id="abc", client_secret="def")  # pylint: disable=protected-access
+            api._create_oauth_session(
+                client_id="abc", client_secret="def"
+            )  # pylint: disable=protected-access
 
         self.assertIn(
             "Authentication failed: No authorization response received",


### PR DESCRIPTION
Introduce `auth_timeout=None,`as new argument in the API client.
This PR fixes an ungraceful crash that occurred when the OAuth authentication flow timed out. 

* **Graceful OAuth Error Handling:** Catches the specific `AttributeError` thrown by `google_auth_oauthlib` when an OAuth flow times out, and raises a user-friendly `RuntimeError` instead.
*  **Includes a test** .