### PR TITLE
Fix super().setUp() in intelligence test

### DIFF
--- a/cli_client/python/timesketch_cli_client/commands/intelligence_test.py
+++ b/cli_client/python/timesketch_cli_client/commands/intelligence_test.py
@@ -33,6 +33,8 @@ class IntelligenceTest(unittest.TestCase):
     @mock.patch("requests.Session", api_test_lib.mock_session)
     def setUp(self):
         """Setup test case."""
+
+        super().setUp()
         self.ctx = test_lib.get_cli_context()
 
     def test_list_intelligence(self):


### PR DESCRIPTION
Small addition in intelligence_test.py to add `super().setUp()` in `def setUp(self)`