### PR TITLE
fix: map __ts_timeline_id to timeline name in to_pandas

### DIFF
--- a/api_client/python/timesketch_api_client/search.py
+++ b/api_client/python/timesketch_api_client/search.py
@@ -1164,11 +1164,18 @@ class Search(resource.SketchResource):
                 source["_type"] = result.get("_type")
             if not return_fields or "_index" in return_field_list:
                 source["_index"] = result.get("_index")
-            timeline_id = source.get("__ts_timeline_id")
+            raw_timeline_id = source.get("__ts_timeline_id")
+            timeline_id = raw_timeline_id
+            if timeline_id is not None:
+                try:
+                    timeline_id = int(timeline_id)
+                except (TypeError, ValueError):
+                    pass
+            timeline_name = timelines.get(timeline_id, raw_timeline_id)
             if not return_fields or "_source" in return_field_list:
-                source["_source"] = timelines.get(timeline_id)
+                source["_source"] = timeline_name
             if not return_fields or "__ts_timeline_id" in return_field_list:
-                source["__ts_timeline_id"] = timelines.get(timeline_id)
+                source["__ts_timeline_id"] = timeline_name
 
             return_list.append(source)
 

--- a/api_client/python/timesketch_api_client/search.py
+++ b/api_client/python/timesketch_api_client/search.py
@@ -1164,10 +1164,11 @@ class Search(resource.SketchResource):
                 source["_type"] = result.get("_type")
             if not return_fields or "_index" in return_field_list:
                 source["_index"] = result.get("_index")
+            timeline_id = source.get("__ts_timeline_id")
             if not return_fields or "_source" in return_field_list:
-                source["_source"] = timelines.get(result.get("__ts_timeline_id"))
+                source["_source"] = timelines.get(timeline_id)
             if not return_fields or "__ts_timeline_id" in return_field_list:
-                source["_source"] = timelines.get(result.get("__ts_timeline_id"))
+                source["__ts_timeline_id"] = timelines.get(timeline_id)
 
             return_list.append(source)
 

--- a/api_client/python/timesketch_api_client/search_test.py
+++ b/api_client/python/timesketch_api_client/search_test.py
@@ -57,9 +57,10 @@ class SearchTest(unittest.TestCase):
         self.assertEqual(len(objects), 1)
 
     def test_to_pandas_timeline_fields(self):
-        """Test that to_pandas maps the timeline to its name."""
+        """Test that to_pandas maps timeline fields to timeline names."""
         search_obj = search.Search(sketch=self.sketch)
-        search_obj.return_fields = "message,__ts_timeline_id"
+        search_obj.return_fields = "message,_source,__ts_timeline_id"
+        # pylint: disable=protected-access
         search_obj._raw_response = {
             "objects": [
                 {
@@ -69,18 +70,25 @@ class SearchTest(unittest.TestCase):
                     "_index": "test",
                 },
                 {
-                    "_source": {"message": "bar", "__ts_timeline_id": 2},
+                    "_source": {"message": "bar", "__ts_timeline_id": "2"},
                     "_id": "a2",
+                    "_type": "generic_event",
+                    "_index": "test",
+                },
+                {
+                    "_source": {"message": "baz", "__ts_timeline_id": "999"},
+                    "_id": "a3",
                     "_type": "generic_event",
                     "_index": "test",
                 },
             ]
         }
         data_frame = search_obj.to_pandas()
-        self.assertEqual(list(data_frame.columns), ["message", "__ts_timeline_id"])
         self.assertEqual(
-            list(data_frame["__ts_timeline_id"]), ["test", "test"]
+            list(data_frame.columns), ["message", "__ts_timeline_id", "_source"]
         )
+        self.assertEqual(list(data_frame["_source"]), ["test", "test", "999"])
+        self.assertEqual(list(data_frame["__ts_timeline_id"]), ["test", "test", "999"])
 
     def test_range_chip(self):
         """Test date range chip."""

--- a/api_client/python/timesketch_api_client/search_test.py
+++ b/api_client/python/timesketch_api_client/search_test.py
@@ -56,6 +56,32 @@ class SearchTest(unittest.TestCase):
         objects = search_dict.get("objects", [])
         self.assertEqual(len(objects), 1)
 
+    def test_to_pandas_timeline_fields(self):
+        """Test that to_pandas maps the timeline to its name."""
+        search_obj = search.Search(sketch=self.sketch)
+        search_obj.return_fields = "message,__ts_timeline_id"
+        search_obj._raw_response = {
+            "objects": [
+                {
+                    "_source": {"message": "foo", "__ts_timeline_id": 1},
+                    "_id": "a1",
+                    "_type": "generic_event",
+                    "_index": "test",
+                },
+                {
+                    "_source": {"message": "bar", "__ts_timeline_id": 2},
+                    "_id": "a2",
+                    "_type": "generic_event",
+                    "_index": "test",
+                },
+            ]
+        }
+        data_frame = search_obj.to_pandas()
+        self.assertEqual(list(data_frame.columns), ["message", "__ts_timeline_id"])
+        self.assertEqual(
+            list(data_frame["__ts_timeline_id"]), ["test", "test"]
+        )
+
     def test_range_chip(self):
         """Test date range chip."""
         chip = search.DateRangeChip()


### PR DESCRIPTION
## Summary

Fixes timeline-name mapping in `Search.to_pandas()` when `_source` or `__ts_timeline_id` is requested as a return field.

## Root Cause

The field-mapping block contained two related defects:

1. The `__ts_timeline_id` branch assigned its result to `_source`, so callers received a spurious or overwritten `_source` value instead of the requested `__ts_timeline_id` column.
2. Both branches read `__ts_timeline_id` from the top level of the OpenSearch hit. The ID is stored within the event's `_source`, so the lookup returned `None` instead of the timeline name.

Timeline IDs may also be represented as strings in event data while sketch timeline objects expose integer IDs. Without normalization, valid string IDs silently miss the timeline lookup.

## Implementation

- Read the timeline ID from the event source.
- Normalize string-form IDs for lookup against the sketch timeline map.
- Populate `_source` and `__ts_timeline_id` independently when requested.
- Preserve the original timeline ID when no matching timeline exists, avoiding loss of event provenance.

## Test Coverage

The regression test covers:

- integer timeline IDs;
- string timeline IDs;
- unknown timeline IDs and fallback behavior;
- both `_source` and `__ts_timeline_id` output columns.

## Verification

```text
python -m pytest api_client/python/timesketch_api_client/search_test.py -q
9 passed in 3.12s

python -m pylint --rcfile=.pylintrc \
  api_client/python/timesketch_api_client/search.py \
  api_client/python/timesketch_api_client/search_test.py
Passed

python -m black --check --diff \
  api_client/python/timesketch_api_client/search.py \
  api_client/python/timesketch_api_client/search_test.py
2 files would be left unchanged
```
