### PR TITLE
Implement Sec-Gemini BYOT Log Analysis Support

### DIFF
--- a/contrib/secgemini_byot/Dockerfile
+++ b/contrib/secgemini_byot/Dockerfile
@@ -1,0 +1,18 @@
+# Use a lightweight python image
+FROM python:3.12-slim
+
+# Prevent python from writing pyc files and buffering stdout/stderr
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Copy requirements and install
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy implementation files
+COPY *.py ./
+
+# Entrypoint running the BYOT client
+ENTRYPOINT ["python", "byot_client.py"]

--- a/contrib/secgemini_byot/Dockerfile
+++ b/contrib/secgemini_byot/Dockerfile
@@ -11,8 +11,14 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy implementation files
-COPY *.py ./
+# Create a non-privileged user for least-privilege execution
+RUN useradd -u 1000 -m -s /bin/bash byotuser
+
+# Copy implementation files and set ownership
+COPY --chown=byotuser:byotuser *.py ./
+
+# Drop root privileges
+USER byotuser
 
 # Entrypoint running the BYOT client
 ENTRYPOINT ["python", "byot_client.py"]

--- a/contrib/secgemini_byot/README.md
+++ b/contrib/secgemini_byot/README.md
@@ -1,0 +1,96 @@
+# SecGemini Bring Your Own Tool (BYOT) client for Timesketch
+
+This directory contains the code to build and run a client-side BYOT connection
+tunnel for Google's SecGemini log analysis agent.
+
+Instead of uploading raw log files to the cloud, this client establishes a secure
+outbound reverse tunnel to SecGemini, exposing standard search and describe
+tools that query your Timesketch server on-demand using the official
+`timesketch-api-client`.
+
+---
+
+## Deployment Steps
+
+### 1. Create a Bot User in Timesketch
+It is recommended to run the BYOT client under a dedicated "bot user" profile (e.g. `sec-gemini-bot`):
+1. Create a new user account in Timesketch.
+  * `tsctl create-user --username sec-gemini-bot --password <password>`
+2. **Sharing sketches:**
+   * **Automatic (Recommended):** If you configure `byot_username` in the server's
+      `timesketch.conf` (see Server Configuration below), the server will
+      automatically share any analyzed sketch with the bot user.
+   * **Manual:** Alternatively, manually use the "Share" button in the Timesketch
+      UI and grant **Read** permission to your bot user.
+
+### 2. Build the Docker Image
+Build the image locally:
+
+```bash
+cd contrib/secgemini_byot/
+docker build -t timesketch-secgemini-byot .
+```
+
+### 3. Run the Container
+Run the container on a host that has network access to both the Timesketch
+server API and the internet (to reach SecGemini API in the cloud).
+
+Pass the credentials and configurations via environment variables:
+
+```bash
+docker run -d \
+  --name timesketch-byot-client \
+  -e TIMESKETCH_URL="<Timesketch-URL>" \
+  -e TIMESKETCH_USERNAME="<sec-gemini-bot>" \
+  -e TIMESKETCH_PASSWORD="<password>" \
+  -e SEC_GEMINI_API_KEY="<your-secgemini-cloud-api-key>" \
+  -e TUNNEL_NAME="byot-sec-gemini-bot" \
+  timesketch-secgemini-byot
+```
+
+> [!NOTE]
+> If running in a local development environment (e.g., Docker Compose), you may
+> need to attach the container to the same network as the Timesketch instance:
+> `--network timesketch-network` and set `TIMESKETCH_URL="http://timesketch:5000"`.
+
+### Environment Variables
+
+| Variable | Description | Required |
+| :--- | :--- | :--- |
+| `TIMESKETCH_URL` | Root URL of the Timesketch instance (e.g. `https://timesketch.example.com`) | Yes |
+| `TIMESKETCH_USERNAME` | Username of the bot or analyst account | Yes |
+| `TIMESKETCH_PASSWORD` | Password of the bot or analyst account | Yes |
+| `SEC_GEMINI_API_KEY` | Your Google Cloud API Key for SecGemini | Yes |
+| `SEC_GEMINI_HOST` | Custom endpoint/host for the SecGemini Hub (e.g. to route to internal or staging endpoints) | No |
+| `TUNNEL_NAME` | Name of the reverse tunnel. Must match `byot_tunnel_name` in the Timesketch server configuration. Default: `byot-sec-gemini-bot` | No |
+
+---
+
+## Server Configuration
+For this tunnel to work, the Timesketch server must know not to upload logs and
+instead reference the tunnel name.
+
+In your Timesketch server's `timesketch.conf`, configure the
+`secgemini_log_analyzer_agent` provider:
+
+```python
+LLM_PROVIDER_CONFIGS = {
+    "secgemini_log_analyzer_agent": {
+        "host": "",
+        "api_key": "<SEC-GEMINI-API-KEY>",
+        # Disable log uploading
+        "upload_logs_to_secgemini": False,
+        # Specify the name of the tunnel created by this client container
+        "byot_tunnel_name": "byot-sec-gemini-bot",
+        # Automatically grant access to this bot user when triggering analysis
+        "byot_username": "sec-gemini-bot",
+        "meta": {},
+    }
+}
+```
+
+---
+
+## Ownership & Support
+* [samomi-oss](https://github.com/samomi-oss)
+* [jkppr](https://github.com/jkppr)

--- a/contrib/secgemini_byot/README.md
+++ b/contrib/secgemini_byot/README.md
@@ -40,6 +40,7 @@ Pass the credentials and configurations via environment variables:
 ```bash
 docker run -d \
   --name timesketch-byot-client \
+  --restart unless-stopped \
   -e TIMESKETCH_URL="<Timesketch-URL>" \
   -e TIMESKETCH_USERNAME="<sec-gemini-bot>" \
   -e TIMESKETCH_PASSWORD="<password>" \
@@ -47,6 +48,13 @@ docker run -d \
   -e TUNNEL_NAME="byot-sec-gemini-bot" \
   timesketch-secgemini-byot
 ```
+
+> [!TIP]
+> **Automatic Recovery:** We strongly recommend running the container with
+> `--restart unless-stopped` (or `--restart always`). The BYOT client runs an
+> internal health check every 5 seconds and will exit automatically if the
+> reverse tunnel disconnects, allowing Docker to restart it and re-establish a
+> clean websocket connection within seconds.
 
 > [!NOTE]
 > If running in a local development environment (e.g., Docker Compose), you may

--- a/contrib/secgemini_byot/byot_client.py
+++ b/contrib/secgemini_byot/byot_client.py
@@ -1,0 +1,130 @@
+# Copyright 2026 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Entrypoint script for the client-side SecGemini BYOT container."""
+
+import asyncio
+import inspect
+import logging
+import os
+import sys
+
+from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+from sec_gemini.byot import ByotService
+from sec_gemini.logs_mcp.backends.sqlite import multi_db_tools
+from timesketch_api_client import client as ts_client
+
+from timesketch_logstore import DynamicLogStoreMap
+
+# Setup logging to stdout
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    stream=sys.stdout,
+)
+logger = logging.getLogger("timesketch.byot.client")
+
+
+def get_required_env(name: str) -> str:
+    val = os.getenv(name)
+    if not val:
+        logger.error("Missing required environment variable: %s", name)
+        sys.exit(1)
+    return val
+
+
+async def main():
+    """Main execution function for the BYOT client container."""
+    # Read configuration from environment
+    timesketch_url = get_required_env("TIMESKETCH_URL")
+    username = get_required_env("TIMESKETCH_USERNAME")
+    password = get_required_env("TIMESKETCH_PASSWORD")
+    secgemini_api_key = get_required_env("SEC_GEMINI_API_KEY")
+    tunnel_name = os.getenv("TUNNEL_NAME", "byot-sec-gemini-bot")
+
+    logger.info("Initializing Timesketch API client for %s...", timesketch_url)
+    try:
+        api = ts_client.TimesketchApi(
+            host_uri=timesketch_url,
+            username=username,
+            password=password,
+        )
+        # Attempt to fetch list of sketches to verify connection/credentials
+        sketches = list(api.list_sketches(scope="all"))
+        logger.info(
+            "Successfully authenticated. User has access to %d sketches.",
+            len(sketches),
+        )
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.exception("Failed to authenticate to Timesketch API")
+        sys.exit(1)
+
+    logger.info("Configuring LogStore map...")
+    # Monkeypatch the SQLite multi_db_tools LOG_STORES map with our API
+    # client-backed version.
+    multi_db_tools.LOG_STORES = DynamicLogStoreMap(api)
+
+    # Initialize FastMCP server
+    logger.info("Setting up FastMCP server: %s", tunnel_name)
+    mcp = FastMCP(tunnel_name)
+
+    # Register the tools from multi_db_tools
+    mcp.tool(
+        description=inspect.getdoc(multi_db_tools.describe_available_logs),
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )(multi_db_tools.describe_available_logs)
+
+    mcp.tool(
+        description=inspect.getdoc(multi_db_tools.search_logs),
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )(multi_db_tools.search_logs)
+
+    secgemini_host = os.getenv("SEC_GEMINI_HOST")
+
+    # Initialize and start BYOT Tunnel Service
+    logger.info("Starting BYOT reverse tunnel connection to SecGemini...")
+    byot_kwargs = {
+        "api_key": secgemini_api_key,
+        "name": tunnel_name,
+        "max_retries": -1,
+    }
+    if secgemini_host:
+        logger.info("Using custom SecGemini Hub host: %s", secgemini_host)
+        byot_kwargs["hub_url"] = secgemini_host
+
+    byot = ByotService(**byot_kwargs)
+
+    try:
+        await byot.start(tools=[mcp])
+        logger.info("Waiting for tunnel connection to establish...")
+        await byot.wait_connected()
+        logger.info("Tunnel connected successfully! Listening for tool calls...")
+
+        # Keep running until terminated
+        while True:
+            await asyncio.sleep(3600)
+    except asyncio.CancelledError:
+        logger.info("Shutting down BYOT client...")
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.exception("BYOT service encountered an error")
+    finally:
+        await byot.stop()
+        logger.info("BYOT client stopped.")
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        logger.info("Execution interrupted by user.")

--- a/contrib/secgemini_byot/byot_client.py
+++ b/contrib/secgemini_byot/byot_client.py
@@ -24,6 +24,7 @@ from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 from sec_gemini.byot import ByotService
 from sec_gemini.logs_mcp.backends.sqlite import multi_db_tools
+
 # pylint: enable=import-error
 from timesketch_api_client import client as ts_client
 

--- a/contrib/secgemini_byot/byot_client.py
+++ b/contrib/secgemini_byot/byot_client.py
@@ -114,9 +114,17 @@ async def main():
         await byot.wait_connected()
         logger.info("Tunnel connected successfully! Listening for tool calls...")
 
-        # Keep running until terminated
+        # Monitor tunnel health periodically; exit on failure for Docker restart
         while True:
-            await asyncio.sleep(3600)
+            await asyncio.sleep(5)
+            status = byot.status()
+            if status.state.name in ("ERROR", "STOPPED"):
+                logger.error(
+                    "Tunnel entered %s state (error: %s). Exiting for restart...",
+                    status.state.name,
+                    status.error,
+                )
+                sys.exit(1)
     except asyncio.CancelledError:
         logger.info("Shutting down BYOT client...")
     except Exception:  # pylint: disable=broad-exception-caught

--- a/contrib/secgemini_byot/byot_client.py
+++ b/contrib/secgemini_byot/byot_client.py
@@ -19,10 +19,12 @@ import logging
 import os
 import sys
 
+# pylint: disable=import-error
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 from sec_gemini.byot import ByotService
 from sec_gemini.logs_mcp.backends.sqlite import multi_db_tools
+# pylint: enable=import-error
 from timesketch_api_client import client as ts_client
 
 from timesketch_logstore import DynamicLogStoreMap

--- a/contrib/secgemini_byot/plaso_types.py
+++ b/contrib/secgemini_byot/plaso_types.py
@@ -1,0 +1,370 @@
+# Copyright 2026 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utilities for working with Plaso logs and log source descriptions."""
+
+# List of data types that are supported by Plaso.
+PLASO_DATA_TYPE_DESCRIPTIONS = {
+    "android:app_usage": "Android application usage event data.",
+    "android:event:battery": "Android turbo battery event data.",
+    "android:event:call": "Android Call event data.",
+    "android:logcat": "Android logcat event data.",
+    "android:messaging:hangouts": "Google Hangouts Message event data.",
+    "android:messaging:sms": "Android SMS event data.",
+    "android:sqlite:app_usage": "Android app usage event data.",
+    "android:tango:contact": "Tango on Android contact event data.",
+    "android:tango:conversation": "Tango on Android conversation event data.",
+    "android:tango:message": "Tango on Android message event data.",
+    "android:twitter:contact": "Twitter on Android contact event data.",
+    "android:twitter:search": "Twitter on Android search event data.",
+    "android:twitter:status": "Twitter on Android status event data.",
+    "android:webview:cookie": "Android WebView cookie event data.",
+    "android:webviewcache": "Android WebViewCache event data.",
+    "apache:access_log:entry": "Apache access log event data.",
+    "av:defender:detection_history": (
+        "Windows Defender scan DetectionHistory event data."
+    ),
+    "av:mcafee:accessprotectionlog": "McAfee AV Log event data.",
+    "av:symantec:scanlog": "Symantec event data.",
+    "av:trendmicro:scan": "Trend Micro AV Log event data.",
+    "av:trendmicro:webrep": "Trend Micro Web Reputation Log event data.",
+    "aws:cloudtrail:entry": "AWS CloudTrail log event data.",
+    "aws:elb:access": "AWS Elastic Load Balancer access log event data.",
+    "azure:activitylog:entry": "Azure activity log event data.",
+    "azure:application_gateway_access:entry": (
+        "Azure application gateway access log event data."
+    ),
+    "bash:history:entry": "Bash history log event data.",
+    "bsm:entry": "Basic Security Module (BSM) audit event data.",
+    "ccleaner:configuration": "CCleaner configuration event data.",
+    "ccleaner:update": "CCleaner update event data.",
+    "chrome:autofill:entry": "Chrome Autofill event data.",
+    "chrome:cache:entry": "Chrome Cache event data.",
+    "chrome:cookie:entry": "Chrome Cookie event data.",
+    "chrome:extension_activity:activity_log": ("Chrome Extension Activity event data."),
+    "chrome:history:file_downloaded": ("Chrome History file downloaded event data."),
+    "chrome:history:page_visited": "Chrome History page visited event data.",
+    "chrome:preferences:content_settings:exceptions": (
+        "Chrome content settings exceptions event data."
+    ),
+    "chrome:preferences:extension_installation": "Chrome extension event data.",
+    "chrome:preferences:extensions_autoupdater": (
+        "Chrome Extension Autoupdater event data."
+    ),
+    "confluence:access": "Confluence access event data.",
+    "cookie:google:analytics:utma": ("Google analytics __utma cookie event data."),
+    "cookie:google:analytics:utmb": ("Google analytics __utmb cookie event data."),
+    "cookie:google:analytics:utmt": ("Google analytics __utmt cookie event data."),
+    "cookie:google:analytics:utmz": ("Google analytics __utmz cookie event data."),
+    "cri:container:log:entry": "CRI log event data.",
+    "cups:ipp:event": "CUPS IPP event data.",
+    "docker:container:configuration": ("Docker container configuration event data."),
+    "docker:container:log:entry": "Docker container log event data.",
+    "docker:layer:configuration": "Docker layer configuration event data.",
+    "docker:json:container:log": "Docker Container Logs.",
+    "docker:json:container": "Docker Container Logs.",
+    "dropbox:sync_history:entry": "Dropbox Sync History Database event data.",
+    "edge:resources:load_statistics": (
+        "Microsoft Edge load statistics resource event data."
+    ),
+    "event": "Formatter for events that do not have any defined formatter.",
+    "file_entry": "File entry event source.",
+    "firefox:cache:record": "Firefox cache event data.",
+    "firefox:cookie:entry": "Firefox Cookie event data.",
+    "firefox:downloads:download": "Firefox download event data.",
+    "firefox:places:bookmark": "Firefox bookmark event data.",
+    "firefox:places:bookmark_annotation": ("Firefox bookmark annotation event data."),
+    "firefox:places:bookmark_folder": "Firefox bookmark folder event data.",
+    "firefox:places:page_visited": "Firefox page visited event data.",
+    "fish:history:entry": "Fish history log event data.",
+    "fs:bodyfile:entry": "Bodyfile event data.",
+    "fs:ntfs:usn_change": "NTFS USN change event data.",
+    "fs:stat": "File system stat event data.",
+    "fs:stat:ntfs": "NTFS file system stat event data.",
+    "gcp:log:entry": "Google Cloud (GCP) log event data.",
+    "gcp:log:json": "Google Cloud (GCP) json data.",
+    "gdrive:snapshot:cloud_entry": ("Google Drive snapshot cloud entry event data."),
+    "gdrive:snapshot:local_entry": ("Google Drive snapshot local entry event data."),
+    "google_drive_sync_log:entry": "Google Drive Sync log event data.",
+    "googlelog:log": "Google-formatted log file event data.",
+    "iis:log:line": "IIS log event data.",
+    "imessage:event:chat": "iMessage and SMS event data.",
+    "ios:app_privacy:access": ("iOS application privacy report event of type access."),
+    "ios:app_privacy:network": (
+        "iOS application privacy report event of type network activity."
+    ),
+    "ios:carplay:history:entry": ("Apple iOS Car Play application history event data."),
+    "ios:datausage:event": "iOS datausage event data.",
+    "ios:idstatuscache:lookup": ("iOS identity services status cache event data."),
+    "ios:kik:messaging": "Kik message event data.",
+    "ios:lockdownd_log:entry": ("iOS lockdown daemon (lockdownd) log event data."),
+    "ios:netusage:process": "iOS netusage process event data.",
+    "ios:netusage:route": "iOS netusage connection event data.",
+    "ios:powerlog:application_usage": (
+        "iOS powerlog file application usage event data."
+    ),
+    "ios:screentime:event": "iOS Screen Time file usage event data.",
+    "ios:sysdiag_log:entry": "iOS sysdiagnose log event data.",
+    "ios:sysdiagnose:logd:line": "iOS sysdiagnose logd event data.",
+    "ios:twitter:contact": "Twitter on iOS 8+ contact event data.",
+    "ios:twitter:status": "Parent class for Twitter on iOS 8+ status events.",
+    "ipod:device:entry": "iPod plist event data.",
+    "java:download:idx": "Java IDX cache file event data.",
+    "kodi:videos:viewing": "Kodi video event data.",
+    "linux:apt_history_log:entry": "APT History log event data.",
+    "linux:dpkg_log:entry": "Dpkg event data.",
+    "linux:locate_database:entry": ("Linux locate database (updatedb) event data."),
+    "linux:popularity_contest_log:entry": "Popularity Contest event data.",
+    "linux:popularity_contest_log:session": ("Popularity Contest session event data."),
+    "linux:utmp:event": "Linux libc6 utmp event data.",
+    "mackeeper:cache": "MacKeeper Cache event data.",
+    "macos:airport:entry": "MacOS airport event data.",
+    "macos:appfirewall_log:entry": (
+        "MacOS Application firewall log (appfirewall.log) file event data."
+    ),
+    "macos:apple_account:entry": "Apple account event data.",
+    "macos:application_usage:entry": "MacOS application usage event data.",
+    "macos:asl:entry": "Apple System Log (ASL) event data.",
+    "macos:asl:file": "Apple System Log (ASL) file event data.",
+    "macos:background_items:entry": "Mac OS background item event data.",
+    "macos:bluetooth:entry": "MacOS Bluetooth event data.",
+    "macos:document_versions:file": "MacOS document revision event data.",
+    "macos:fseventsd:record": "MacOS file system event (fseventsd) event data.",
+    "macos:install_history:entry": "MacOS install history event data.",
+    "macos:keychain:application": (
+        "MacOS keychain application password record event data."
+    ),
+    "macos:keychain:internet": "MacOS keychain internet record event data.",
+    "macos:knowledgec:application": ("KnowledgeC application execution event data."),
+    "macos:knowledgec:safari": (
+        "MacOS Duet/KnowledgeC database event data for Safari."
+    ),
+    "macos:launchd:entry": "MacOS launchd event data.",
+    "macos:launchd_log:entry": "Mac OS launchd log event data.",
+    "macos:login_items:entry": "Mac OS login item event data.",
+    "macos:login_window:entry": "Mac OS login window event data.",
+    "macos:login_window:managed_login_item": (
+        "Mac OS login window managed login item event data."
+    ),
+    "macos:lsquarantine:entry": "MacOS launch services quarantine event data.",
+    "macos:notes:entry": "MacOS Notes event data.",
+    "macos:notification_center:entry": "MacOS NotificationCenter event data.",
+    "macos:securityd_log:entry": "MacOS securityd log event data.",
+    "macos:software_updata:entry": "MacOS software update event data.",
+    "macos:startup_item:entry": "Mac OS startup item event data.",
+    "macos:tcc_entry": "MacOS TCC event data.",
+    "macos:time_machine:backup": "MacOS TimeMachine backup event data.",
+    "macos:unified_logging:event": "Apple Unified Logging (AUL) event data.",
+    "macos:user:entry": "MacOS user event data.",
+    "macos:utmpx:entry": "MacOS utmpx event data.",
+    "macos:wifi_log:entry": "MacOS Wi-Fi log event data.",
+    "microsoft365:audit_log:entry": ("Microsoft (Office) 365 audit log event data."),
+    "msie:webcache:container": "MSIE WebCache Container table event data.",
+    "msie:webcache:containers": "MSIE WebCache Containers table event data.",
+    "msie:webcache:cookie": "MSIE WebCache Container table event data.",
+    "msie:webcache:leak_file": "MSIE WebCache LeakFiles event data.",
+    "msie:webcache:partitions": "MSIE WebCache Partitions table event data.",
+    "msiecf:leak": "MSIECF leak event data.",
+    "msiecf:redirected": "MSIECF redirected event data.",
+    "msiecf:url": "MSIECF URL event data.",
+    "networkminer:fileinfos:file": "NetworkMiner event Data.",
+    "olecf:dest_list:entry": (".automaticDestinations-ms DestList entry event data."),
+    "olecf:document_summary_info": ("OLECF document summary information event data."),
+    "olecf:item": "OLECF item event data.",
+    "olecf:summary_info": "OLECF summary information event data.",
+    "openxml:metadata": "OXML event data.",
+    "opera:history:entry": "Opera global history entry data.",
+    "opera:history:typed_entry": "Opera typed history entry data.",
+    "p2p:bittorrent:transmission": "Transmission BitTorrent event data.",
+    "p2p:bittorrent:utorrent": "UTorrent active torrent event data.",
+    "pe_coff:dll_import": "Portable Executable (PE) DLL import event data.",
+    "pe_coff:file": "Portable Executable (PE) file event data.",
+    "pe_coff:resource": "Portable Executable (PE) resource event data.",
+    "plist:key": "Plist event data attribute container.",
+    "pls_recall:entry": "PL/SQL Recall event data.",
+    "postgresql:application_log:entry": "PostgreSQL application log data.",
+    "powershell:transcript_log:entry": "PowerShell transcript log event data.",
+    "safari:cookie:entry": "Safari binary cookie event data.",
+    "safari:downloads:entry": "Safari download event data.",
+    "safari:history:visit": "Safari history event data.",
+    "safari:history:visit_sqlite": "Safari history event data.",
+    "santa:diskmount": "Santa mount event data.",
+    "santa:execution": "Santa execution event data.",
+    "santa:file_system_event": "Santa file system event data.",
+    "santa:process_exit": "Santa process exit event data.",
+    "sccm_log:entry": "SCCM log event data.",
+    "selinux:line": "SELinux log event data.",
+    "setupapi:log:line": "SetupAPI log event data.",
+    "shell:zsh:history": "ZSH history event data.",
+    "skydrive:log:entry": "SkyDrive log event data.",
+    "skype:event:account": "Skype account event data.",
+    "skype:event:call": "Skype call event data.",
+    "skype:event:chat": "Skype chat event data.",
+    "skype:event:sms": "Skype SMS event data.",
+    "skype:event:transferfile": "Skype file transfer event data.",
+    "snort:fastlog:alert": "Snort3/Suricata fast-log alert event data.",
+    "sophos:av:log": "Sophos anti-virus log event data.",
+    "spotlight:metadata_item": (
+        "Apple Spotlight store database metadata item event data."
+    ),
+    "spotlight_searched_terms:entry": "Spotlight searched terms event data.",
+    "spotlight_volume_configuration:store": (
+        "Spotlight volume configuration event data."
+    ),
+    "syslog:comment": "Syslog comment event data.",
+    "syslog:cron:task_run": "Syslog cron task run event data.",
+    "syslog:line": "Syslog line event data.",
+    "syslog:ssh:failed_connection": "SSH failed connection event data.",
+    "syslog:ssh:login": "SSH login event data.",
+    "syslog:ssh:opened_connection": "SSH opened connection event data.",
+    "systemd:journal": "Systemd journal event data.",
+    "task_scheduler:task_cache:entry": "Task Cache event data.",
+    "teamviewer:application_log:entry": ("TeamViewer application log event data."),
+    "teamviewer:connections_incoming:entry": (
+        "TeamViewer incoming connection log event data."
+    ),
+    "teamviewer:connections_outgoing:entry": (
+        "TeamViewer outgoing connection log event data."
+    ),
+    "viminfo:history": "VimInfo event data.",
+    "vsftpd:log": "Vsftpd log event data.",
+    "wincc:simatic_s7:entry": "SIMATIC S7 event data.",
+    "wincc:sys_log:entry": "WinCC Sys Log event data.",
+    "windows:diagnosis:eventtranscript": (
+        "Windows diagnosis EventTranscript event data."
+    ),
+    "windows:distributed_link_tracking:creation": (
+        "Windows distributed link event data attribute container."
+    ),
+    "windows:evt:record": "Windows EventLog (EVT) record event data.",
+    "windows:evtx:record": "Windows XML EventLog (EVTX) record event data.",
+    "windows:file_history:namespace": ("File history namespace table event data."),
+    "windows:firewall_log:entry": "Windows Firewall event data.",
+    "windows:lnk:link": "Windows Shortcut (LNK) link event data.",
+    "windows:metadata:deleted_item": "Windows Recycle Bin event data.",
+    "windows:onedrive:log": "OneDrive log event data.",
+    "windows:pca_log:entry": (
+        "Windows PCA (Program Compatibility Assistant) event data."
+    ),
+    "windows:prefetch:execution": "Windows Prefetch event data.",
+    "windows:registry:amcache": "AMCache file event data.",
+    "windows:registry:amcache:programs": "AMCache programs event data.",
+    "windows:registry:appcompatcache": ("Application Compatibility Cache event data."),
+    "windows:registry:bagmru": (
+        "BagMRU (or ShellBags) event data attribute container."
+    ),
+    "windows:registry:bam": "Background Activity Moderator event data.",
+    "windows:registry:boot_execute": (
+        "Windows Boot Execute event data attribute container."
+    ),
+    "windows:registry:boot_verification": (
+        "Windows Boot Verification event data attribute container."
+    ),
+    "windows:registry:explorer:programcache": (
+        "Explorer ProgramsCache event data attribute container."
+    ),
+    "windows:registry:installation": (
+        "Windows installation event data attribute container."
+    ),
+    "windows:registry:key_value": ("Windows Registry event data attribute container."),
+    "windows:registry:motherboard_info": (
+        "Windows Motherboard Info event data attribute container."
+    ),
+    "windows:registry:mount_points2": (
+        "Windows MountPoints2 event data attribute container."
+    ),
+    "windows:registry:mrulist": "MRUList event data attribute container.",
+    "windows:registry:mrulistex": "MRUListEx event data attribute container.",
+    "windows:registry:msie_zone_settings": (
+        "MSIE zone settings event data attribute container."
+    ),
+    "windows:registry:mstsc:connection": (
+        "Terminal Server client connection event data attribute container."
+    ),
+    "windows:registry:mstsc:mru": (
+        "Terminal Server client MRU event data attribute container."
+    ),
+    "windows:registry:network": "Windows NetworkList event data.",
+    "windows:registry:network_drive": ("Network drive event data attribute container."),
+    "windows:registry:office_mru": (
+        "Microsoft Office MRU Windows Registry event data."
+    ),
+    "windows:registry:office_mru_list": (
+        "Microsoft Office MRU list Windows Registry event data."
+    ),
+    "windows:registry:outlook_search_mru": (
+        "Outlook search MRU event data attribute container."
+    ),
+    "windows:registry:run": "Run/RunOnce key event data attribute container.",
+    "windows:registry:sam_users": (
+        "Class that defines SAM users Windows Registry event data."
+    ),
+    "windows:registry:service": (
+        "Windows Registry driver or service event data attribute container."
+    ),
+    "windows:registry:shutdown": "Shutdown Windows Registry event data.",
+    "windows:registry:timezone": ("Timezone settings event data attribute container."),
+    "windows:registry:typedurls": "Typed URLs event data attribute container.",
+    "windows:registry:usb": ("Windows USB device event data attribute container."),
+    "windows:registry:usbstor:instance": (
+        "USBStor device instance event data attribute container."
+    ),
+    "windows:registry:userassist": "UserAssist Windows Registry event data.",
+    "windows:registry:winlogon": "Winlogon event data attribute container.",
+    "windows:restore_point:info": "Windows Restore Point event data.",
+    "windows:shell_item:file_entry": (
+        "Windows shell item file entry event data attribute container."
+    ),
+    "windows:srum:application_usage": ("SRUM application resource usage event data."),
+    "windows:srum:network_connectivity": (
+        "SRUM network connectivity usage event data."
+    ),
+    "windows:srum:network_usage": "SRUM network data usage event data.",
+    "windows:tasks:job": "Windows Scheduled Task event data.",
+    "windows:tasks:trigger": "Windows Scheduled Task trigger event data.",
+    "windows:timeline:generic": ("Windows 10 timeline database generic event data."),
+    "windows:timeline:user_engaged": (
+        "Windows 10 timeline database User Engaged event data."
+    ),
+    "windows:user_access_logging:clients": (
+        "Windows User Access Logging CLIENTS table event data."
+    ),
+    "windows:user_access_logging:dns": (
+        "Windows User Access Logging DNS table event data."
+    ),
+    "windows:user_access_logging:role_access": (
+        "Windows User Access Logging ROLE_ACCESS table event data."
+    ),
+    "windows:user_access_logging:system_identity": (
+        "Windows User Access Logging SYSTEM_IDENTITY table event data."
+    ),
+    "windows:user_access_logging:virtual_machines": (
+        "Windows User Access Logging VIRTUALMACHINES table event data."
+    ),
+    "windows:volume:creation": "Windows volume event data attribute container.",
+    "windows:wpndatabase:notification": "Windows push notification event data.",
+    "windows:wpndatabase:notification_handler": (
+        "Windows push notification handler event data."
+    ),
+    "winrar:history": "WinRAR history event data attribute container.",
+    "xchat:log:line": "XChat Log event data.",
+    "xchat:scrollback:line": "XChat Scrollback line event data.",
+    "zeitgeist:activity": "Zeitgeist activity event data.",
+    "linux:locate": "Linux locate database (updatedb) event data.",
+    "bash:history:command": "Bash history log event data.",
+    "PLSRecall:event": "PL/SQL Recall event data.",
+    "fs:mactime:line": "Mactime filesystem event data.",
+    "dpkg:line": "Dpkg event data.",
+    "apt:history:line": "APT History log event data.",
+    "pe": "Portable Executable (PE).",
+}

--- a/contrib/secgemini_byot/requirements.txt
+++ b/contrib/secgemini_byot/requirements.txt
@@ -1,0 +1,5 @@
+# Standard python requirements for BYOT client
+timesketch-api-client
+pandas
+fastmcp
+sec-gemini

--- a/contrib/secgemini_byot/timesketch_logstore.py
+++ b/contrib/secgemini_byot/timesketch_logstore.py
@@ -1,0 +1,459 @@
+# Copyright 2026 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Timesketch API Client LogStore implementation aligned with reference."""
+
+import asyncio
+import datetime
+import logging
+import math
+from typing import Any, Iterable, Optional
+
+from sec_gemini.logs_mcp.common import logstore as ls
+from timesketch_api_client import client as ts_client
+from timesketch_api_client import search
+
+import plaso_types
+
+logger = logging.getLogger("timesketch.byot.logstore")
+
+EPOCH_START = datetime.datetime(1970, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+
+
+def _escape_opensearch_query(k: str) -> str:
+    """Escapes OpenSearch reserved characters including backslashes."""
+    # Backslash must be escaped first
+    k = k.replace("\\", "\\\\")
+    for char in [
+        "+",
+        "-",
+        "=",
+        "&&",
+        "||",
+        ">",
+        "<",
+        "!",
+        "(",
+        ")",
+        "{",
+        "}",
+        "[",
+        "]",
+        "^",
+        '"',
+        "~",
+        "*",
+        "?",
+        ":",
+        "/",
+        " ",
+    ]:
+        k = k.replace(char, f"\\{char}")
+    return k
+
+
+def _multi_field_clause(keyword: str, negate: bool = False) -> str:
+    """Builds a substring match query across message, tags, and timestamp_desc."""
+    escaped = _escape_opensearch_query(keyword)
+    fields = [
+        "message.keyword",
+        "tag",
+        "yara_match",
+        "timestamp_desc",
+    ]
+    match_clause = " OR ".join(f"{field}:*{escaped}*" for field in fields)
+    if negate:
+        return f"NOT ({match_clause})"
+    return f"({match_clause})"
+
+
+def _parse_datetime(val) -> datetime.datetime:
+    """Safely parses a cell value as a datetime object, returning Epoch 0 on failure."""
+    if val is None or (isinstance(val, float) and math.isnan(val)):
+        return EPOCH_START
+    if isinstance(val, datetime.datetime):
+        return val
+    try:
+        clean_val = str(val).replace("Z", "+00:00")
+        return datetime.datetime.fromisoformat(clean_val)
+    except ValueError:
+        return EPOCH_START
+
+
+class TimesketchLogStore(ls.LogStore):
+    """Adapter implementing the Arcadia LogStore format backed by Timesketch API."""
+
+    def __init__(self, api: ts_client.TimesketchApi, sketch_id: int):
+        self.api = api
+        self.sketch_id = sketch_id
+
+    async def describe_logs(self) -> ls.LogDescriptions:
+        """Discovers Timesketch data types and computes daily histograms."""
+        return await asyncio.to_thread(self._describe_logs_sync)
+
+    def _describe_logs_sync(self) -> ls.LogDescriptions:
+        """Synchronously discovers log types and aggregates histograms.
+
+        Returns:
+            LogDescriptions: Discovered data types and volume information.
+        """
+        logger.info("[%d] Discovering sketch log types...", self.sketch_id)
+        try:
+            sketch = self.api.get_sketch(self.sketch_id)
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logger.exception("Failed to get sketch %d", self.sketch_id)
+            return ls.LogDescriptions(
+                status=ls.ResultStatus.ERROR,
+                descriptions=[],
+                error_messages=[f"Failed to get sketch {self.sketch_id}: {str(e)}"],
+            )
+
+        # Discover unique data types using run_aggregator
+        try:
+            type_res = sketch.run_aggregator(
+                aggregator_name="field_bucket",
+                aggregator_parameters={"field": "data_type", "limit": 1000},
+            )
+            objects = type_res.data.get("objects")
+            buckets = []
+            if objects and isinstance(objects, list) and objects[0]:
+                buckets = objects[0].get("field_bucket", {}).get("buckets", [])
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logger.exception("Failed to discover unique log types")
+            return ls.LogDescriptions(
+                status=ls.ResultStatus.ERROR,
+                descriptions=[],
+                error_messages=[f"Failed to discover unique log types: {str(e)}"],
+            )
+
+        descriptions = []
+        for b in buckets:
+            dt = b["data_type"]
+
+            # Query for the earliest event (min time) for this data type
+            min_search = search.Search(sketch=sketch)
+            min_search.query_string = f'data_type:"{dt}"'
+            min_search.max_entries = 1
+            min_search.return_fields = "datetime"
+            min_search.order_ascending()
+            min_df = min_search.table
+
+            start_str = "1970-01-01T00:00:00Z"
+            if not min_df.empty:
+                min_val = min_df.iloc[0].get("datetime")
+                if min_val:
+                    min_time = _parse_datetime(min_val)
+                    min_bounded = (min_time - datetime.timedelta(days=1)).replace(
+                        hour=0, minute=0, second=0, microsecond=0
+                    )
+                    start_str = min_bounded.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+            # Query for the latest event (max time) for this data type
+            max_search = search.Search(sketch=sketch)
+            max_search.query_string = f'data_type:"{dt}"'
+            max_search.max_entries = 1
+            max_search.return_fields = "datetime"
+            max_search.order_descending()
+            max_df = max_search.table
+
+            end_str = "2099-01-01T00:00:00Z"
+            if not max_df.empty:
+                max_val = max_df.iloc[0].get("datetime")
+                if max_val:
+                    max_time = _parse_datetime(max_val)
+                    max_bounded = (max_time + datetime.timedelta(days=1)).replace(
+                        hour=0, minute=0, second=0, microsecond=0
+                    )
+                    end_str = max_bounded.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+            search_obj = search.Search(sketch=sketch)
+            search_obj.query_string = f'data_type:"{dt}"'
+            search_obj.max_entries = 5
+            search_obj.return_fields = (
+                "datetime,message,_id,timestamp_desc,tag,yara_match"
+            )
+            search_obj.order_descending()
+            results_df = search_obj.table
+
+            examples = []
+            for _, row in results_df.iterrows():
+                msg = row.get("message", "")
+                tags_val = row.get("tag", [])
+                if isinstance(tags_val, list):
+                    tags_list = tags_val
+                elif tags_val:
+                    tags_list = [tags_val]
+                else:
+                    tags_list = []
+
+                yara_val = row.get("yara_match", [])
+                if isinstance(yara_val, list):
+                    yara_list = yara_val
+                elif yara_val:
+                    yara_list = [yara_val]
+                else:
+                    yara_list = []
+
+                merged_tags = sorted(
+                    list(
+                        set(
+                            str(t)
+                            for t in tags_list + yara_list
+                            if t and str(t).lower() != "n/a"
+                        )
+                    )
+                )
+                enrich = ", ".join(merged_tags) if merged_tags else None
+
+                examples.append(
+                    ls.LogRecordResult(
+                        record_id=str(row.get("_id", "")),
+                        log_type=dt,
+                        timestamp=_parse_datetime(row.get("datetime")),
+                        timestamp_desc=str(row.get("timestamp_desc", "null")),
+                        message=str(msg),
+                        enrichment=enrich,
+                    )
+                )
+
+            day_counts = []
+            error_suffix = ""
+            try:
+                aggregator_params = {
+                    "field": "data_type",
+                    "field_query_string": dt,
+                    "supported_intervals": "day",
+                    "supported_charts": "table",
+                    "start_time": start_str,
+                    "end_time": end_str,
+                }
+                agg_obj = sketch.run_aggregator(
+                    aggregator_name="date_histogram",
+                    aggregator_parameters=aggregator_params,
+                )
+                raw_objects = agg_obj.resource_data.get("objects", [])
+                if raw_objects:
+                    agg_data = raw_objects[0].get("date_histogram", {})
+                    hist_buckets = agg_data.get("buckets", [])
+
+                    if hist_buckets and isinstance(hist_buckets[0], list):
+                        hist_buckets = hist_buckets[0]
+
+                    for row in hist_buckets:
+                        d_raw = row.get("datetime") or row.get("key_as_string")
+                        if d_raw:
+                            d_str = str(d_raw)[:10]
+                            c_val = int(row.get("count") or row.get("doc_count") or 0)
+                            if c_val > 0:
+                                day_counts.append((d_str, c_val))
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.exception("Failed to run date histogram aggregation for %s", dt)
+                error_suffix = " ERROR: Failed to compute date histogram."
+
+            dt_desc = plaso_types.PLASO_DATA_TYPE_DESCRIPTIONS.get(
+                dt, f"Timesketch log source for {dt}"
+            )
+            if error_suffix:
+                dt_desc += error_suffix
+
+            descriptions.append(
+                ls.LogDescription(
+                    log_type=dt,
+                    description=dt_desc,
+                    per_day_counts=day_counts,
+                    examples=examples,
+                )
+            )
+
+        return ls.LogDescriptions(
+            status=ls.ResultStatus.SUCCESS, descriptions=descriptions
+        )
+
+    async def search_logs(
+        self,
+        log_type: Optional[Any],
+        limit: int,
+        at_or_after: Optional[datetime.datetime],
+        at_or_before: Optional[datetime.datetime],
+        contains_at_least_one_of: Optional[Iterable[str]] = None,
+        must_contain_all_of: Optional[Iterable[str]] = None,
+        must_not_contain_any_of: Optional[Iterable[str]] = None,
+        order_by: ls.Order = ls.Order.CHRONOLOGICAL,
+        exclude_log_type: Optional[Any] = None,
+    ) -> ls.SearchResult:
+        """Executes a search mapped directly to OpenSearch query strings."""
+        return await asyncio.to_thread(
+            self._search_logs_sync,
+            log_type=log_type,
+            limit=limit,
+            at_or_after=at_or_after,
+            at_or_before=at_or_before,
+            contains_at_least_one_of=contains_at_least_one_of,
+            must_contain_all_of=must_contain_all_of,
+            must_not_contain_any_of=must_not_contain_any_of,
+            order_by=order_by,
+        )
+
+    def _search_logs_sync(
+        self,
+        log_type: Optional[str],
+        limit: int,
+        at_or_after: Optional[datetime.datetime],
+        at_or_before: Optional[datetime.datetime],
+        contains_at_least_one_of: Optional[Iterable[str]] = None,
+        must_contain_all_of: Optional[Iterable[str]] = None,
+        must_not_contain_any_of: Optional[Iterable[str]] = None,
+        order_by: ls.Order = ls.Order.CHRONOLOGICAL,
+    ) -> ls.SearchResult:
+        """Synchronously searches logs in Timesketch using specific filters.
+
+        Args:
+            log_type: The log source type string.
+            limit: Maximum count of results.
+            at_or_after: Lower bound timestamp.
+            at_or_before: Upper bound timestamp.
+            contains_at_least_one_of: Match any of these keywords.
+            must_contain_all_of: Match all of these keywords.
+            must_not_contain_any_of: Exclude these keywords.
+            order_by: Order enum value.
+
+        Returns:
+            SearchResult: Result object matching search criteria.
+        """
+        sketch = self.api.get_sketch(self.sketch_id)
+
+        terms = []
+        if log_type:
+            terms.append(f'data_type:"{log_type}"')
+
+        if must_contain_all_of:
+            for keyword in must_contain_all_of:
+                terms.append(_multi_field_clause(keyword))
+
+        if contains_at_least_one_of:
+            or_terms = [_multi_field_clause(k) for k in contains_at_least_one_of]
+            terms.append("(" + " OR ".join(or_terms) + ")")
+
+        if must_not_contain_any_of:
+            for keyword in must_not_contain_any_of:
+                terms.append(_multi_field_clause(keyword, negate=True))
+
+        if at_or_after or at_or_before:
+            start_str = at_or_after.isoformat() if at_or_after else "*"
+            end_str = at_or_before.isoformat() if at_or_before else "*"
+            terms.append(f"datetime:[{start_str} TO {end_str}]")
+
+        query_str = " AND ".join(terms) if terms else "*"
+        logger.info("[%d] Searching Timesketch logs: ( %s )", self.sketch_id, query_str)
+
+        search_obj = search.Search(sketch=sketch)
+        search_obj.query_string = query_str
+        search_obj.max_entries = min(limit, 1000)
+
+        hash_fields = [
+            "hash",
+            "sha256_hash",
+            "sha256",
+            "sha1_hash",
+            "sha1",
+            "md5_hash",
+            "md5",
+        ]
+        base_fields = [
+            "datetime",
+            "message",
+            "_id",
+            "timestamp_desc",
+            "tag",
+            "yara_match",
+        ]
+        search_obj.return_fields = ",".join(base_fields + hash_fields)
+
+        if order_by == ls.Order.REVERSE_CHRONOLOGICAL:
+            search_obj.order_descending()
+        elif order_by == ls.Order.CHRONOLOGICAL:
+            search_obj.order_ascending()
+
+        results_df = search_obj.table
+
+        res = []
+        for _, row in results_df.iterrows():
+            msg = str(row.get("message", ""))
+
+            found_hashes = []
+            for field_name in hash_fields:
+                val = row.get(field_name)
+                if val and str(val).strip() and str(val).lower() != "n/a":
+                    found_hashes.append(f"{field_name}={val}")
+
+            if found_hashes:
+                hash_ctx = ", ".join(found_hashes)
+                msg = f"[{hash_ctx}] {msg}"
+
+            tags_val = row.get("tag", [])
+            if isinstance(tags_val, list):
+                tags_list = tags_val
+            elif tags_val:
+                tags_list = [tags_val]
+            else:
+                tags_list = []
+
+            yara_val = row.get("yara_match", [])
+            if isinstance(yara_val, list):
+                yara_list = yara_val
+            elif yara_val:
+                yara_list = [yara_val]
+            else:
+                yara_list = []
+
+            merged_tags = sorted(
+                list(
+                    set(
+                        str(t)
+                        for t in tags_list + yara_list
+                        if t and str(t).lower() != "n/a"
+                    )
+                )
+            )
+            enrich = ", ".join(merged_tags) if merged_tags else None
+
+            res.append(
+                ls.LogRecordResult(
+                    record_id=str(row.get("_id", "")),
+                    log_type=str(row.get("data_type", "none")),
+                    timestamp=_parse_datetime(row.get("datetime")),
+                    timestamp_desc=str(row.get("timestamp_desc", "null")),
+                    message=msg,
+                    enrichment=enrich,
+                )
+            )
+
+        return ls.SearchResult(status=ls.ResultStatus.SUCCESS, results=res)
+
+
+class DynamicLogStoreMap(dict):
+    """Dynamic dict subclass returning TimesketchLogStore per sketch/ticket ID."""
+
+    def __init__(self, api: ts_client.TimesketchApi):
+        self.api = api
+        super().__init__()
+
+    def __contains__(self, key: Any) -> bool:
+        return True
+
+    def __getitem__(self, key: Any) -> TimesketchLogStore:
+        try:
+            sketch_id = int(key)
+        except (ValueError, TypeError) as exc:
+            raise KeyError(f"Invalid sketch_id format: {key}") from exc
+        return TimesketchLogStore(self.api, sketch_id)

--- a/contrib/secgemini_byot/timesketch_logstore.py
+++ b/contrib/secgemini_byot/timesketch_logstore.py
@@ -19,7 +19,10 @@ import logging
 import math
 from typing import Any, Iterable, Optional
 
+# pylint: disable=import-error
 from sec_gemini.logs_mcp.common import logstore as ls
+
+# pylint: enable=import-error
 from timesketch_api_client import client as ts_client
 from timesketch_api_client import search
 
@@ -289,7 +292,7 @@ class TimesketchLogStore(ls.LogStore):
         must_contain_all_of: Optional[Iterable[str]] = None,
         must_not_contain_any_of: Optional[Iterable[str]] = None,
         order_by: ls.Order = ls.Order.CHRONOLOGICAL,
-        exclude_log_type: Optional[Any] = None,
+        exclude_log_type: Optional[Any] = None,  # pylint: disable=unused-argument
     ) -> ls.SearchResult:
         """Executes a search mapped directly to OpenSearch query strings."""
         return await asyncio.to_thread(

--- a/contrib/secgemini_byot/timesketch_logstore.py
+++ b/contrib/secgemini_byot/timesketch_logstore.py
@@ -33,6 +33,15 @@ logger = logging.getLogger("timesketch.byot.logstore")
 EPOCH_START = datetime.datetime(1970, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
 
 
+def _safe_str(val: Any, default: str = "") -> str:
+    """Safely converts a value to a string, handling pandas NaN and None."""
+    if val is None:
+        return default
+    if isinstance(val, float) and math.isnan(val):
+        return default
+    return str(val).strip()
+
+
 def _escape_opensearch_query(k: str) -> str:
     """Escapes OpenSearch reserved characters including backslashes."""
     # Backslash must be escaped first
@@ -127,8 +136,10 @@ class TimesketchLogStore(ls.LogStore):
             )
             objects = type_res.data.get("objects")
             buckets = []
-            if objects and isinstance(objects, list) and objects[0]:
-                buckets = objects[0].get("field_bucket", {}).get("buckets", [])
+            if objects and isinstance(objects, list) and isinstance(objects[0], dict):
+                field_bucket = objects[0].get("field_bucket")
+                if isinstance(field_bucket, dict):
+                    buckets = field_bucket.get("buckets", [])
         except Exception as e:  # pylint: disable=broad-exception-caught
             logger.exception("Failed to discover unique log types")
             return ls.LogDescriptions(
@@ -242,21 +253,33 @@ class TimesketchLogStore(ls.LogStore):
                     aggregator_name="date_histogram",
                     aggregator_parameters=aggregator_params,
                 )
-                raw_objects = agg_obj.resource_data.get("objects", [])
-                if raw_objects:
-                    agg_data = raw_objects[0].get("date_histogram", {})
-                    hist_buckets = agg_data.get("buckets", [])
+                resource_data = agg_obj.resource_data
+                raw_objects = (
+                    resource_data.get("objects", [])
+                    if isinstance(resource_data, dict)
+                    else []
+                )
 
-                    if hist_buckets and isinstance(hist_buckets[0], list):
-                        hist_buckets = hist_buckets[0]
+                hist_buckets = []
+                if (
+                    raw_objects
+                    and isinstance(raw_objects, list)
+                    and isinstance(raw_objects[0], dict)
+                ):
+                    agg_data = raw_objects[0].get("date_histogram")
+                    if isinstance(agg_data, dict):
+                        hist_buckets = agg_data.get("buckets", [])
 
-                    for row in hist_buckets:
-                        d_raw = row.get("datetime") or row.get("key_as_string")
-                        if d_raw:
-                            d_str = str(d_raw)[:10]
-                            c_val = int(row.get("count") or row.get("doc_count") or 0)
-                            if c_val > 0:
-                                day_counts.append((d_str, c_val))
+                if hist_buckets and isinstance(hist_buckets[0], list):
+                    hist_buckets = hist_buckets[0]
+
+                for row in hist_buckets:
+                    d_raw = row.get("datetime") or row.get("key_as_string")
+                    if d_raw:
+                        d_str = str(d_raw)[:10]
+                        c_val = int(row.get("count") or row.get("doc_count") or 0)
+                        if c_val > 0:
+                            day_counts.append((d_str, c_val))
             except Exception:  # pylint: disable=broad-exception-caught
                 logger.exception("Failed to run date histogram aggregation for %s", dt)
                 error_suffix = " ERROR: Failed to compute date histogram."
@@ -389,12 +412,12 @@ class TimesketchLogStore(ls.LogStore):
 
         res = []
         for _, row in results_df.iterrows():
-            msg = str(row.get("message", ""))
+            msg = _safe_str(row.get("message"))
 
             found_hashes = []
             for field_name in hash_fields:
                 val = row.get(field_name)
-                if val and str(val).strip() and str(val).lower() != "n/a":
+                if val and _safe_str(val) and _safe_str(val).lower() != "n/a":
                     found_hashes.append(f"{field_name}={val}")
 
             if found_hashes:
@@ -420,9 +443,9 @@ class TimesketchLogStore(ls.LogStore):
             merged_tags = sorted(
                 list(
                     set(
-                        str(t)
+                        _safe_str(t)
                         for t in tags_list + yara_list
-                        if t and str(t).lower() != "n/a"
+                        if _safe_str(t) and _safe_str(t).lower() != "n/a"
                     )
                 )
             )
@@ -430,10 +453,10 @@ class TimesketchLogStore(ls.LogStore):
 
             res.append(
                 ls.LogRecordResult(
-                    record_id=str(row.get("_id", "")),
-                    log_type=str(row.get("data_type", "none")),
+                    record_id=_safe_str(row.get("_id")),
+                    log_type=_safe_str(row.get("data_type"), default="none"),
                     timestamp=_parse_datetime(row.get("datetime")),
-                    timestamp_desc=str(row.get("timestamp_desc", "null")),
+                    timestamp_desc=_safe_str(row.get("timestamp_desc"), default="null"),
                     message=msg,
                     enrichment=enrich,
                 )

--- a/contrib/secgemini_byot/timesketch_logstore.py
+++ b/contrib/secgemini_byot/timesketch_logstore.py
@@ -41,8 +41,6 @@ def _escape_opensearch_query(k: str) -> str:
         "+",
         "-",
         "=",
-        "&&",
-        "||",
         ">",
         "<",
         "!",

--- a/data/timesketch.conf
+++ b/data/timesketch.conf
@@ -462,6 +462,17 @@ LLM_PROVIDER_CONFIGS = {
         "secgemini_log_analyzer_agent": {
             "api_key": "",
             "host": "",
+            # Setting this to True will upload sketch logs directly to Google's Cloud
+            # where they are stored as an ephemeral temporary cache.
+            # Setting this to False (default) enables Bring-Your-Own-Tool (BYOT) mode
+            # which queries logs in-place via an outbound reverse tunnel.
+            "upload_logs_to_secgemini": False,
+            # Specifies the name of the tunnel created by the client-side container.
+            "byot_tunnel_name": "byot-sec-gemini-bot",
+            # When using BYOT mode, specify the username of the bot account.
+            # If set, the Timesketch server will automatically share the sketch with
+            # this user (read-only) when a log analysis is triggered.
+            "byot_username": "sec-gemini-bot",
             # Optional metadata overrides to pass to the SecGemini session prompts.
             # Example:
             # "meta": {

--- a/data/timesketch.conf
+++ b/data/timesketch.conf
@@ -466,6 +466,9 @@ LLM_PROVIDER_CONFIGS = {
             # where they are stored as an ephemeral temporary cache.
             # Setting this to False (default) enables Bring-Your-Own-Tool (BYOT) mode
             # which queries logs in-place via an outbound reverse tunnel.
+            # NOTE: This requires setting up the sec-gemini-byot container.
+            # See https://github.com/google/timesketch/tree/master/contrib/secgemini_byot/README.md
+            # for instructions.
             "upload_logs_to_secgemini": False,
             # Specifies the name of the tunnel created by the client-side container.
             "byot_tunnel_name": "byot-sec-gemini-bot",

--- a/timesketch/lib/llms/features/log_analyzer.py
+++ b/timesketch/lib/llms/features/log_analyzer.py
@@ -130,6 +130,7 @@ class LogAnalyzer(LLMFeatureInterface):
             raw_response_generator = llm_provider.generate_stream_from_logs(
                 log_events_generator=log_events_generator,
                 prompt=kwargs.get("prompt"),
+                sketch=sketch,
             )
 
             final_summary_json = None

--- a/timesketch/lib/llms/providers/secgemini_log_analyzer_agent.py
+++ b/timesketch/lib/llms/providers/secgemini_log_analyzer_agent.py
@@ -281,6 +281,15 @@ class SecGeminiLogAnalyzer(interface.LLMProvider):
                         "Finished writing SecGemini debug log: %s", log_file_path
                     )
         finally:
+            if self._session and hasattr(self._session, "close"):
+                try:
+                    await self._session.close()
+                except Exception as e:  # pylint: disable=broad-exception-caught
+                    logger.debug(
+                        "Ignored error closing remote session %s: %s",
+                        self.session_id,
+                        e,
+                    )
             # Ensure client is properly closed
             await self.sg_client.close()
 

--- a/timesketch/lib/llms/providers/secgemini_log_analyzer_agent.py
+++ b/timesketch/lib/llms/providers/secgemini_log_analyzer_agent.py
@@ -340,8 +340,7 @@ class SecGeminiLogAnalyzer(interface.LLMProvider):
                     raise e
                 except Exception as e:  # pylint: disable=broad-exception-caught
                     logger.error(
-                        "Failed to auto-grant read permission to bot user "
-                        "'%s': %s",
+                        "Failed to auto-grant read permission to bot user '%s': %s",
                         self.byot_username,
                         e,
                         exc_info=True,

--- a/timesketch/lib/llms/providers/secgemini_log_analyzer_agent.py
+++ b/timesketch/lib/llms/providers/secgemini_log_analyzer_agent.py
@@ -356,6 +356,9 @@ class SecGeminiLogAnalyzer(interface.LLMProvider):
 
                 try:
                     loop = asyncio.get_event_loop()
+                    if loop.is_closed():
+                        loop = asyncio.new_event_loop()
+                        asyncio.set_event_loop(loop)
                 except RuntimeError:
                     loop = asyncio.new_event_loop()
                     asyncio.set_event_loop(loop)

--- a/timesketch/lib/llms/providers/secgemini_log_analyzer_agent.py
+++ b/timesketch/lib/llms/providers/secgemini_log_analyzer_agent.py
@@ -72,6 +72,13 @@ class SecGeminiLogAnalyzer(interface.LLMProvider):
 
         self.host = self.config.get("host")
         self.meta_config = self.config.get("meta", {})
+        self.upload_logs_to_secgemini = self.config.get(
+            "upload_logs_to_secgemini", False
+        )
+        self.byot_tunnel_name = self.config.get(
+            "byot_tunnel_name", "byot-sec-gemini-bot"
+        )
+        self.byot_username = self.config.get("byot_username")
 
         try:
             if self.host:
@@ -85,18 +92,20 @@ class SecGeminiLogAnalyzer(interface.LLMProvider):
         self._session = None
         self.session_id = None
 
-    async def _run_async_stream(self, log_path, prompt):
+    async def _run_async_stream(self, prompt, log_path=None, sketch=None):
         """Initializes a SecGemini session and streams the analysis response.
 
-        This is an async helper method that:
-        1. Creates a new SecGemini session.
-        2. Uploads the local log file to the session.
-        3. Streams the analysis results for the given prompt.
-        4. If debugging is enabled, streams the raw sec-gemini response to a log.
+        This method supports two modes:
+        1. Local Mode (BYOT): If upload_logs_to_secgemini is False (default),
+           it registers a local BYOT tunnel name and instructs the agent to
+           use describe and search tools.
+        2. Remote Mode: If upload_logs_to_secgemini is True, it uploads the
+           local log file to the SecGemini session for analysis.
 
         Args:
-            log_path (Path): The local filesystem path to the JSONL log file.
             prompt (str): The analysis prompt to send to the agent.
+            log_path (Path, optional): The local filesystem path to the JSONL log file.
+            sketch (Sketch, optional): The active Timesketch Sketch object.
 
         Yields:
             str: The content chunks of the streamed response from the agent.
@@ -110,16 +119,16 @@ class SecGeminiLogAnalyzer(interface.LLMProvider):
             self.session_id = self._session.id
             logger.info("Started new SecGemini session: '%s'", self.session_id)
 
-            # Upload logs file using the new files.upload API
-            await self._session.files.upload(str(log_path), content_type="text/plain")
-            logger.info("Uploaded logs file: '%s'", log_path)
+            if self.upload_logs_to_secgemini:
+                if not log_path:
+                    raise ValueError("Remote log analysis requires a log_path.")
+                # Upload logs file using the new files.upload API
+                await self._session.files.upload(
+                    str(log_path), content_type="text/plain"
+                )
+                logger.info("Uploaded logs file: '%s'", log_path)
 
             logger.info("Starting the SecGemini analysis...")
-            logger.info(
-                "NOTE: 'ConnectionClosedOK' errors from the SecGemini client in the "
-                "log are expected. The client automatically reconnects during "
-                "long-running analysis."
-            )
 
             debug_log_file = None
             if current_app.config.get("DEBUG"):
@@ -144,21 +153,52 @@ class SecGeminiLogAnalyzer(interface.LLMProvider):
                     debug_log_file = None
 
             try:
-                # Trigger the prompt first
-                logger.info("Sending prompt to SecGemini: '%s'", prompt[:100])
                 meta = {"config.mode": "dfir"}
                 if self.meta_config:
                     for key, val in self.meta_config.items():
+                        if key in ("sec-gemini-enabled-byots", "config.mode", "mode"):
+                            continue
                         if isinstance(val, bool):
                             meta[key] = "true" if val else "false"
                         else:
                             meta[key] = str(val)
 
-                await self._session.prompt(prompt, meta=meta)
+                if not self.upload_logs_to_secgemini:
+                    meta["sec-gemini-enabled-byots"] = self.byot_tunnel_name
+
+                final_prompt = prompt
+                if not self.upload_logs_to_secgemini:
+                    local_instructions = (
+                        "You MUST query the logs by calling the "
+                        "`describe_available_logs` and `search_logs` tools "
+                        f"provided to you, passing '{sketch.id}' as the "
+                        "`ticket_id` argument.\n"
+                        "CRITICAL: If the required tools are not available in "
+                        "your workspace, or if calling them returns a "
+                        "permission-denied, resource-not-found, or connection "
+                        "failure error (indicating you cannot access the "
+                        "requested sketch), you MUST immediately abort the "
+                        "analysis and output a JSON error message explaining "
+                        "the access failure."
+                    )
+                    final_prompt = local_instructions + "\n\n" + prompt
+                else:
+                    remote_instructions = (
+                        "IMPORTANT: The log records have been uploaded directly to "
+                        "your session environment as a file. There are no "
+                        "describe_available_logs or search_logs tools. You "
+                        "MUST analyze the uploaded log file directly."
+                    )
+                    final_prompt = remote_instructions + "\n\n" + prompt
+
+                # Trigger the prompt first
+                logger.info("Sending prompt to SecGemini: '%s'", final_prompt[:100])
+                await self._session.prompt(final_prompt, meta=meta)
                 logger.info("Prompt sent successfully!")
 
                 # Stream messages using messages.stream()
                 async for response in self._session.messages.stream():
+
                     if debug_log_file:
                         try:
                             debug_log_file.write(str(response) + "\n")
@@ -248,23 +288,21 @@ class SecGeminiLogAnalyzer(interface.LLMProvider):
         self,
         log_events_generator: Iterable[Dict[str, Any]],
         prompt: str = None,
+        sketch: Any = None,
     ) -> Generator[str, None, None]:
         """Analyzes a stream of log events using the SecGemini log analysis agent.
 
         This method orchestrates the entire analysis process:
-        1.  It receives a generator of Timesketch log events.
-        2.  Each event is serialized into a JSON string and written to a
-            temporary JSONL (JSON Lines) file on disk.
-        3.  It invokes the asynchronous SecGemini client, passing the path to the
-            log file.
-        4.  It manages an asyncio event loop to handle the async streaming response.
-        5.  It yields chunks of the raw JSON response from the LLM as they are
-            received.
+        1.  If BYOT is enabled (upload_logs_to_secgemini=False), it bypasses
+            file writing and initiates a local tunnel connection to execute
+            tools against Timesketch API.
+        2.  Otherwise, it serializes events into a JSONL temp file and uploads it.
 
         Args:
             log_events_generator: An iterable of dictionaries, where each
                                   dictionary is a Timesketch log event.
             prompt: The prompt to send to the SecGemini agent for analysis.
+            sketch: The active Sketch object.
 
         Yields:
             str: Chunks of the raw JSON string response from the LLM provider.
@@ -274,6 +312,89 @@ class SecGeminiLogAnalyzer(interface.LLMProvider):
                 "LLM_LOG_ANALYZER_DEFAULT_PROMPT",
                 "Perform a forensics investigation on the provided logs.",
             )
+
+        if not self.upload_logs_to_secgemini:
+            if not sketch:
+                raise ValueError("Local log analysis (BYOT) requires a sketch object.")
+
+            granted_by_automation = False
+            if self.byot_username:
+                try:
+                    success = sketch.grant_permission_by_username(
+                        "read", self.byot_username
+                    )
+                    if success:
+                        granted_by_automation = True
+                        logger.info(
+                            "Automatically granted read permission on sketch "
+                            "%d to bot user %s",
+                            sketch.id,
+                            self.byot_username,
+                        )
+                except ValueError as e:
+                    logger.error(
+                        "Configured byot_username '%s' was not found in "
+                        "the database. Aborting log analysis.",
+                        self.byot_username,
+                    )
+                    raise e
+                except Exception as e:  # pylint: disable=broad-exception-caught
+                    logger.error(
+                        "Failed to auto-grant read permission to bot user "
+                        "'%s': %s",
+                        self.byot_username,
+                        e,
+                        exc_info=True,
+                    )
+
+            try:
+
+                async def main_local():
+                    async for chunk in self._run_async_stream(
+                        prompt=prompt, sketch=sketch
+                    ):
+                        yield chunk
+
+                try:
+                    loop = asyncio.get_event_loop()
+                except RuntimeError:
+                    loop = asyncio.new_event_loop()
+                    asyncio.set_event_loop(loop)
+
+                gen = main_local()
+                log_trigger = 0
+                while True:
+                    try:
+                        chunk = loop.run_until_complete(gen.__anext__())
+                        if chunk is not None:
+                            log_trigger += 1
+                            if log_trigger % 50 == 0:
+                                logger.info(
+                                    "[%s] SecGemini is still processing...",
+                                    self.session_id,
+                                )
+                            yield chunk
+                    except StopAsyncIteration:
+                        break
+            finally:
+                if granted_by_automation:
+                    try:
+                        sketch.revoke_permission_by_username("read", self.byot_username)
+                        logger.info(
+                            "Automatically revoked read permission on sketch "
+                            "%d from bot user %s",
+                            sketch.id,
+                            self.byot_username,
+                        )
+                    except Exception as e:  # pylint: disable=broad-exception-caught
+                        logger.error(
+                            "Failed to auto-revoke read permission from bot user "
+                            "'%s': %s",
+                            self.byot_username,
+                            e,
+                            exc_info=True,
+                        )
+            return
 
         with tempfile.NamedTemporaryFile(
             mode="w", delete=True, suffix=".jsonl", encoding="utf-8"
@@ -321,7 +442,9 @@ class SecGeminiLogAnalyzer(interface.LLMProvider):
             )
 
             async def main():
-                async for chunk in self._run_async_stream(log_path, prompt):
+                async for chunk in self._run_async_stream(
+                    prompt=prompt, log_path=log_path
+                ):
                     yield chunk
 
             try:

--- a/timesketch/models/acl.py
+++ b/timesketch/models/acl.py
@@ -416,9 +416,7 @@ class AccessControlMixin:
         if not user:
             raise ValueError(f"User not found: {username}")
 
-        user_ace = self._get_ace(
-            permission=permission, user=user, check_group=False
-        )
+        user_ace = self._get_ace(permission=permission, user=user, check_group=False)
         if user_ace:
             self.revoke_permission(permission=permission, user=user)
             return True

--- a/timesketch/models/acl.py
+++ b/timesketch/models/acl.py
@@ -388,8 +388,6 @@ class AccessControlMixin:
 
         if not self.has_permission(user=user, permission=permission):
             self.grant_permission(permission=permission, user=user)
-            db_session.add(self)
-            db_session.commit()
             return True
 
         return False
@@ -402,7 +400,8 @@ class AccessControlMixin:
             username: The username of the collaborator.
 
         Returns:
-            bool: True if the permission was successfully revoked.
+            bool: True if a direct permission ACE existed and was revoked,
+                  False if the user had no direct permission to revoke.
 
         Raises:
             ValueError: If the username cannot be resolved to a database User.
@@ -417,8 +416,14 @@ class AccessControlMixin:
         if not user:
             raise ValueError(f"User not found: {username}")
 
-        self.revoke_permission(permission=permission, user=user)
-        return True
+        user_ace = self._get_ace(
+            permission=permission, user=user, check_group=False
+        )
+        if user_ace:
+            self.revoke_permission(permission=permission, user=user)
+            return True
+
+        return False
 
     def revoke_permission(self, permission, user=None, group=None):
         """Revoke permission for user/group on the object.

--- a/timesketch/models/acl.py
+++ b/timesketch/models/acl.py
@@ -354,11 +354,71 @@ class AccessControlMixin:
             db_session.commit()
             return
 
-        # Grant permission to a user.
         if not self._get_ace(permission, user=user, check_group=False):
             self.acl.append(self.AccessControlEntry(permission=permission, user=user))
             db_session.add(self)
             db_session.commit()
+
+    def grant_permission_by_username(self, permission: str, username: str) -> bool:
+        """Grants permission on this object to a user by username.
+
+        This is a wrapper that resolves the username to a User object, checks
+        existing permissions, and then calls the lower-level grant_permission.
+
+        Args:
+            permission: The permission string (e.g. 'read').
+            username: The username of the collaborator.
+
+        Returns:
+            bool: True if the permission was newly granted,
+                  False if the user already had the permission.
+
+        Raises:
+            ValueError: If the username cannot be resolved to a database User.
+        """
+        user = User.query.filter_by(username=username).first()
+
+        # Fallback: support domain stripping (matching standard sharing endpoint)
+        if not user and "@" in username:
+            base_username = username.split("@")[0].strip()
+            user = User.query.filter_by(username=base_username).first()
+
+        if not user:
+            raise ValueError(f"User not found: {username}")
+
+        if not self.has_permission(user=user, permission=permission):
+            self.grant_permission(permission=permission, user=user)
+            db_session.add(self)
+            db_session.commit()
+            return True
+
+        return False
+
+    def revoke_permission_by_username(self, permission: str, username: str) -> bool:
+        """Revokes permission on this object for a user by username.
+
+        Args:
+            permission: The permission string (e.g. 'read').
+            username: The username of the collaborator.
+
+        Returns:
+            bool: True if the permission was successfully revoked.
+
+        Raises:
+            ValueError: If the username cannot be resolved to a database User.
+        """
+        user = User.query.filter_by(username=username).first()
+
+        # Fallback: support domain stripping (matching standard sharing endpoint)
+        if not user and "@" in username:
+            base_username = username.split("@")[0].strip()
+            user = User.query.filter_by(username=base_username).first()
+
+        if not user:
+            raise ValueError(f"User not found: {username}")
+
+        self.revoke_permission(permission=permission, user=user)
+        return True
 
     def revoke_permission(self, permission, user=None, group=None):
         """Revoke permission for user/group on the object.
@@ -379,7 +439,7 @@ class AccessControlMixin:
             return
 
         # Revoke permission for a user.
-        user_ace = self._get_ace(permission=permission, user=user)
+        user_ace = self._get_ace(permission=permission, user=user, check_group=False)
         if user_ace:
             for ace in user_ace:
                 self.acl.remove(ace)

--- a/timesketch/models/acl_test.py
+++ b/timesketch/models/acl_test.py
@@ -47,3 +47,75 @@ class AclModelTest(BaseTest):
         self.assertTrue(self.sketch1.is_public)
         self.sketch1.revoke_permission(permission="read")
         self.assertFalse(self.sketch1.is_public)
+
+    def test_change_permission_by_username(self):
+        """Test changing permissions on a sketch using username resolution."""
+        # 1. Grant permission newly
+        success = self.sketch1.grant_permission_by_username(
+            permission="read", username="test2"
+        )
+        self.assertTrue(success)
+        self.assertTrue(self.sketch1.has_permission(permission="read", user=self.user2))
+
+        # 2. Grant permission again (should return False because already present)
+        success = self.sketch1.grant_permission_by_username(
+            permission="read", username="test2"
+        )
+        self.assertFalse(success)
+
+        # 3. Revoke permission
+        success = self.sketch1.revoke_permission_by_username(
+            permission="read", username="test2"
+        )
+        self.assertTrue(success)
+        self.assertFalse(
+            self.sketch1.has_permission(permission="read", user=self.user2)
+        )
+
+        # 4. Fallback: domain stripping in grant
+        # (Should resolve "test2@example.com" to database user "test2")
+        success = self.sketch1.grant_permission_by_username(
+            permission="read", username="test2@example.com"
+        )
+        self.assertTrue(success)
+        self.assertTrue(self.sketch1.has_permission(permission="read", user=self.user2))
+
+        # 5. Fallback: domain stripping in revoke
+        success = self.sketch1.revoke_permission_by_username(
+            permission="read", username="test2@example.com"
+        )
+        self.assertTrue(success)
+        self.assertFalse(
+            self.sketch1.has_permission(permission="read", user=self.user2)
+        )
+
+        # 6. Raise ValueError on non-existent user (grant)
+        with self.assertRaises(ValueError):
+            self.sketch1.grant_permission_by_username(
+                permission="read", username="nonexistent_user"
+            )
+
+        # 7. Raise ValueError on non-existent user (revoke)
+        with self.assertRaises(ValueError):
+            self.sketch1.revoke_permission_by_username(
+                permission="read", username="nonexistent_user"
+            )
+
+    def test_revoke_user_with_group_permission(self):
+        """Test revoking user permission doesn't affect group permission."""
+        # 1. Grant read permission to a group that self.user1 belongs to
+        self.sketch1.grant_permission(permission="read", group=self.group1)
+        self.assertTrue(self.sketch1.has_permission(permission="read", user=self.user1))
+
+        # 2. Revoke the user's read permission directly (this should be a no-op
+        # because the user doesn't have a direct ACE, only group permission)
+        self.sketch1.revoke_permission(permission="read", user=self.user1)
+
+        # 3. Assert the user still has permission (inherited from the group)
+        self.assertTrue(self.sketch1.has_permission(permission="read", user=self.user1))
+
+        # Cleanup: revoke group permission
+        self.sketch1.revoke_permission(permission="read", group=self.group1)
+        self.assertFalse(
+            self.sketch1.has_permission(permission="read", user=self.user1)
+        )

--- a/timesketch/models/acl_test.py
+++ b/timesketch/models/acl_test.py
@@ -89,6 +89,12 @@ class AclModelTest(BaseTest):
             self.sketch1.has_permission(permission="read", user=self.user2)
         )
 
+        # 5b. Revoking again when no direct ACE exists should return False
+        success = self.sketch1.revoke_permission_by_username(
+            permission="read", username="test2@example.com"
+        )
+        self.assertFalse(success)
+
         # 6. Raise ValueError on non-existent user (grant)
         with self.assertRaises(ValueError):
             self.sketch1.grant_permission_by_username(


### PR DESCRIPTION
This PR introduces support for local Bring Your Own Tool (BYOT) log analysis utilized by the Sec-Gemini agent, optimizes search aggregations, and implements transparent sketch access control (auto-sharing) with automatic cleanup.

The BYOT client is run in a separate lightweight docker container from the `contrib/secgemini_byot/` folder. It takes care of the reverse tunnel to the Sec-Gemini hub and implements the compatible Timesketch LogStore class that exposes the necessary search tools for Sec-Gemini to investigate a Sketch.

## Key Changes

### 1. Client-side BYOT Connection Tunnel (`contrib/secgemini_byot/`)
* **Connection Tunnel:** Created a Docker-containerized client-side connection tunnel (`byot_client.py`) that establishes a secure outbound reverse websocket connection to the Sec-Gemini Hub.
* **Local MCP Server:** Uses the `FastMCP` framework to expose standard search and type-describe tools executing queries directly against the local Timesketch API (using the Python `timesketch-api-client`), bypassing any requirement to upload raw log files to the cloud.
* **Documentation:** Added a detailed `README.md` with build/run guidelines, Docker-Compose network configurations, and troubleshooting tips.

### 2. Date Histogram Aggregator Optimization (`timesketch_logstore.py`)
* **Dynamic Bounds Querying:** Optimized log type discovery in the BYOT client. Instead of executing OpenSearch `date_histogram` queries over a default 130-year span (which blocks queues for large sketches), the store now runs lightweight queries to discover the earliest and latest log events per data type.
* **Mid-night Buffer Align:** Applies a `+/- 1 day` buffer aligned to midnight (`00:00:00`) to dynamically scope histogram boundaries.

### 3. Sketch Auto-Sharing & Temporary Collaborator Access
* **ACL Resolution Wrappers:** Implemented `grant_permission_by_username()` and `revoke_permission_by_username()` on the SQL model `AccessControlMixin` (`acl.py`) with domain-stripping fallback to manage sketch permissions using LDAP/SSO strings.
* **Transparent sharing:** Integrated auto-sharing into the Sec-Gemini provider. When BYOT is active and `byot_username` is configured, the sketch is automatically shared (read-only) with the bot user at task startup.
* **Early Abort:** Validates that the configured bot user exists at startup, failing early with a descriptive config error instead of throwing a generic connection error during streaming.
* **Lifecycle Cleanup:** Implemented a generator-level `finally` block to automatically revoke the granted sketch permission once the streaming session completes, errors out, or is cancelled, preventing bot accounts from accumulating permanent sketch access.

### 4. Core Bugfix: Group Revocation Leak (`acl.py`)
* **Bug:** In `revoke_permission()`, the `_get_ace()` call was checking group membership by default. If a user had no direct sketch ACE but belonged to an allowed group, the query returned the group's ACE, causing the loop to delete the group entry—meaning **the entire group lost access to the sketch**.
* **Fix:** Updated the `revoke_permission()` call to specify `check_group=False`, targeting only the user's direct Access Control Entries.

### 5. Tests
* Added comprehensive coverage in `acl_test.py`:
  * Verifies username-based grant/revoke, duplicate grant protections, and email domain stripping fallback.
  * Verifies that revoking a user who only holds group-level permissions does not delete the group ACE (`test_revoke_user_with_group_permission`).

