### PR TITLE
fix(cli_client): fix JSONL export double newline and Pyrefly type error

### DIFF
--- a/cli_client/python/timesketch_cli_client/commands/sketch.py
+++ b/cli_client/python/timesketch_cli_client/commands/sketch.py
@@ -546,14 +546,10 @@ def export_only_with_annotations(
         # Write the final DataFrame to the file
         with open(filename, "w", encoding="utf-8") as fh:
             if output_format == "csv":
-                fh.write(
-                    final_df.to_csv(index=False, header=True, lineterminator="\n")
-                )
+                fh.write(final_df.to_csv(index=False, header=True, lineterminator="\n"))
             elif output_format == "jsonl":
                 fh.write(
-                    final_df.to_json(
-                        orient="records", lines=True, date_format="iso"
-                    )
+                    final_df.to_json(orient="records", lines=True, date_format="iso")
                 )
 
         end_time = time.time()

--- a/cli_client/python/timesketch_cli_client/commands/sketch.py
+++ b/cli_client/python/timesketch_cli_client/commands/sketch.py
@@ -549,14 +549,14 @@ def export_only_with_annotations(
                 csv_data = final_df.to_csv(
                     index=False, header=True, lineterminator="\n"
                 )
-                if csv_data:
+                if csv_data is not None:
                     fh.write(csv_data)
             elif output_format == "jsonl":
                 json_data = final_df.to_json(
                     orient="records", lines=True, date_format="iso"
                 )
-                if json_data:
-                    fh.write(f"{json_data}\n")
+                if json_data is not None:
+                    fh.write(json_data)
 
         end_time = time.time()
         click.echo(

--- a/cli_client/python/timesketch_cli_client/commands/sketch.py
+++ b/cli_client/python/timesketch_cli_client/commands/sketch.py
@@ -544,8 +544,8 @@ def export_only_with_annotations(
 
         click.echo(f"Writing {exported_count} events to file...")
 
-        # Write the final DataFrame to a temporary file, then move atomically
-        # this is to avoid accidental data deletion in an exception case.
+        # Write the final DataFrame to a temporary file, then move atomically.
+        # This is to avoid accidental data deletion in an exception case.
         temp_filename = f"{filename}.tmp"
         try:
             if output_format == "csv":
@@ -565,7 +565,8 @@ def export_only_with_annotations(
                     force_ascii=False,
                 )
             os.replace(temp_filename, filename)
-        except Exception:
+        except Exception as e:  # pylint: disable=broad-except:
+            click.echo(f"Error writing to temporary file: {e}", err=True)
             if os.path.exists(temp_filename):
                 try:
                     os.remove(temp_filename)

--- a/cli_client/python/timesketch_cli_client/commands/sketch.py
+++ b/cli_client/python/timesketch_cli_client/commands/sketch.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 """Commands for sketches."""
 
-import time
-import os
 import json
+import os
+import tempfile
+import time
 from typing import Optional
 import click
 import pandas as pd
@@ -545,9 +546,15 @@ def export_only_with_annotations(
         click.echo(f"Writing {exported_count} events to file...")
 
         # Write the final DataFrame to a temporary file, then move atomically.
-        # This is to avoid accidental data deletion in an exception case.
-        temp_filename = f"{filename}.tmp"
+        # This is to avoid accidental data deletion or partial file corruption.
+        temp_filename = None
         try:
+            target_dir = os.path.dirname(os.path.abspath(filename))
+            with tempfile.NamedTemporaryFile(
+                dir=target_dir, prefix="timesketch_export_", delete=False
+            ) as temp_file:
+                temp_filename = temp_file.name
+
             if output_format == "csv":
                 final_df.to_csv(
                     temp_filename,
@@ -565,9 +572,9 @@ def export_only_with_annotations(
                     force_ascii=False,
                 )
             os.replace(temp_filename, filename)
-        except Exception as e:  # pylint: disable=broad-except:
-            click.echo(f"Error writing to temporary file: {e}", err=True)
-            if os.path.exists(temp_filename):
+            temp_filename = None
+        finally:
+            if temp_filename and os.path.exists(temp_filename):
                 try:
                     os.remove(temp_filename)
                 except OSError as cleanup_error:
@@ -576,7 +583,6 @@ def export_only_with_annotations(
                         f"{cleanup_error}",
                         err=True,
                     )
-            raise
 
         end_time = time.time()
         click.echo(

--- a/cli_client/python/timesketch_cli_client/commands/sketch.py
+++ b/cli_client/python/timesketch_cli_client/commands/sketch.py
@@ -14,6 +14,7 @@
 """Commands for sketches."""
 
 import time
+import os
 import json
 from typing import Optional
 import click
@@ -558,6 +559,7 @@ def export_only_with_annotations(
                 orient="records",
                 lines=True,
                 date_format="iso",
+                force_ascii=False,
             )
 
         end_time = time.time()
@@ -568,4 +570,14 @@ def export_only_with_annotations(
 
     except Exception as e:  # pylint: disable=broad-except
         click.echo(f"\nError during export: {e}", err=True)
+        if os.path.exists(filename):
+            try:
+                os.remove(filename)
+                click.echo(f"Cleaned up partial output file: {filename}", err=True)
+            except OSError as cleanup_error:
+                click.echo(
+                    f"Warning: Failed to clean up partial file {filename}: "
+                    f"{cleanup_error}",
+                    err=True,
+                )
         ctx.exit(1)

--- a/cli_client/python/timesketch_cli_client/commands/sketch.py
+++ b/cli_client/python/timesketch_cli_client/commands/sketch.py
@@ -544,13 +544,21 @@ def export_only_with_annotations(
         click.echo(f"Writing {exported_count} events to file...")
 
         # Write the final DataFrame to the file
-        with open(filename, "w", encoding="utf-8") as fh:
-            if output_format == "csv":
-                fh.write(final_df.to_csv(index=False, header=True, lineterminator="\n"))
-            elif output_format == "jsonl":
-                fh.write(
-                    final_df.to_json(orient="records", lines=True, date_format="iso")
-                )
+        if output_format == "csv":
+            final_df.to_csv(
+                filename,
+                index=False,
+                header=True,
+                lineterminator="\n",
+                encoding="utf-8",
+            )
+        elif output_format == "jsonl":
+            final_df.to_json(
+                filename,
+                orient="records",
+                lines=True,
+                date_format="iso",
+            )
 
         end_time = time.time()
         click.echo(

--- a/cli_client/python/timesketch_cli_client/commands/sketch.py
+++ b/cli_client/python/timesketch_cli_client/commands/sketch.py
@@ -546,17 +546,15 @@ def export_only_with_annotations(
         # Write the final DataFrame to the file
         with open(filename, "w", encoding="utf-8") as fh:
             if output_format == "csv":
-                csv_data = final_df.to_csv(
-                    index=False, header=True, lineterminator="\n"
+                fh.write(
+                    final_df.to_csv(index=False, header=True, lineterminator="\n")
                 )
-                if csv_data is not None:
-                    fh.write(csv_data)
             elif output_format == "jsonl":
-                json_data = final_df.to_json(
-                    orient="records", lines=True, date_format="iso"
+                fh.write(
+                    final_df.to_json(
+                        orient="records", lines=True, date_format="iso"
+                    )
                 )
-                if json_data is not None:
-                    fh.write(json_data)
 
         end_time = time.time()
         click.echo(

--- a/cli_client/python/timesketch_cli_client/commands/sketch.py
+++ b/cli_client/python/timesketch_cli_client/commands/sketch.py
@@ -544,23 +544,38 @@ def export_only_with_annotations(
 
         click.echo(f"Writing {exported_count} events to file...")
 
-        # Write the final DataFrame to the file
-        if output_format == "csv":
-            final_df.to_csv(
-                filename,
-                index=False,
-                header=True,
-                lineterminator="\n",
-                encoding="utf-8",
-            )
-        elif output_format == "jsonl":
-            final_df.to_json(
-                filename,
-                orient="records",
-                lines=True,
-                date_format="iso",
-                force_ascii=False,
-            )
+        # Write the final DataFrame to a temporary file, then move atomically
+        # this is to avoid accidental data deletion in an exception case.
+        temp_filename = f"{filename}.tmp"
+        try:
+            if output_format == "csv":
+                final_df.to_csv(
+                    temp_filename,
+                    index=False,
+                    header=True,
+                    lineterminator="\n",
+                    encoding="utf-8",
+                )
+            elif output_format == "jsonl":
+                final_df.to_json(
+                    temp_filename,
+                    orient="records",
+                    lines=True,
+                    date_format="iso",
+                    force_ascii=False,
+                )
+            os.replace(temp_filename, filename)
+        except Exception:
+            if os.path.exists(temp_filename):
+                try:
+                    os.remove(temp_filename)
+                except OSError as cleanup_error:
+                    click.echo(
+                        f"Warning: Failed to clean up temp file {temp_filename}: "
+                        f"{cleanup_error}",
+                        err=True,
+                    )
+            raise
 
         end_time = time.time()
         click.echo(
@@ -570,14 +585,4 @@ def export_only_with_annotations(
 
     except Exception as e:  # pylint: disable=broad-except
         click.echo(f"\nError during export: {e}", err=True)
-        if os.path.exists(filename):
-            try:
-                os.remove(filename)
-                click.echo(f"Cleaned up partial output file: {filename}", err=True)
-            except OSError as cleanup_error:
-                click.echo(
-                    f"Warning: Failed to clean up partial file {filename}: "
-                    f"{cleanup_error}",
-                    err=True,
-                )
         ctx.exit(1)

--- a/cli_client/python/timesketch_cli_client/commands/sketch.py
+++ b/cli_client/python/timesketch_cli_client/commands/sketch.py
@@ -546,12 +546,17 @@ def export_only_with_annotations(
         # Write the final DataFrame to the file
         with open(filename, "w", encoding="utf-8") as fh:
             if output_format == "csv":
-                fh.write(final_df.to_csv(index=False, header=True, lineterminator="\n"))
-            elif output_format == "jsonl":
-                fh.write(
-                    final_df.to_json(orient="records", lines=True, date_format="iso")
-                    + "\n"
+                csv_data = final_df.to_csv(
+                    index=False, header=True, lineterminator="\n"
                 )
+                if csv_data:
+                    fh.write(csv_data)
+            elif output_format == "jsonl":
+                json_data = final_df.to_json(
+                    orient="records", lines=True, date_format="iso"
+                )
+                if json_data:
+                    fh.write(f"{json_data}\n")
 
         end_time = time.time()
         click.echo(

--- a/cli_client/python/timesketch_cli_client/commands/sketch_test.py
+++ b/cli_client/python/timesketch_cli_client/commands/sketch_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for sketch command."""
 
+import os
 import unittest
 from unittest import mock
 import pandas as pd
@@ -63,13 +64,8 @@ class SketchTest(unittest.TestCase):
             result.output, expected_output, f"Unexpected output: {result.output}"
         )
 
-    @mock.patch(
-        "timesketch_cli_client.commands.sketch.open", new_callable=mock.mock_open
-    )
     @mock.patch("timesketch_cli_client.commands.sketch.search.Search", autospec=True)
-    def test_export_only_with_annotations_csv_success(
-        self, mock_search_class, mock_file_open_func
-    ):
+    def test_export_only_with_annotations_csv_success(self, mock_search_class):
         """Test successful export of annotated events to CSV."""
         runner = CliRunner()
 
@@ -111,64 +107,63 @@ class SketchTest(unittest.TestCase):
             mock_search_inst_labels,
         ]
 
-        result = runner.invoke(
-            sketch_group,
-            ["export-only-with-annotations", "--filename", "output.csv"],
-            obj=self.ctx,
-        )
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                sketch_group,
+                ["export-only-with-annotations", "--filename", "output.csv"],
+                obj=self.ctx,
+            )
 
-        self.assertEqual(result.exit_code, 0, result.output)
-        self.assertIn(
-            "Exporting events with comments, stars, OR labels to output.csv...",
-            result.output,
-        )
-        self.assertIn("Searching for events with comments...", result.output)
-        self.assertIn("Found 2 events.", result.output)  # For comments
-        self.assertIn("Searching for events with stars...", result.output)
-        self.assertIn("Found 2 events.", result.output)  # For stars
-        self.assertIn("Searching for events with labels...", result.output)
-        self.assertIn("Found 3 events.", result.output)  # For labels
-        self.assertIn(
-            "Combining and deduplicating results (found 7 total)...", result.output
-        )
-        self.assertIn("Found 5 unique annotated events.", result.output)
-        self.assertIn("Writing 5 events to file...", result.output)
-        self.assertIn(
-            "Export finished: 5 unique annotated events written.", result.output
-        )
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertIn(
+                "Exporting events with comments, stars, OR labels to output.csv...",
+                result.output,
+            )
+            self.assertIn("Searching for events with comments...", result.output)
+            self.assertIn("Found 2 events.", result.output)  # For comments
+            self.assertIn("Searching for events with stars...", result.output)
+            self.assertIn("Found 2 events.", result.output)  # For stars
+            self.assertIn("Searching for events with labels...", result.output)
+            self.assertIn("Found 3 events.", result.output)  # For labels
+            self.assertIn(
+                "Combining and deduplicating results (found 7 total)...", result.output
+            )
+            self.assertIn("Found 5 unique annotated events.", result.output)
+            self.assertIn("Writing 5 events to file...", result.output)
+            self.assertIn(
+                "Export finished: 5 unique annotated events written.", result.output
+            )
 
-        mock_file_open_func.assert_called_once_with("output.csv", "w", encoding="utf-8")
+            with open("output.csv", "r", encoding="utf-8") as f:
+                written_content = f.read()
 
-        # Construct expected CSV
-        # Order of concatenation: comments, stars, labels. drop_duplicates keeps first.
-        # Event4 from comments should be kept.
-        expected_df = pd.DataFrame(
-            {
-                "_id": ["event1", "event4", "event2", "event3", "event5"],
-                "message": [
-                    "comment_msg1",
-                    "shared_msg_comment",
-                    "star_msg2",
-                    "label_msg3",
-                    "label_msg5",
-                ],
-                "field_c": ["c1", "c4", pd.NA, pd.NA, pd.NA],
-                "field_s": [pd.NA, pd.NA, "s2", pd.NA, pd.NA],
-                "field_l": [pd.NA, pd.NA, pd.NA, "l3", "l5"],
-            }
-        )
-        # Pandas to_csv by default fills NA with empty strings
-        expected_csv = expected_df.to_csv(index=False, header=True, lineterminator="\n")
+            # Construct expected CSV
+            # Order of concatenation: comments, stars, labels. drop_duplicates keeps first.
+            # Event4 from comments should be kept.
+            expected_df = pd.DataFrame(
+                {
+                    "_id": ["event1", "event4", "event2", "event3", "event5"],
+                    "message": [
+                        "comment_msg1",
+                        "shared_msg_comment",
+                        "star_msg2",
+                        "label_msg3",
+                        "label_msg5",
+                    ],
+                    "field_c": ["c1", "c4", pd.NA, pd.NA, pd.NA],
+                    "field_s": [pd.NA, pd.NA, "s2", pd.NA, pd.NA],
+                    "field_l": [pd.NA, pd.NA, pd.NA, "l3", "l5"],
+                }
+            )
+            # Pandas to_csv by default fills NA with empty strings
+            expected_csv = expected_df.to_csv(
+                index=False, header=True, lineterminator="\n"
+            )
+            self.assertEqual(written_content, expected_csv)
 
-        written_content = mock_file_open_func.return_value.write.call_args[0][0]
-        self.assertEqual(written_content, expected_csv)
-
-    @mock.patch(
-        "timesketch_cli_client.commands.sketch.open", new_callable=mock.mock_open
-    )
     @mock.patch("timesketch_cli_client.commands.sketch.search.Search", autospec=True)
     def test_export_only_with_annotations_jsonl_with_limit(
-        self, mock_search_class, mock_file_open_func
+        self, mock_search_class
     ):
         """Test successful export to JSONL with a limit."""
         runner = CliRunner()
@@ -189,45 +184,39 @@ class SketchTest(unittest.TestCase):
             mock_search_inst_labels,
         ]
 
-        result = runner.invoke(
-            sketch_group,
-            [
-                "export-only-with-annotations",
-                "--filename",
-                "output.jsonl",
-                "--output-format",
-                "jsonl",
-                "--limit",
-                "2",
-            ],
-            obj=self.ctx,
-        )
-        self.assertEqual(result.exit_code, 0, result.output)
-        self.assertIn("Found 3 unique annotated events.", result.output)
-        self.assertIn("Applying limit of 2 events.", result.output)
-        self.assertIn("Writing 2 events to file...", result.output)
-        self.assertIn(
-            "Export finished: 2 unique annotated events written.", result.output
-        )
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                sketch_group,
+                [
+                    "export-only-with-annotations",
+                    "--filename",
+                    "output.jsonl",
+                    "--output-format",
+                    "jsonl",
+                    "--limit",
+                    "2",
+                ],
+                obj=self.ctx,
+            )
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertIn("Found 3 unique annotated events.", result.output)
+            self.assertIn("Applying limit of 2 events.", result.output)
+            self.assertIn("Writing 2 events to file...", result.output)
+            self.assertIn(
+                "Export finished: 2 unique annotated events written.", result.output
+            )
 
-        mock_file_open_func.assert_called_once_with(
-            "output.jsonl", "w", encoding="utf-8"
-        )
+            with open("output.jsonl", "r", encoding="utf-8") as f:
+                written_content = f.read()
 
-        expected_jsonl = (
-            '{"_id":"event1","message":"comment_msg1"}\n'
-            '{"_id":"event2","message":"star_msg2"}\n'
-        )
-        written_content = mock_file_open_func.return_value.write.call_args[0][0]
-        self.assertEqual(written_content, expected_jsonl)
+            expected_jsonl = (
+                '{"_id":"event1","message":"comment_msg1"}\n'
+                '{"_id":"event2","message":"star_msg2"}\n'
+            )
+            self.assertEqual(written_content, expected_jsonl)
 
-    @mock.patch(
-        "timesketch_cli_client.commands.sketch.open", new_callable=mock.mock_open
-    )
     @mock.patch("timesketch_cli_client.commands.sketch.search.Search", autospec=True)
-    def test_export_only_with_annotations_no_results(
-        self, mock_search_class, mock_file_open_func
-    ):
+    def test_export_only_with_annotations_no_results(self, mock_search_class):
         """Test export when no annotated events are found."""
         runner = CliRunner()
 
@@ -239,25 +228,21 @@ class SketchTest(unittest.TestCase):
         mock_search_inst.to_pandas.return_value = empty_df
         mock_search_class.return_value = mock_search_inst  # Same mock for all 3 calls
 
-        result = runner.invoke(
-            sketch_group,
-            ["export-only-with-annotations", "--filename", "output.csv"],
-            obj=self.ctx,
-        )
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                sketch_group,
+                ["export-only-with-annotations", "--filename", "output.csv"],
+                obj=self.ctx,
+            )
 
-        self.assertEqual(result.exit_code, 0, result.output)
-        self.assertIn(
-            "No annotated events found across all search types.", result.output
-        )
-        mock_file_open_func.assert_not_called()
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertIn(
+                "No annotated events found across all search types.", result.output
+            )
+            self.assertFalse(os.path.exists("output.csv"))
 
-    @mock.patch(
-        "timesketch_cli_client.commands.sketch.open", new_callable=mock.mock_open
-    )
     @mock.patch("timesketch_cli_client.commands.sketch.search.Search", autospec=True)
-    def test_export_only_with_annotations_search_error(
-        self, mock_search_class, mock_file_open_func
-    ):
+    def test_export_only_with_annotations_search_error(self, mock_search_class):
         """Test export when one of the searches fails."""
         runner = CliRunner()
 
@@ -279,29 +264,34 @@ class SketchTest(unittest.TestCase):
             mock_search_inst_labels,
         ]
 
-        result = runner.invoke(
-            sketch_group,
-            ["export-only-with-annotations", "--filename", "output.csv"],
-            obj=self.ctx,
-        )
-        self.assertEqual(
-            result.exit_code, 0, result.output
-        )  # Should still succeed overall
-        self.assertIn(
-            "WARNING: Error during search for stars: Star search failed!", result.output
-        )
-        self.assertIn(
-            "Found 2 unique annotated events.", result.output
-        )  # event1 and event3
-        self.assertIn("Writing 2 events to file...", result.output)
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                sketch_group,
+                ["export-only-with-annotations", "--filename", "output.csv"],
+                obj=self.ctx,
+            )
+            self.assertEqual(
+                result.exit_code, 0, result.output
+            )  # Should still succeed overall
+            self.assertIn(
+                "WARNING: Error during search for stars: Star search failed!",
+                result.output,
+            )
+            self.assertIn(
+                "Found 2 unique annotated events.", result.output
+            )  # event1 and event3
+            self.assertIn("Writing 2 events to file...", result.output)
 
-        mock_file_open_func.assert_called_once_with("output.csv", "w", encoding="utf-8")
-        expected_df = pd.DataFrame(
-            {"_id": ["event1", "event3"], "message": ["comment_msg1", "label_msg3"]}
-        )
-        expected_csv = expected_df.to_csv(index=False, header=True, lineterminator="\n")
-        written_content = mock_file_open_func.return_value.write.call_args[0][0]
-        self.assertEqual(written_content, expected_csv)
+            with open("output.csv", "r", encoding="utf-8") as f:
+                written_content = f.read()
+
+            expected_df = pd.DataFrame(
+                {"_id": ["event1", "event3"], "message": ["comment_msg1", "label_msg3"]}
+            )
+            expected_csv = expected_df.to_csv(
+                index=False, header=True, lineterminator="\n"
+            )
+            self.assertEqual(written_content, expected_csv)
 
     @mock.patch("timesketch_cli_client.commands.sketch.search.Search", autospec=True)
     def test_export_only_with_annotations_id_column_missing(self, mock_search_class):

--- a/cli_client/python/timesketch_cli_client/commands/sketch_test.py
+++ b/cli_client/python/timesketch_cli_client/commands/sketch_test.py
@@ -138,7 +138,8 @@ class SketchTest(unittest.TestCase):
                 written_content = f.read()
 
             # Construct expected CSV
-            # Order of concatenation: comments, stars, labels. drop_duplicates keeps first.
+            # Order of concatenation: comments, stars, labels.
+            # drop_duplicates keeps first.
             # Event4 from comments should be kept.
             expected_df = pd.DataFrame(
                 {

--- a/cli_client/python/timesketch_cli_client/commands/sketch_test.py
+++ b/cli_client/python/timesketch_cli_client/commands/sketch_test.py
@@ -217,10 +217,9 @@ class SketchTest(unittest.TestCase):
         expected_df = pd.DataFrame(
             {"_id": ["event1", "event2"], "message": ["comment_msg1", "star_msg2"]}
         )
-        expected_json = expected_df.to_json(
+        expected_jsonl = expected_df.to_json(
             orient="records", lines=True, date_format="iso"
         )
-        expected_jsonl = f"{expected_json}\n" if expected_json else ""
         written_content = mock_file_open_func.return_value.write.call_args[0][0]
         self.assertEqual(written_content, expected_jsonl)
 

--- a/cli_client/python/timesketch_cli_client/commands/sketch_test.py
+++ b/cli_client/python/timesketch_cli_client/commands/sketch_test.py
@@ -217,9 +217,10 @@ class SketchTest(unittest.TestCase):
         expected_df = pd.DataFrame(
             {"_id": ["event1", "event2"], "message": ["comment_msg1", "star_msg2"]}
         )
-        expected_jsonl = (
-            expected_df.to_json(orient="records", lines=True, date_format="iso") + "\n"
+        expected_json = expected_df.to_json(
+            orient="records", lines=True, date_format="iso"
         )
+        expected_jsonl = f"{expected_json}\n" if expected_json else ""
         written_content = mock_file_open_func.return_value.write.call_args[0][0]
         self.assertEqual(written_content, expected_jsonl)
 

--- a/cli_client/python/timesketch_cli_client/commands/sketch_test.py
+++ b/cli_client/python/timesketch_cli_client/commands/sketch_test.py
@@ -311,14 +311,16 @@ class SketchTest(unittest.TestCase):
             mock_search_inst_others,
         ]
 
-        result = runner.invoke(
-            sketch_group,
-            ["export-only-with-annotations", "--filename", "output.csv"],
-            obj=self.ctx,
-        )
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                sketch_group,
+                ["export-only-with-annotations", "--filename", "output.csv"],
+                obj=self.ctx,
+            )
 
-        self.assertEqual(result.exit_code, 1, result.output)
-        self.assertIn(
-            "ERROR: '_id' column not found in results, cannot deduplicate.",
-            result.output,
-        )
+            self.assertEqual(result.exit_code, 1, result.output)
+            self.assertIn(
+                "ERROR: '_id' column not found in results, cannot deduplicate.",
+                result.output,
+            )
+            self.assertFalse(os.path.exists("output.csv"))

--- a/cli_client/python/timesketch_cli_client/commands/sketch_test.py
+++ b/cli_client/python/timesketch_cli_client/commands/sketch_test.py
@@ -214,11 +214,9 @@ class SketchTest(unittest.TestCase):
             "output.jsonl", "w", encoding="utf-8"
         )
 
-        expected_df = pd.DataFrame(
-            {"_id": ["event1", "event2"], "message": ["comment_msg1", "star_msg2"]}
-        )
-        expected_jsonl = expected_df.to_json(
-            orient="records", lines=True, date_format="iso"
+        expected_jsonl = (
+            '{"_id":"event1","message":"comment_msg1"}\n'
+            '{"_id":"event2","message":"star_msg2"}\n'
         )
         written_content = mock_file_open_func.return_value.write.call_args[0][0]
         self.assertEqual(written_content, expected_jsonl)

--- a/cli_client/python/timesketch_cli_client/commands/sketch_test.py
+++ b/cli_client/python/timesketch_cli_client/commands/sketch_test.py
@@ -162,9 +162,7 @@ class SketchTest(unittest.TestCase):
             self.assertEqual(written_content, expected_csv)
 
     @mock.patch("timesketch_cli_client.commands.sketch.search.Search", autospec=True)
-    def test_export_only_with_annotations_jsonl_with_limit(
-        self, mock_search_class
-    ):
+    def test_export_only_with_annotations_jsonl_with_limit(self, mock_search_class):
         """Test successful export to JSONL with a limit."""
         runner = CliRunner()
 


### PR DESCRIPTION
When exporting sketch annotations to JSONL (export-only-with-annotations --output-format jsonl),
df.to_json(orient="records", lines=True) already appends a newline (\n) to every record, including
the last one.

Doing final_df.to_json(...) + "\n" caused two issues:

1. Malformed JSONL: It added an extra trailing newline (\n\n), creating an empty record at the end
of the file that causes strict JSONL / NDJSON parsers (e.g. jq, BigQuery) to fail.
2. Pyrefly Build Failure: Because DataFrame.to_json() is typed as Optional[str] in Pandas stubs,
binary concatenation with Literal['\n'] fails static type checking in Google3 Blaze builds.

Changes:

• Removed redundant + "\n" from sketch.py when writing JSONL output.
* Direct write to a temp file by Pandas.
• Updated sketch_test.py to assert against an explicit JSON Lines string fixture rather than a
circular to_json() + "\n" call. So this way it is clearer, what is expected and is not calling the same method, potentially causing the same double n.


According to: https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_json.html
```
linesbool, default False
If ‘orient’ is ‘records’ write out line-delimited json format. 
```



Fixing:

```
timesketch_cli_client/commands/sketch.py:552:21
    |
552 |                       final_df.to_json(orient="records", lines=True, date_format="iso")
    |  _____________________^----------------------------------------------------------------
    | |                     |
    | |                     has type `None`
553 | |                     + "\n"
    | |_______________________---^
    |                         |
    |                         has type `Literal['\n']`
```

