### PR TITLE
fix(cli_client) columns was annotated as Optional[str] = None, but then reassigned to

### DIFF
--- a/cli_client/python/timesketch_cli_client/commands/intelligence.py
+++ b/cli_client/python/timesketch_cli_client/commands/intelligence.py
@@ -145,7 +145,7 @@ def add_intelligence(
         tags_list = tags.split(",")
         tags_dict = {tag: [] for tag in tags_list}
     else:
-        tags_dict = []
+        tags_dict = {}
 
     ioc_dict = {"ioc": ioc, "type": ioc_type, "tags": tags_dict}
     # Put the ioc in a nested object to match the format of the API

--- a/cli_client/python/timesketch_cli_client/commands/intelligence.py
+++ b/cli_client/python/timesketch_cli_client/commands/intelligence.py
@@ -55,7 +55,7 @@ def list_intelligence(
     if not columns:
         columns = "ioc,type"
 
-    columns = columns.split(",")
+    columns_list = columns.split(",")
 
     output = ctx.obj.output_format
     sketch = ctx.obj.sketch
@@ -72,10 +72,10 @@ def list_intelligence(
         click.echo(json.dumps(intelligence, indent=4, sort_keys=True))
     elif output == "text":
         if header:
-            click.echo("\t".join(columns))
+            click.echo("\t".join(columns_list))
         for entry in intelligence:
             row = []
-            for column in columns:
+            for column in columns_list:
                 if column == "tags":
                     row.append(",".join(entry.get(column, [])))
                 else:
@@ -83,10 +83,10 @@ def list_intelligence(
             click.echo("\t".join(row))
     elif output == "csv":
         if header:
-            click.echo(",".join(columns))
+            click.echo(",".join(columns_list))
         for entry in intelligence:
             row = []
-            for column in columns:
+            for column in columns_list:
                 if column == "tags":
                     # Tags can be multiple values but they should only be
                     # one value on the csv so we join them with a comma
@@ -142,12 +142,12 @@ def add_intelligence(
 
     # Create a tags dict from the comma separated list
     if tags:
-        tags = tags.split(",")
-        tags = {tag: [] for tag in tags}
+        tags_list = tags.split(",")
+        tags_dict = {tag: [] for tag in tags_list}
     else:
-        tags = []
+        tags_dict = []
 
-    ioc_dict = {"ioc": ioc, "type": ioc_type, "tags": tags}
+    ioc_dict = {"ioc": ioc, "type": ioc_type, "tags": tags_dict}
     # Put the ioc in a nested object to match the format of the API
     data = {"data": [ioc_dict]}
     try:

--- a/cli_client/python/timesketch_cli_client/commands/sigma.py
+++ b/cli_client/python/timesketch_cli_client/commands/sigma.py
@@ -48,7 +48,7 @@ def list_sigmarules(ctx: click.Context, header: bool, columns: str):
     if not columns:
         columns = "rule_uuid,title"
 
-    columns = columns.split(",")
+    columns_list = columns.split(",")
 
     output = ctx.obj.output_format
     try:
@@ -65,10 +65,10 @@ def list_sigmarules(ctx: click.Context, header: bool, columns: str):
         click.echo(sigma_rules.to_csv(header=header))
     elif output == "text":
         click.echo(
-            sigma_rules.to_string(index=header, columns=columns),
+            sigma_rules.to_string(index=header, columns=columns_list),
         )
     else:
-        click.echo(sigma_rules.to_string(index=header, columns=columns))
+        click.echo(sigma_rules.to_string(index=header, columns=columns_list))
 
 
 @sigma_group.command("describe")


### PR DESCRIPTION
In two places lists where checked as str but then assigned lists, which made checks unhappy. assigning them to propper lists now.

This pull request refactors variable names in the intelligence and sigma CLI commands to avoid shadowing